### PR TITLE
Add sorting after table header click for main and isotp windows

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -238,11 +238,6 @@ void MainWindow::closeEvent(QCloseEvent *event)
     exitApp();
 }
 
-void MainWindow::headerClicked(int logicalIndex)
-{
-    ui->canFramesView->sortByColumn(logicalIndex);
-}
-
 void MainWindow::updateSettings()
 {
     readUpdateableSettings();
@@ -306,6 +301,11 @@ void MainWindow::updateConnectionSettings(QString connectionType, QString port, 
     {
         //emit updateBaudRates(speed0, speed1);
     }
+}
+
+void MainWindow::headerClicked(int logicalIndex)
+{
+    ui->canFramesView->sortByColumn(logicalIndex);
 }
 
 void MainWindow::gridClicked(QModelIndex idx)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -41,7 +41,10 @@ MainWindow::MainWindow(QWidget *parent) :
 
     model = new CANFrameModel(this); // set parent to mainwindow to prevent canframemodel to change thread (might be done by setModel but just in case)
 
-    ui->canFramesView->setModel(model);
+    QSortFilterProxyModel* proxyModel = new QSortFilterProxyModel;
+    proxyModel->setSourceModel(model);
+
+    ui->canFramesView->setModel(proxyModel);
 
     readSettings();
 
@@ -54,7 +57,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->canFramesView->setColumnWidth(6, 225);
     QHeaderView *HorzHdr = ui->canFramesView->horizontalHeader();
     HorzHdr->setStretchLastSection(true); //causes the data column to automatically fill the tableview
-    connect(HorzHdr, SIGNAL(sectionClicked(int)), this, SLOT(on_sectionClicked(int)));
+    connect(HorzHdr, SIGNAL(sectionClicked(int)), this, SLOT(headerClicked(int)));
 
     graphingWindow = NULL;
     frameInfoWindow = NULL;
@@ -235,10 +238,8 @@ void MainWindow::closeEvent(QCloseEvent *event)
     exitApp();
 }
 
-void MainWindow::on_sectionClicked ( int logicalIndex )
+void MainWindow::headerClicked(int logicalIndex)
 {
-    QHeaderView *HorzHdr = ui->canFramesView->horizontalHeader();
-    HorzHdr->setSortIndicator(logicalIndex, Qt::AscendingOrder);
     ui->canFramesView->sortByColumn(logicalIndex);
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -54,6 +54,7 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->canFramesView->setColumnWidth(6, 225);
     QHeaderView *HorzHdr = ui->canFramesView->horizontalHeader();
     HorzHdr->setStretchLastSection(true); //causes the data column to automatically fill the tableview
+    connect(HorzHdr, SIGNAL(sectionClicked(int)), this, SLOT(on_sectionClicked(int)));
 
     graphingWindow = NULL;
     frameInfoWindow = NULL;
@@ -232,6 +233,13 @@ void MainWindow::closeEvent(QCloseEvent *event)
     Q_UNUSED(event);
     writeSettings();
     exitApp();
+}
+
+void MainWindow::on_sectionClicked ( int logicalIndex )
+{
+    QHeaderView *HorzHdr = ui->canFramesView->horizontalHeader();
+    HorzHdr->setSortIndicator(logicalIndex, Qt::AscendingOrder);
+    ui->canFramesView->sortByColumn(logicalIndex);
 }
 
 void MainWindow::updateSettings()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -102,6 +102,7 @@ public slots:
     void readUpdateableSettings();
     void gotCenterTimeID(int32_t ID, double timestamp);
     void updateConnectionSettings(QString connectionType, QString port, int speed0, int speed1);
+    void on_sectionClicked ( int logicalIndex );
 
 signals:
     void sendCANFrame(const CANFrame *, int);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -95,6 +95,7 @@ private slots:
     void filterListItemChanged(QListWidgetItem *item);
     void filterSetAll();
     void filterClearAll();
+    void headerClicked (int logicalIndex);
 
 public slots:
     void gotFrames(int);
@@ -102,7 +103,6 @@ public slots:
     void readUpdateableSettings();
     void gotCenterTimeID(int32_t ID, double timestamp);
     void updateConnectionSettings(QString connectionType, QString port, int speed0, int speed1);
-    void on_sectionClicked ( int logicalIndex );
 
 signals:
     void sendCANFrame(const CANFrame *, int);

--- a/re/isotp_interpreterwindow.cpp
+++ b/re/isotp_interpreterwindow.cpp
@@ -49,12 +49,6 @@ ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames
     decoder->setProcessAll(true);
 }
 
-void ISOTP_InterpreterWindow::headerClicked(int logicalIndex)
-{
-    ui->tableIsoFrames->sortByColumn(logicalIndex);
-}
-
-
 ISOTP_InterpreterWindow::~ISOTP_InterpreterWindow()
 {
     delete decoder;
@@ -159,6 +153,11 @@ void ISOTP_InterpreterWindow::updatedFrames(int numFrames)
     else //just got some new frames. See if they are relevant.
     {
     }
+}
+
+void ISOTP_InterpreterWindow::headerClicked(int logicalIndex)
+{
+    ui->tableIsoFrames->sortByColumn(logicalIndex);
 }
 
 void ISOTP_InterpreterWindow::showDetailView()

--- a/re/isotp_interpreterwindow.cpp
+++ b/re/isotp_interpreterwindow.cpp
@@ -42,11 +42,18 @@ ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames
     ui->tableIsoFrames->setHorizontalHeaderLabels(headers);
     QHeaderView *HorzHdr = ui->tableIsoFrames->horizontalHeader();
     HorzHdr->setStretchLastSection(true);
+    connect(HorzHdr, SIGNAL(sectionClicked(int)), this, SLOT(headerClicked(int)));
 
     decoder->setReception(true);
     decoder->setFlowCtrl(false);
     decoder->setProcessAll(true);
 }
+
+void ISOTP_InterpreterWindow::headerClicked(int logicalIndex)
+{
+    ui->tableIsoFrames->sortByColumn(logicalIndex);
+}
+
 
 ISOTP_InterpreterWindow::~ISOTP_InterpreterWindow()
 {

--- a/re/isotp_interpreterwindow.h
+++ b/re/isotp_interpreterwindow.h
@@ -31,6 +31,7 @@ private slots:
     void filterNone();
     void interpretCapturedFrames();
     void useExtendedAddressing(bool checked);
+    void headerClicked(int logicalIndex);
 
 private:
     Ui::ISOTP_InterpreterWindow *ui;


### PR DESCRIPTION
That seems very native action to me, just feeling upset when frames are not sorted after a table header was clicked. I don't have any experience with Qt but it seems that QSortFilterProxyModel implements sort for most basic data types, so sorting seems to work somehow.