### PR TITLE
Register metatypes before loading and saving configuration.

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -504,8 +504,6 @@ CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName)
 
 void ConnectionWindow::loadConnections()
 {
-    qRegisterMetaTypeStreamOperators<QVector<QString>>();
-    qRegisterMetaTypeStreamOperators<QVector<int>>();
     qRegisterMetaTypeStreamOperators<CANBus>();
     qRegisterMetaTypeStreamOperators<QList<CANBus>>();
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -29,6 +29,8 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+    qRegisterMetaTypeStreamOperators<QVector<QString>>();
+    qRegisterMetaTypeStreamOperators<QVector<int>>();
 
     useHex = true;
 


### PR DESCRIPTION
Commit 03f8e2c makes SavvyCAN save settings on startup but types used for connection settings were not registered so the connection configuration was lost.