### PR TITLE
Manage J1939 databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@
 *.out
 *.app
 *.user
+
+# Generated files
+**/moc_*
+**/ui_*.h
+**/qrc_*.cpp

--- a/dbc/dbc_classes.cpp
+++ b/dbc/dbc_classes.cpp
@@ -67,12 +67,22 @@ bool DBC_SIGNAL::processAsText(const CANFrame &frame, QString &outString)
     if (valType == SIGNED_INT) isSigned = true;
     if (valType == SIGNED_INT || valType == UNSIGNED_INT)
     {
+        if ( frame.len*8 < (startBit+signalSize) )
+        {
+            result = 0;
+            return false;
+        }
         result = Utility::processIntegerSignal(frame.data, startBit, signalSize, intelByteOrder, isSigned);
         endResult = ((double)result * factor) + bias;
         result = (int64_t)endResult;
     }
     else if (valType == SP_FLOAT)
     {
+        if ( frame.len*8 < (startBit+32) )
+        {
+            result = 0;
+            return false;
+        }
         //The theory here is that we force the integer signal code to treat this as
         //a 32 bit unsigned integer. This integer is then cast into a float in such a way
         //that the bytes that make up the integer are instead treated as having made up
@@ -83,6 +93,11 @@ bool DBC_SIGNAL::processAsText(const CANFrame &frame, QString &outString)
     }
     else //double precision float
     {
+        if ( frame.len < 8 )
+        {
+            result = 0;
+            return false;
+        }
         //like the above, this is rotten and evil and wrong in so many ways. Force
         //calculation of a 64 bit integer and then cast it into a double.
         result = Utility::processIntegerSignal(frame.data, 0, 64, false, false);
@@ -144,6 +159,11 @@ bool DBC_SIGNAL::processAsInt(const CANFrame &frame, int32_t &outValue)
     }
 
     if (valType == SIGNED_INT) isSigned = true;
+    if ( frame.len*8 < (startBit+signalSize) )
+    {
+        result = 0;
+        return false;
+    }
     result = Utility::processIntegerSignal(frame.data, startBit, signalSize, intelByteOrder, isSigned);
 
     double endResult = ((double)result * factor) + bias;
