### PR TITLE
add setWindowFlags(Qt::Window) to improve window management

### DIFF
--- a/bisectwindow.cpp
+++ b/bisectwindow.cpp
@@ -13,6 +13,7 @@ BisectWindow::BisectWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     ui(new Ui::BisectWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -14,6 +14,7 @@ ConnectionWindow::ConnectionWindow(QWidget *parent) :
     ui(new Ui::ConnectionWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     QSettings settings;
 

--- a/dbc/dbcloadsavewindow.cpp
+++ b/dbc/dbcloadsavewindow.cpp
@@ -7,6 +7,7 @@ DBCLoadSaveWindow::DBCLoadSaveWindow(const QVector<CANFrame> *frames, QWidget *p
     QDialog(parent),
     ui(new Ui::DBCLoadSaveWindow)
 {
+    setWindowFlags(Qt::Window);
 
     dbcHandler = DBCHandler::getReference();
     referenceFrames = frames;

--- a/firmwareuploaderwindow.cpp
+++ b/firmwareuploaderwindow.cpp
@@ -8,7 +8,8 @@ FirmwareUploaderWindow::FirmwareUploaderWindow(const QVector<CANFrame> *frames, 
     QDialog(parent),
     ui(new Ui::FirmwareUploaderWindow)
 {
-    ui->setupUi(this);    
+    ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     transferInProgress = false;
     startedProcess = false;
@@ -25,7 +26,7 @@ FirmwareUploaderWindow::FirmwareUploaderWindow(const QVector<CANFrame> *frames, 
     updateProgress();
 
     timer = new QTimer();
-    timer->setInterval(100); //100ms without a reply will cause us to attempt a resend    
+    timer->setInterval(100); //100ms without a reply will cause us to attempt a resend
 
     connect(MainWindow::getReference(), SIGNAL(framesUpdated(int)), this, SLOT(updatedFrames(int)));
     connect(ui->btnLoadFile, SIGNAL(clicked(bool)), this, SLOT(handleLoadFile()));
@@ -136,7 +137,7 @@ void FirmwareUploaderWindow::sendFirmwareChunk()
     output->data[4] = firmwareData[firmwareLocation++];
     output->data[5] = firmwareData[firmwareLocation++];
     for (int i = 0; i < 6; i++) xorByte = xorByte ^ output->data[i];
-    output->data[6] = xorByte;    
+    output->data[6] = xorByte;
     sendCANFrame(output);
     timer->start();
 }
@@ -162,7 +163,7 @@ void FirmwareUploaderWindow::handleStartStopTransfer()
     if (startedProcess) //start the process
     {
         ui->progressBar->setValue(0);
-        ui->btnStartStop->setText("Stop Upload");        
+        ui->btnStartStop->setText("Stop Upload");
         token = Utility::ParseStringToNum(ui->txtToken->text());
         bus = ui->spinBus->value();
         baseAddress = Utility::ParseStringToNum(ui->txtBaseAddr->text());

--- a/frameplaybackwindow.cpp
+++ b/frameplaybackwindow.cpp
@@ -25,7 +25,7 @@ FramePlaybackWindow::FramePlaybackWindow(const QVector<CANFrame> *frames, QWidge
     ui(new Ui::FramePlaybackWindow)
 {
     ui->setupUi(this);
-
+    setWindowFlags(Qt::Window);
 
     int numBuses = CANConManager::getInstance()->getNumBuses();
     for (int n = 0; n < numBuses; n++) ui->comboCANBus->addItem(QString::number(n));
@@ -553,7 +553,7 @@ void FramePlaybackWindow::btnStopClick()
     {
         ui->tblSequence->setCurrentCell(0, 0);
         refreshIDList();
-    }    
+    }
     updateFrameLabel();
 }
 
@@ -594,7 +594,7 @@ void FramePlaybackWindow::changeSendingBus(int newIdx)
 void FramePlaybackWindow::changeIDFiltering(QListWidgetItem *item)
 {
     qDebug() << "Changed ID filter " << item->text() << " : " << item->checkState();
-    int ID = Utility::ParseStringToNum(item->text()); 
+    int ID = Utility::ParseStringToNum(item->text());
     currentSeqItem->idFilters[ID] = (item->checkState() == Qt::Checked) ? true : false;
 }
 

--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -20,6 +20,7 @@ FrameSenderWindow::FrameSenderWindow(const QVector<CANFrame> *frames, QWidget *p
     ui(new Ui::FrameSenderWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 

--- a/helpwindow.cpp
+++ b/helpwindow.cpp
@@ -9,6 +9,7 @@ HelpWindow::HelpWindow(QWidget *parent) :
     ui(new Ui::HelpWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     m_helpEngine = new QHelpEngineCore(QApplication::applicationDirPath() +"/SavvyCAN.qhc", this);
     if (!m_helpEngine->setupData()) {

--- a/motorcontrollerconfigwindow.cpp
+++ b/motorcontrollerconfigwindow.cpp
@@ -9,6 +9,7 @@ MotorControllerConfigWindow::MotorControllerConfigWindow(const QVector<CANFrame>
     ui(new Ui::MotorControllerConfigWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 

--- a/re/discretestatewindow.cpp
+++ b/re/discretestatewindow.cpp
@@ -8,6 +8,7 @@ DiscreteStateWindow::DiscreteStateWindow(const QVector<CANFrame> *frames, QWidge
     ui(new Ui::DiscreteStateWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
     operatingState = DWStates::IDLE;

--- a/re/filecomparatorwindow.cpp
+++ b/re/filecomparatorwindow.cpp
@@ -8,6 +8,7 @@ FileComparatorWindow::FileComparatorWindow(QWidget *parent) :
     ui(new Ui::FileComparatorWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     connect(ui->btnInterestedFile, SIGNAL(clicked(bool)), this, SLOT(loadInterestedFile()));
     connect(ui->btnLoadRefFile, SIGNAL(clicked(bool)), this, SLOT(loadReferenceFile()));
@@ -167,8 +168,8 @@ void FileComparatorWindow::calculateDetails()
                 //qDebug() << "bitmap: " << QString::number(newData->bitmap, 16);
             }
             interestedIDs.insert(frame.ID, *newData);
-        }        
-    }    
+        }
+    }
 
     for (int x = 0; x < referenceFrames.count(); x++)
     {
@@ -227,7 +228,7 @@ void FileComparatorWindow::calculateDetails()
         {
             interestedHadUnique = false;
             sharedItem = new QTreeWidgetItem();
-            sharedItem->setText(0, Utility::formatHexNum(keyone));            
+            sharedItem->setText(0, Utility::formatHexNum(keyone));
             //if the ID was in both files then we can use the data accumulated above in bitmap
             //and values to figure out what has changed between the two files
 

--- a/re/flowviewwindow.cpp
+++ b/re/flowviewwindow.cpp
@@ -12,6 +12,7 @@ FlowViewWindow::FlowViewWindow(const QVector<CANFrame> *frames, QWidget *parent)
     ui(new Ui::FlowViewWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     readSettings();
 

--- a/re/frameinfowindow.cpp
+++ b/re/frameinfowindow.cpp
@@ -9,6 +9,7 @@ FrameInfoWindow::FrameInfoWindow(const QVector<CANFrame> *frames, QWidget *paren
     ui(new Ui::FrameInfoWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     readSettings();
 

--- a/re/fuzzingwindow.cpp
+++ b/re/fuzzingwindow.cpp
@@ -11,6 +11,7 @@ FuzzingWindow::FuzzingWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     ui(new Ui::FuzzingWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 
@@ -185,7 +186,7 @@ void FuzzingWindow::setAllFilters()
 void FuzzingWindow::calcNextID()
 {
     if (seqIDScan)
-    {        
+    {
         if (rangeIDSelect)
         {
             currentID++;
@@ -368,7 +369,7 @@ void FuzzingWindow::refreshIDList()
 
     int id;
     for (int i = 0; i < modelFrames->count(); i++)
-    {        
+    {
         CANFrame thisFrame = modelFrames->at(i);
         id = thisFrame.ID;
         if (!foundIDs.contains(id))

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -10,6 +10,7 @@ GraphingWindow::GraphingWindow(const QVector<CANFrame> *frames, QWidget *parent)
     ui(new Ui::GraphingWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     readSettings();
 

--- a/re/isotp_interpreterwindow.cpp
+++ b/re/isotp_interpreterwindow.cpp
@@ -8,6 +8,7 @@ ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames
     ui(new Ui::ISOTP_InterpreterWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
     modelFrames = frames;
 
     decoder = new ISOTP_HANDLER;

--- a/re/rangestatewindow.cpp
+++ b/re/rangestatewindow.cpp
@@ -9,6 +9,7 @@ RangeStateWindow::RangeStateWindow(const QVector<CANFrame> *frames, QWidget *par
     ui(new Ui::RangeStateWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 
@@ -225,7 +226,7 @@ void RangeStateWindow::recalcButton()
                 if (modelFrames->at(j).ID == id) frameCache.append(modelFrames->at(j));
             }
             //now we've got a list with all the same ID. Time to send it off for processing
-            signalsFactory();            
+            signalsFactory();
         }
     }
 

--- a/re/sniffer/snifferwindow.cpp
+++ b/re/sniffer/snifferwindow.cpp
@@ -13,6 +13,7 @@ SnifferWindow::SnifferWindow(QWidget *parent) :
     mFilter(false)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
     ui->treeView->setModel(&mModel);
 
     /* set column width */

--- a/re/udsscanwindow.cpp
+++ b/re/udsscanwindow.cpp
@@ -11,6 +11,7 @@ UDSScanWindow::UDSScanWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     ui(new Ui::UDSScanWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     modelFrames = frames;
 

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -13,6 +13,7 @@ ScriptingWindow::ScriptingWindow(const QVector<CANFrame> *frames, QWidget *paren
     ui(new Ui::ScriptingWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     editor = new JSEdit();
     editor->setFrameShape(JSEdit::NoFrame);

--- a/signalviewerwindow.cpp
+++ b/signalviewerwindow.cpp
@@ -7,10 +7,11 @@ SignalViewerWindow::SignalViewerWindow(QWidget *parent) :
     ui(new Ui::SignalViewerWindow)
 {
     ui->setupUi(this);
+    setWindowFlags(Qt::Window);
 
     QStringList headers;
     headers << "Signal" << "Value";
-    ui->tableViewer->setHorizontalHeaderLabels(headers);    
+    ui->tableViewer->setHorizontalHeaderLabels(headers);
     ui->tableViewer->setColumnWidth(0, 150);
     ui->tableViewer->setColumnWidth(1, 300);
     QHeaderView *HorzHdr = ui->tableViewer->horizontalHeader();


### PR DESCRIPTION
    * improves window handling a lot
	(on Linux GNOME 3 at least: quickly resizing windows left/right, not forced in foreground anymore etc.)
	setWindowFlags() inserted in all *window.cpp files except mainwindow
    * some whitespace at EOL trimmed