### PR TITLE
FramesView: Fix auto scrolling when frame capturing is suspended

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -409,7 +409,7 @@ void MainWindow::tickGUIUpdate()
             framesPerSec = 0;
 
         ui->lbNumFrames->setText(QString::number(model->rowCount()));
-        if (ui->cbAutoScroll->isChecked()) ui->canFramesView->scrollToBottom();
+        if (allowCapture && ui->cbAutoScroll->isChecked()) ui->canFramesView->scrollToBottom();
         ui->lbFPS->setText(QString::number(framesPerSec));
         if (rxFrames > 0)
         {


### PR DESCRIPTION
Allow to freely scroll the captured frames window in suspended state.

Fixes #111