@@ -183,6 +203,11 @@ bool DBC_SIGNAL::processAsDouble(const CANFrame &frame, double &outValue)
     if (valType == SIGNED_INT) isSigned = true;
     if (valType == SIGNED_INT || valType == UNSIGNED_INT)
     {
+        if ( frame.len*8 < (startBit+signalSize) )
+        {
+            result = 0;
+            return false;
+        }
         result = Utility::processIntegerSignal(frame.data, startBit, signalSize, intelByteOrder, isSigned);
         endResult = ((double)result * factor) + bias;
         result = (int64_t)endResult;
@@ -190,6 +215,11 @@ bool DBC_SIGNAL::processAsDouble(const CANFrame &frame, double &outValue)
     /*TODO: It should be noted that the below floating point has not even been tested. For shame! Test it!*/
     else if (valType == SP_FLOAT)
     {
+        if ( frame.len*8 < (startBit+32) )
+        {
+            result = 0;
+            return false;
+        }
         //The theory here is that we force the integer signal code to treat this as
         //a 32 bit unsigned integer. This integer is then cast into a float in such a way
         //that the bytes that make up the integer are instead treated as having made up
@@ -200,6 +230,11 @@ bool DBC_SIGNAL::processAsDouble(const CANFrame &frame, double &outValue)
     }
     else //double precision float
     {
+        if ( frame.len < 8 )
+        {
+            result = 0;
+            return false;
+        }
         //like the above, this is rotten and evil and wrong in so many ways. Force
         //calculation of a 64 bit integer and then cast it into a double.
         result = Utility::processIntegerSignal(frame.data, 0, 64, false, false);

--- a/dbc/dbchandler.h
+++ b/dbc/dbchandler.h
@@ -40,8 +40,11 @@ public:
     bool removeMessage(QString name);
     void removeAllMessages();
     int getCount();
+    bool isJ1939();
+    void setJ1939(bool j1939);
 private:
     QList<DBC_MESSAGE> messages;
+    bool isJ1939Handler;
 };
 
 //technically there should be a node handler too but I'm sort of treating nodes as second class

--- a/dbc/dbcloadsavewindow.cpp
+++ b/dbc/dbcloadsavewindow.cpp
@@ -30,7 +30,6 @@ DBCLoadSaveWindow::DBCLoadSaveWindow(const QVector<CANFrame> *frames, QWidget *p
     connect(ui->btnNewDBC, &QAbstractButton::clicked, this, &DBCLoadSaveWindow::newFile);
     connect(ui->tableFiles, &QTableWidget::cellChanged, this, &DBCLoadSaveWindow::cellChanged);
     connect(ui->tableFiles, &QTableWidget::cellDoubleClicked, this, &DBCLoadSaveWindow::cellDoubleClicked);
-    //connect(ui->tableFiles, &QTableWidget::cellActivated, this, &DBCLoadSaveWindow::cellChanged);
 
     editorWindow = new DBCMainEditor(frames);
 }

--- a/dbc/dbcloadsavewindow.cpp
+++ b/dbc/dbcloadsavewindow.cpp
@@ -1,5 +1,6 @@
 #include "dbcloadsavewindow.h"
 #include "ui_dbcloadsavewindow.h"
+#include <QCheckBox>
 
 DBCLoadSaveWindow::DBCLoadSaveWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     QDialog(parent),
@@ -12,11 +13,13 @@ DBCLoadSaveWindow::DBCLoadSaveWindow(const QVector<CANFrame> *frames, QWidget *p
     ui->setupUi(this);
 
     QStringList header;
-    header << "Filename" << "Associated Bus";
-    ui->tableFiles->setColumnCount(2);
+    header << "Filename" << "Associated Bus" << "J1939";
+    ui->tableFiles->setColumnCount(3);
     ui->tableFiles->setHorizontalHeaderLabels(header);
-    ui->tableFiles->setColumnWidth(0, 355);
+    ui->tableFiles->setColumnWidth(0, 265);
     ui->tableFiles->setColumnWidth(1, 125);
+    ui->tableFiles->setColumnWidth(2, 80);
+    ui->tableFiles->horizontalHeader()->setStretchLastSection(true);
 
     connect(ui->btnEdit, &QAbstractButton::clicked, this, &DBCLoadSaveWindow::editFile);
     connect(ui->btnLoad, &QAbstractButton::clicked, this, &DBCLoadSaveWindow::loadFile);
@@ -27,6 +30,7 @@ DBCLoadSaveWindow::DBCLoadSaveWindow(const QVector<CANFrame> *frames, QWidget *p
     connect(ui->btnNewDBC, &QAbstractButton::clicked, this, &DBCLoadSaveWindow::newFile);
     connect(ui->tableFiles, &QTableWidget::cellChanged, this, &DBCLoadSaveWindow::cellChanged);
     connect(ui->tableFiles, &QTableWidget::cellDoubleClicked, this, &DBCLoadSaveWindow::cellDoubleClicked);
+    //connect(ui->tableFiles, &QTableWidget::cellActivated, this, &DBCLoadSaveWindow::cellChanged);
 
     editorWindow = new DBCMainEditor(frames);
 }
@@ -43,6 +47,10 @@ void DBCLoadSaveWindow::newFile()
     ui->tableFiles->insertRow(ui->tableFiles->rowCount());
     ui->tableFiles->setItem(idx, 0, new QTableWidgetItem("UNNAMEDFILE"));
     ui->tableFiles->setItem(idx, 1, new QTableWidgetItem("-1"));
+
+    QTableWidgetItem *item = new QTableWidgetItem("");
+    item->setCheckState(Qt::Unchecked);
+    ui->tableFiles->setItem(idx, 2, item);
 }
 
 void DBCLoadSaveWindow::loadFile()
@@ -53,6 +61,17 @@ void DBCLoadSaveWindow::loadFile()
         ui->tableFiles->insertRow(ui->tableFiles->rowCount());
         ui->tableFiles->setItem(idx, 0, new QTableWidgetItem(file->getFullFilename()));
         ui->tableFiles->setItem(idx, 1, new QTableWidgetItem("-1"));
+        DBC_ATTRIBUTE *attr = file->findAttributeByName("isj1939dbc");
+        QTableWidgetItem *item = new QTableWidgetItem("");
+        ui->tableFiles->setItem(idx, 2, item);
+        if (attr && attr->defaultValue > 0)
+        {
+            item->setCheckState(Qt::Checked);
+        }
+        else
+        {
+            item->setCheckState(Qt::Unchecked);
+        }
     }
 }
 
@@ -108,6 +127,35 @@ void DBCLoadSaveWindow::cellChanged(int row, int col)
         if (bus > -2 && bus < 2)
         {
             file->setAssocBus(bus);
+        }
+    }
+    else if (col == 2)
+    {
+        DBCFile *file = dbcHandler->getFileByIdx(row);
+        if (file)
+        {
+            //int isj1939dbc = ui->tableFiles->item(row, col)->text().toInt();
+            bool isj1939dbc = ui->tableFiles->item(row, col)->checkState() == Qt::Checked;
+            DBC_ATTRIBUTE *attr = file->findAttributeByName("isj1939dbc");
+            if (attr)
+            {
+                attr->defaultValue = isj1939dbc ? 1 : 0;
+                file->messageHandler->setJ1939(isj1939dbc);
+            }
+            else
+            {
+                DBC_ATTRIBUTE attr;
+
+                attr.attrType = MESSAGE;
+                attr.defaultValue = isj1939dbc ? 1 : 0;
+                attr.enumVals.clear();
+                attr.lower = 0;
+                attr.upper = 0;
+                attr.name = "isj1939dbc";
+                attr.valType = QINT;
+                file->dbc_attributes.append(attr);
+                file->messageHandler->setJ1939(isj1939dbc);
+            }
         }
     }
 }


### PR DESCRIPTION
Ignore the source address part of the ID when a database is marked as a J1939 database.

I could not find a way to center the checkbox on the DBC file dialog without subclassing or complicating the signal handling for the checkbox, so I leave it that way.