### PR TITLE
Add Read Support for CANHacker trace files (.trc)

### DIFF
--- a/framefileio.h
+++ b/framefileio.h
@@ -44,6 +44,7 @@ public:
     static bool loadKvaserFile(QString, QVector<CANFrame>*, bool);
     static bool loadCanalyzerASC(QString, QVector<CANFrame>*);
     static bool loadCanalyzerBLF(QString, QVector<CANFrame>*);
+    static bool loadCANHackerFile(QString filename, QVector<CANFrame>* frames);
     static bool saveCRTDFile(QString, const QVector<CANFrame>*);
     static bool saveNativeCSVFile(QString, const QVector<CANFrame>*);
     static bool saveGenericCSVFile(QString, const QVector<CANFrame>*);


### PR DESCRIPTION
This PR adds read support for the trace files generated by CANHacker. The software is obsolete and has been for a while, yet I still like to use it and reading the files is pretty straightforward.