### PR TITLE
show tooltip for socketCAN error string

### DIFF
--- a/connections/newconnectiondialog.cpp
+++ b/connections/newconnectiondialog.cpp
@@ -9,7 +9,18 @@ NewConnectionDialog::NewConnectionDialog(QVector<QString>* ips, QWidget *parent)
 {
     ui->setupUi(this);
 
-    ui->rbSocketCAN->setEnabled(isSerialBusAvailable());
+    if (isSerialBusAvailable())
+    {
+        ui->rbSocketCAN->setEnabled(true);
+    }
+    else
+    {
+        ui->rbSocketCAN->setEnabled(false);
+        QString errorString;
+        const QList<QCanBusDeviceInfo> devices = QCanBus::instance()->availableDevices(QStringLiteral("socketcan"), &errorString);
+        if (!errorString.isEmpty()) ui->rbSocketCAN->setToolTip(errorString);
+    }
+
 
     connect(ui->rbGVRET, &QAbstractButton::clicked, this, &NewConnectionDialog::handleConnTypeChanged);
     connect(ui->rbSocketCAN, &QAbstractButton::clicked, this, &NewConnectionDialog::handleConnTypeChanged);


### PR DESCRIPTION
Something like this may be useful for people wondering why SocketCAN isn't working.

![image](https://user-images.githubusercontent.com/20824939/59314962-72afef00-8c6c-11e9-9c53-cd16ffd40434.png)