### PR TITLE
Fix Serial Ports with dots

### DIFF
--- a/connections/canconfactory.cpp
+++ b/connections/canconfactory.cpp
@@ -11,9 +11,9 @@ CANConnection* CanConFactory::create(type pType, QString pPortName)
     case SOCKETCAN:
         return new SerialBusConnection(pPortName);
     case GVRET_SERIAL:
-        return new GVRetSerial(pPortName);
+        return new GVRetSerial(pPortName, false);
     case REMOTE:
-        return new GVRetSerial(pPortName);  //it's a special case of GVRET connected over TCP/IP so it uses the same class
+        return new GVRetSerial(pPortName, true);  //it's a special case of GVRET connected over TCP/IP so it uses the same class
     default: {}
     }
 

--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -8,7 +8,8 @@
 
 #include "gvretserial.h"
 
-GVRetSerial::GVRetSerial(QString portName) :
+GVRetSerial::GVRetSerial(QString portName, useTcp) :
+    useTcp(useTcp),
     CANConnection(portName, CANCon::GVRET_SERIAL, 3, 4000, true),
     mTimer(this) /*NB: set this as parent of timer to manage it from working thread */
 {
@@ -284,7 +285,10 @@ void GVRetSerial::connectDevice()
         disconnectDevice();
 
     /* open new device */
-    if (getPort().contains('.')) //TCP/IP mode then since it looks like an IP address
+
+    // this does the wrong thing if the serial port has a '.' in the name
+    // if (getPort().contains('.')) //TCP/IP mode then since it looks like an IP address
+    if (useTcp)
     {
         qDebug() << "TCP Connection to a GVRET device";
         tcpClient = new QTcpSocket();

--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -8,9 +8,9 @@
 
 #include "gvretserial.h"
 
-GVRetSerial::GVRetSerial(QString portName, useTcp) :
-    useTcp(useTcp),
+GVRetSerial::GVRetSerial(QString portName, bool useTcp) :
     CANConnection(portName, CANCon::GVRET_SERIAL, 3, 4000, true),
+    useTcp(useTcp),
     mTimer(this) /*NB: set this as parent of timer to manage it from working thread */
 {
     qDebug() << "GVRetSerial()";

--- a/connections/gvretserial.h
+++ b/connections/gvretserial.h
@@ -42,7 +42,7 @@ class GVRetSerial : public CANConnection
     Q_OBJECT
 
 public:
-    GVRetSerial(QString portName);
+    GVRetSerial(QString portName, bool useTcp);
     virtual ~GVRetSerial();
 
 protected:
@@ -82,6 +82,7 @@ protected:
     bool gotValidated;
     bool isAutoRestart;
     bool continuousTimeSync;
+    bool useTcp;
     QSerialPort *serial;
     QTcpSocket *tcpClient;
     int framesRapid;


### PR DESCRIPTION
Added bool passed to GVRETSerial to indicate when to use TCP,
rather than infering from port name.

I'm not sure this is the best way to do it, but I'm pretty confident you want to tell GVRETSerial explicitly to use TCP. On my Mac serial ports all look like "cu.usbmodemxxxx", so SavvyCAN won't connect to them. 