### PR TITLE
Fix Compile/build on Ubuntu 14.04

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -14,7 +14,7 @@ CONFIG += c++11 qscintilla2
 
 TARGET = SavvyCAN
 TEMPLATE = app
-
+INCLUDEPATH +=/usr/include/qt5/
 
 SOURCES += main.cpp\
     mainwindow.cpp \
@@ -142,3 +142,5 @@ DISTFILES +=
 RESOURCES += \
     icons.qrc \
     images.qrc
+
+unix:!macx: LIBS += -lqt5scintilla2

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -485,7 +485,7 @@ void ConnectionWindow::handleRevert()
 bool ConnectionWindow::isSocketCanAvailable()
 {
 #ifdef Q_OS_LINUX
-    foreach (const QByteArray &backend, QCanBus::instance()->plugins()) {
+    for (const auto &backend : QCanBus::instance()->plugins()) {
         if (backend == "socketcan")
             return true;
     }


### PR DESCRIPTION
I modified two things.  The first is fixing the compile error.

../SavvyCAN/connections/connectionwindow.cpp: In member function ‘bool ConnectionWindow::isSocketCanAvailable()’:
../../Qt5.8.0/5.8/gcc_64/include/QtCore/qglobal.h:944:34: error: invalid initialization of reference of type ‘const QByteArray&’ from expression of type ‘const QString’
     for (variable = *_container_.i; _container_.control; _container_.control = 0)

...by changing using auto (already using C++11 so why not?)

The second is that you don't need to download and install QScintella on Ubuntu.  You can just 
$ sudo apt-get install libqt5scintilla2-11 libqt5scintilla2-dev
...and it should work with the .pro file changes. 