### PR TITLE
Fix DBC handler and DBCFile. Initialize as j1939 to false by default.

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -214,6 +214,7 @@ void DBCMessageHandler::setJ1939(bool j1939)
 DBCFile::DBCFile()
 {
     messageHandler = new DBCMessageHandler;
+    messageHandler->setJ1939(false);
 }
 
 DBCFile::DBCFile(const DBCFile& cpy)
@@ -346,6 +347,7 @@ void DBCFile::loadFile(QString fileName)
     qDebug() << "Starting DBC load";
     dbc_nodes.clear();
     messageHandler->removeAllMessages();
+    messageHandler->setJ1939(false);
 
     DBC_NODE falseNode;
     falseNode.name = "Vector__XXX";


### PR DESCRIPTION
This was causing the DBC handler to threat a DBC file as a J1939 database during the parsing, even though the files where not marked as a j1939 database. Maybe it would be better to move the attributes definition to the start of the DBC file.