### PR TITLE
CANConManager and example of usage for javascript

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -54,7 +54,8 @@ SOURCES += main.cpp\
     connections/canconnection.cpp \
     connections/socketcan.cpp \
     connections/canconfactory.cpp \
-    connections/gvretserial.cpp
+    connections/gvretserial.cpp \
+    connections/canconmanager.cpp
 
 HEADERS  += mainwindow.h \
     can_structs.h \
@@ -97,7 +98,8 @@ HEADERS  += mainwindow.h \
     connections/socketcan.h \
     connections/canconconst.h \
     connections/canconfactory.h \
-    connections/gvretserial.h
+    connections/gvretserial.h \
+    connections/canconmanager.h
 
 FORMS    += mainwindow.ui \
     graphingwindow.ui \

--- a/canbus.cpp
+++ b/canbus.cpp
@@ -3,10 +3,10 @@
 
 CANBus::CANBus()
 {
-    speed = 250000;
-    listenOnly = false;
-    singleWire = false;
-    active = false;
+    speed       = 250000;
+    listenOnly  = false;
+    singleWire  = false;
+    active      = false;
 }
 
 
@@ -24,44 +24,53 @@ bool CANBus::operator==(const CANBus& bus) const{
             active == bus.active;
 }
 
-
-void CANBus::setSpeed(int newSpeed)
-{
+void CANBus::setSpeed(int newSpeed){
     speed = newSpeed;
 }
 
-void CANBus::setListenOnly(bool mode)
-{
+void CANBus::setListenOnly(bool mode){
     listenOnly = mode;
 }
 
-void CANBus::setSingleWire(bool mode)
-{
+void CANBus::setSingleWire(bool mode){
     singleWire = mode;
 }
 
-void CANBus::setEnabled(bool mode)
-{
+void CANBus::setEnabled(bool mode){
     active = mode;
 }
 
-int CANBus::getSpeed()
-{
+int CANBus::getSpeed(){
     return speed;
 }
 
-bool CANBus::isListenOnly()
-{
+bool CANBus::isListenOnly(){
     return listenOnly;
 }
 
-bool CANBus::isSingleWire()
-{
+bool CANBus::isSingleWire(){
     return singleWire;
 }
 
-bool CANBus::isActive()
-{
+bool CANBus::isActive(){
     return active;
 }
 
+
+QDataStream& operator<<( QDataStream & pStream, const CANBus& pCanBus )
+{
+    pStream << pCanBus.speed;
+    pStream << pCanBus.listenOnly;
+    pStream << pCanBus.singleWire;
+    pStream << pCanBus.active;
+    return pStream;
+}
+
+QDataStream & operator>>(QDataStream & pStream, CANBus& pCanBus)
+{
+    pStream >> pCanBus.speed;
+    pStream >> pCanBus.listenOnly;
+    pStream >> pCanBus.singleWire;
+    pStream >> pCanBus.active;
+    return pStream;
+}

--- a/canbus.h
+++ b/canbus.h
@@ -1,6 +1,6 @@
 #ifndef CANBus_H
 #define CANBus_H
-
+#include <QDataStream>
 
 class CANBus
 {
@@ -8,7 +8,8 @@ public:
     CANBus();
     CANBus(const CANBus&);
     bool operator==(const CANBus&) const;
-    virtual ~CANBus(){}; /*TODO: remove connection from CANBus and add CANBus as an element of CANConnection */
+    virtual ~CANBus(){};
+
     int speed;
     bool listenOnly;
     bool singleWire;
@@ -24,5 +25,10 @@ public:
     bool isSingleWire();
     bool isActive();
 };
+
+QDataStream& operator<<( QDataStream & pStream, const CANBus& pCanBus );
+QDataStream & operator>>(QDataStream & pStream, CANBus& pCanBus);
+
+Q_DECLARE_METATYPE(CANBus);
 
 #endif // CANBus_H

--- a/canconnectionmodel.cpp
+++ b/canconnectionmodel.cpp
@@ -1,8 +1,13 @@
-#include "connections/canconnection.h"
 #include "canconnectionmodel.h"
+#include "connections/canconnection.h"
+#include "connections/canconmanager.h"
 
 CANConnectionModel::CANConnectionModel(QObject *parent)
     : QAbstractTableModel(parent)
+{
+}
+
+CANConnectionModel::~CANConnectionModel()
 {
 }
 
@@ -52,17 +57,20 @@ QVariant CANConnectionModel::headerData(int section, Qt::Orientation orientation
 
 int CANConnectionModel::columnCount(const QModelIndex &parent) const
 {
+    Q_UNUSED(parent);
     return 7;
 }
 
 
-int CANConnectionModel::rowCount(const QModelIndex &parent) const {
-    int rows=0;
-    QList<CANConnection*>::const_iterator iter;
+int CANConnectionModel::rowCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
 
-    for (iter = mConns.begin() ; iter != mConns.end() ; ++iter) {
-        rows+=(*iter)->getNumBuses();
-    }
+    int rows=0;
+    QList<CANConnection*>& conns = CANConManager::getInstance()->getConnections();
+
+    foreach(const CANConnection* conn_p, conns)
+        rows+=conn_p->getNumBuses();
 
     return rows;
 }
@@ -124,23 +132,25 @@ QVariant CANConnectionModel::data(const QModelIndex &index, int role) const
 
 void CANConnectionModel::add(CANConnection* pConn_p)
 {
+    CANConManager* manager = CANConManager::getInstance();
+
+    connect(pConn_p, SIGNAL(notify()), manager, SLOT(refreshCanList()));
+
     beginResetModel();
-    mConns.append(pConn_p);
+    manager->getConnections().append(pConn_p);
     endResetModel();
 }
 
 
 void CANConnectionModel::remove(CANConnection* pConn_p)
 {
+    CANConManager* manager = CANConManager::getInstance();
+
+    disconnect(pConn_p, 0, manager, 0);
+
     beginResetModel();
-    mConns.removeOne(pConn_p);
+    manager->getConnections().removeOne(pConn_p);
     endResetModel();
-}
-
-
-QList<CANConnection*>& CANConnectionModel::getConnections()
-{
-    return mConns;
 }
 
 
@@ -150,23 +160,36 @@ CANConnection* CANConnectionModel::getAtIdx(int pIdx, int& pBusId) const
         return NULL;
 
     int i=0;
-    QList<CANConnection*>::const_iterator iter = mConns.begin();
+    QList<CANConnection*>& conns = CANConManager::getInstance()->getConnections();
 
-    for (iter = mConns.begin() ; iter != mConns.end() ; ++iter) {
-        if( i <= pIdx && pIdx < i+(*iter)->getNumBuses() ) {
+    foreach(CANConnection* conn_p, conns)
+    {
+        if( i <= pIdx && pIdx < i+conn_p->getNumBuses() ) {
             pBusId = pIdx - i;
-            return (*iter);
+            return conn_p;
         }
 
-        i+= (*iter)->getNumBuses();
+        i+= conn_p->getNumBuses();
     }
 
     return NULL;
 }
 
 
-void CANConnectionModel::refreshView()
+void CANConnectionModel::refresh(int pIndex)
 {
-    beginResetModel();
-    endResetModel();
+    QModelIndex begin;
+    QModelIndex end;
+
+    if(pIndex>=0) {
+        begin = createIndex(pIndex, 0);
+        end = begin;
+    }
+    else {
+        begin = createIndex(0, 0);
+        begin = createIndex(rowCount()-1, 0);
+        /*beginResetModel();
+        endResetModel();*/
+    }
+    dataChanged(begin, end);
 }

--- a/canconnectionmodel.cpp
+++ b/canconnectionmodel.cpp
@@ -182,14 +182,12 @@ void CANConnectionModel::refresh(int pIndex)
     QModelIndex end;
 
     if(pIndex>=0) {
-        begin = createIndex(pIndex, 0);
-        end = begin;
+        begin   = createIndex(pIndex, 0);
+        end     = createIndex(pIndex, columnCount()-1);
     }
     else {
-        begin = createIndex(0, 0);
-        begin = createIndex(rowCount()-1, 0);
-        /*beginResetModel();
-        endResetModel();*/
+        begin   = createIndex(0, 0);
+        end     = createIndex(rowCount()-1, columnCount()-1);
     }
-    dataChanged(begin, end);
+    dataChanged(begin, end, QVector<int>(Qt::DisplayRole));
 }

--- a/canconnectionmodel.h
+++ b/canconnectionmodel.h
@@ -15,25 +15,19 @@ class CANConnectionModel : public QAbstractTableModel
 
 public:
     explicit CANConnectionModel(QObject *parent = 0);
+    virtual ~CANConnectionModel();
 
-    // Header:
+    // from abstractmodel:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
 
     void add(CANConnection* pConn_p);
     void remove(CANConnection* pConn_p);
 
-    QList<CANConnection*>& getConnections();
     CANConnection* getAtIdx(int, int&) const;
-    void refreshView();
-
-private:
-    QList<CANConnection*> mConns;
+    void refresh(int pIndex=-1);
 };
 
 #endif // CANCONNECTIONMODEL_H

--- a/canfilter.h
+++ b/canfilter.h
@@ -10,7 +10,7 @@ public:
     void setFilter(uint32_t id, uint32_t mask, int bus);
     bool checkFilter(uint32_t id, int bus);
 
-private:
+public:
     uint32_t ID;
     uint32_t mask;
     int bus;

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -8,6 +8,7 @@
 #include <QMutex>
 #include "can_structs.h"
 #include "dbchandler.h"
+#include "connections/canconnection.h"
 
 class CANFrameModel: public QAbstractTableModel
 {
@@ -25,7 +26,7 @@ public:
 
     void sendRefresh();
     void sendRefresh(int);
-    void sendBulkRefresh(int);
+    int  sendBulkRefresh();
     void clearFrames();
     void setDBCHandler(DBCHandler *);
     void setInterpetMode(bool);
@@ -46,7 +47,8 @@ public:
     const QMap<int, bool> *getFiltersReference() const; //this neither
 
 public slots:
-    void addFrame(CANFrame&, bool);
+    void addFrame(const CANFrame&, bool);
+    void addFrames(const CANConnection*, const QVector<CANFrame>&);
 
 signals:
     void updatedFiltersList();

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -1,6 +1,94 @@
 #include "canconmanager.h"
 
-CANConManager::CANConManager()
-{
 
+CANConManager* CANConManager::mInstance = NULL;
+
+CANConManager* CANConManager::getInstance()
+{
+    if(!mInstance)
+        mInstance = new CANConManager();
+
+    return mInstance;
+}
+
+
+CANConManager::CANConManager(QObject *parent): QObject(parent)
+{
+    connect(&mTimer, SIGNAL(timeout()), this, SLOT(refreshCanList()));
+    mTimer.setInterval(500); /*tick twice a second */
+    mTimer.setSingleShot(false);
+    mTimer.start();
+}
+
+
+CANConManager::~CANConManager()
+{
+    mTimer.stop();
+    mInstance = NULL;
+}
+
+
+void CANConManager::add(CANConnection* pConn_p)
+{
+    connect(pConn_p, SIGNAL(notify()), this, SLOT(refreshCanList()));
+    mConns.append(pConn_p);
+}
+
+
+void CANConManager::remove(CANConnection* pConn_p)
+{
+    disconnect(pConn_p, 0, this, 0);
+    mConns.removeOne(pConn_p);
+}
+
+
+void CANConManager::refreshCanList()
+{
+    QObject* sender_p = QObject::sender();
+
+    if( sender_p != &mTimer)
+    {
+        /* if we are not the sender, the signal is coming from a connection */
+        /* refresh only the given connection */
+        if(mConns.contains((CANConnection*) sender_p))
+            refreshConnection((CANConnection*)sender_p);
+    }
+    else
+    {
+        foreach (CANConnection* conn_p, mConns)
+            refreshConnection((CANConnection*)conn_p);
+    }
+}
+
+
+QList<CANConnection*>& CANConManager::getConnections()
+{
+    return mConns;
+}
+
+
+CANConnection* CANConManager::getByName(const QString& pName) const
+{
+    foreach(CANConnection* conn_p, mConns)
+    {
+        if(conn_p->getPort() == pName)
+            return conn_p;
+    }
+
+    return NULL;
+}
+
+
+void CANConManager::refreshConnection(CANConnection* pConn_p)
+{
+    CANFrame* frame_p = NULL;
+    QVector<CANFrame> frames;
+
+    while( (frame_p = pConn_p->getQueue().peek() ) ) {
+        frames.append(*frame_p);
+        pConn_p->getQueue().dequeue();
+    }
+
+    if(frames.size())
+        emit framesReceived(pConn_p, frames);
 }

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -1,0 +1,6 @@
+#include "canconmanager.h"
+
+CANConManager::CANConManager()
+{
+
+}

--- a/connections/canconmanager.h
+++ b/connections/canconmanager.h
@@ -1,0 +1,11 @@
+#ifndef CANCONMANAGER_H
+#define CANCONMANAGER_H
+
+
+class CANConManager
+{
+public:
+    CANConManager();
+};
+
+#endif // CANCONMANAGER_H

--- a/connections/canconmanager.h
+++ b/connections/canconmanager.h
@@ -1,11 +1,39 @@
 #ifndef CANCONMANAGER_H
 #define CANCONMANAGER_H
 
+#include <QObject>
+#include <QTimer>
 
-class CANConManager
+#include "canconnection.h"
+
+class CANConManager : public QObject
 {
+    Q_OBJECT
+
 public:
-    CANConManager();
+    static CANConManager* getInstance();
+    virtual ~CANConManager();
+
+    void add(CANConnection* pConn_p);
+    void remove(CANConnection* pConn_p);
+    QList<CANConnection*>& getConnections();
+
+    CANConnection* getByName(const QString& pName) const;
+
+signals:
+    void framesReceived(CANConnection* pConn_p, QVector<CANFrame>& pFrames);
+
+private slots:
+        void refreshCanList();
+
+private:
+    explicit CANConManager(QObject *parent = 0);
+    void refreshConnection(CANConnection* pConn_p);
+
+    static CANConManager*  mInstance;
+    QList<CANConnection*>  mConns;
+    QTimer                 mTimer;
 };
 
-#endif // CANCONMANAGER_H
+#endif // CANCONNECTIONMODEL_H
+

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -191,7 +191,7 @@ bool CANConnection::sendFrames(const QList<CANFrame>& pFrames)
 }
 
 
-int CANConnection::getNumBuses() {
+int CANConnection::getNumBuses() const{
     return mNumBuses;
 }
 

--- a/connections/canconnection.h
+++ b/connections/canconnection.h
@@ -42,7 +42,7 @@ public:
      * @brief getNumBuses
      * @return returns the number of buses of the device
      */
-    int getNumBuses();
+    int getNumBuses() const;
 
     /**
      * @brief getPort

--- a/connections/socketcan.cpp
+++ b/connections/socketcan.cpp
@@ -147,7 +147,7 @@ void SocketCan::errorReceived(QCanBusDevice::CanBusError error) const
 
 void SocketCan::framesWritten(qint64 count)
 {
-    qDebug() << "Number of frames written:" << count;
+    //qDebug() << "Number of frames written:" << count;
 }
 
 void SocketCan::framesReceived()

--- a/connectionwindow.h
+++ b/connectionwindow.h
@@ -8,8 +8,9 @@
 #include <QDebug>
 #include <QSettings>
 #include <QTimer>
+#include <QItemSelection>
 #include "canconnectionmodel.h"
-#include "canframemodel.h"
+#include "connections/canconnection.h"
 
 
 class CANConnectionModel;
@@ -24,11 +25,10 @@ class ConnectionWindow : public QDialog
     Q_OBJECT
 
 public:
-    explicit ConnectionWindow(CANFrameModel *canModel, QWidget *parent = 0);
+    explicit ConnectionWindow(QWidget *parent = 0);
     ~ConnectionWindow();
     void showEvent(QShowEvent *);
-    int getSpeed();
-    QString getPortName(); //name of port to connect to
+
     CANCon::type getConnectionType();
     bool getSWMode();
 
@@ -39,40 +39,38 @@ signals:
 public slots:
     void setSpeed(int speed0);
     void setSWMode(bool mode);
-    void sendFrame(const CANFrame *);
-    void sendFrameBatch(const QList<CANFrame> *);
-    void setSuspendAll(bool);
 
+    void setSuspendAll(bool pSuspend);
 
 private slots:
     void handleOKButton();
     void handleConnTypeChanged();
-    void handleConnSelectionChanged();
+    void currentRowChanged(const QModelIndex &current, const QModelIndex &previous);
     void handleRemoveConn();
     void handleEnableAll();
     void handleDisableAll();
     void handleRevert();
     void handleNewConn();
-    void receiveBusStatus(int bus, int speed, int status);
     void connectionStatus(CANCon::status);
-
-    void refreshCanList();
 
 private:
     Ui::ConnectionWindow *ui;
     QList<QSerialPortInfo> ports;
     QSettings *settings;
     CANConnectionModel *connModel;
-    CANFrameModel *canModel;
-    QTimer mTicker;
-
-    QAtomicInt mRefreshReqOngoing;
 
     void selectSerial();
     void selectKvaser();
     void selectSocketCan();
     bool isSocketCanAvailable();
+    int getSpeed();
+    QString getPortName();
+    void setPortName(CANCon::type pType, QString pPortName);
+
     void setActiveAll(bool pActive);
+    CANConnection* create(CANCon::type pTye, QString pPortName);
+    void loadConnections();
+    void saveConnections();
 };
 
 #endif // CONNECTIONWINDOW_H

--- a/connectionwindow.ui
+++ b/connectionwindow.ui
@@ -74,7 +74,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="gbType">
        <property name="title">
         <string>Connection Type</string>
        </property>
@@ -116,7 +116,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="lPort">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
          <horstretch>0</horstretch>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -103,6 +103,9 @@
         <property name="text">
          <string>Suspend Capturing</string>
         </property>
+        <property name="checkable">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item>
@@ -197,7 +200,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>27</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_RE_Tools">

--- a/scriptcontainer.h
+++ b/scriptcontainer.h
@@ -13,12 +13,13 @@ class ScriptContainer : public QObject
     Q_OBJECT
 
 public:
-    ScriptContainer();
+    ScriptContainer(QString&);
     void gotFrame(const CANFrame &frame);
 
     QString fileName;
     QString filePath;
     QString scriptText;
+    QString mConName;
 
 public slots:
     void compileScript();

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -3,9 +3,10 @@
 
 #include <QFile>
 #include <QFileDialog>
+#include <QSettings>
 #include <Qsci/qscilexerjavascript.h>
 
-#include "mainwindow.h"
+#include "connections/canconmanager.h"
 
 ScriptingWindow::ScriptingWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     QDialog(parent),
@@ -23,7 +24,8 @@ ScriptingWindow::ScriptingWindow(const QVector<CANFrame> *frames, QWidget *paren
     connect(ui->btnRemoveScript, &QAbstractButton::pressed, this, &ScriptingWindow::deleteCurrentScript);
     connect(ui->btnRevertScript, &QAbstractButton::pressed, this, &ScriptingWindow::revertScript);
     connect(ui->btnSaveScript, &QAbstractButton::pressed, this, &ScriptingWindow::saveScript);
-    connect(MainWindow::getReference(), &MainWindow::framesUpdated, this, &ScriptingWindow::updatedFrames);
+
+    connect(CANConManager::getInstance(), &CANConManager::framesReceived, this, &ScriptingWindow::newFrames);
 
     ui->txtScriptSource->setLexer(new QsciLexerJavaScript(ui->txtScriptSource));
 }
@@ -33,26 +35,21 @@ ScriptingWindow::~ScriptingWindow()
     delete ui;
 }
 
-void ScriptingWindow::updatedFrames(int numFrames)
+
+void ScriptingWindow::newFrames(const CANConnection* pConn, const QVector<CANFrame>& pFrames)
 {
-    CANFrame thisFrame;
-    //-1 means all frames deleted and -2 means a full refresh, neither of which we care about here.
-    if (numFrames > 0)
+    /*FIXME: name of the probe and bus should be checked */
+    Q_UNUSED(pConn);
+
+    for (int j = 0; j < scripts.length(); j++)
     {
-        if (numFrames > modelFrames->count()) return;
-        qDebug() << "Got frames into script window: " << numFrames;
-        //for every new frame pass it on to each script container. The container will determine if it needs to actually
-        //notify the script and do that if applicable.
-        for (int i = modelFrames->count() - numFrames; i < modelFrames->count(); i++)
+        foreach(const CANFrame& frame, pFrames)
         {
-            thisFrame = modelFrames->at(i);
-            for (int j = 0; j < scripts.length(); j++)
-            {
-                scripts[j]->gotFrame(thisFrame);
-            }
+            scripts[j]->gotFrame(frame);
         }
     }
 }
+
 
 void ScriptingWindow::closeEvent(QCloseEvent *event)
 {
@@ -115,13 +112,19 @@ void ScriptingWindow::loadNewScript()
                 QStringList fileList = filename.split('/');
                 QString justFileName = fileList[fileList.length() - 1];
                 ui->listLoadedScripts->addItem(justFileName);
-                container = new ScriptContainer();
+                /* get the first connection in the list for now */
+                qDebug() << "FIXME: connection is always the first in list";
+                QString portName;
+                QList<CANConnection*> list = CANConManager::getInstance()->getConnections();
+                if(!list.isEmpty())
+                    portName = list.first()->getPort();
+
+                container = new ScriptContainer(portName);
                 container->fileName = justFileName;
                 container->filePath = filename;
                 container->scriptText = contents;
                 container->setErrorWidget(ui->listErrors);
                 container->compileScript();
-                connect(container, &ScriptContainer::sendCANFrame, this, &ScriptingWindow::sendCANFrame);
                 scripts.append(container);
                 currentScript = container;
                 ui->txtScriptSource->setText(container->scriptText);
@@ -135,13 +138,17 @@ void ScriptingWindow::createNewScript()
 {
     ScriptContainer *container;
 
-    container = new ScriptContainer();
+    QString portName;
+    QList<CANConnection*> list = CANConManager::getInstance()->getConnections();
+    if(!list.isEmpty())
+        portName = list.first()->getPort();
+
+    container = new ScriptContainer(portName);
 
     container->fileName = "UNNAMED_" + QString::number((qrand() % 10000)) + ".js";
     container->filePath = QString();
     container->scriptText = QString();
     container->setErrorWidget(ui->listErrors);
-    connect(container, &ScriptContainer::sendCANFrame, this, &ScriptingWindow::sendCANFrame);
     scripts.append(container);
     ui->listLoadedScripts->addItem(container->fileName);
     currentScript = container;

--- a/scriptingwindow.h
+++ b/scriptingwindow.h
@@ -3,6 +3,7 @@
 
 #include "can_structs.h"
 #include "scriptcontainer.h"
+#include "connections/canconnection.h"
 
 #include <QDialog>
 #include <QJSEngine>
@@ -28,12 +29,7 @@ private slots:
     void saveScript();
     void revertScript();
     void recompileScript();
-    void updatedFrames(int);
-
-public slots:
-
-signals:
-    void sendCANFrame(const CANFrame *);
+    void newFrames(const CANConnection*, const QVector<CANFrame>&);
 
 private:
     void closeEvent(QCloseEvent *event);


### PR DESCRIPTION
I have added a CANConManager which receives all the frames from the different CANConnections and dispatch them on the UI thread through a signal.
I have added this reception mode to CANFrameModel and tried to add it to scriptingwindow as well but I must say it's not perfect for the latter.

the scriptingwindow should probably have a combobox to select on what canconnection and what bus the script is active.

I have also worked on the canconnectionwindow. I think It's still not really intuitive but at least it now works... 
Also the connection configuration is now persistent through app restart.

It's worth noting that many windows require rework & code cleaning to correctly use the new canconnection abstraction.

You tell me what you think.

Best,
Vincent