### PR TITLE
Fix null pointer access in Playback window

### DIFF
--- a/frameplaybackwindow.cpp
+++ b/frameplaybackwindow.cpp
@@ -275,7 +275,11 @@ void FramePlaybackWindow::loadFilters()
 
 void FramePlaybackWindow::refreshIDList()
 {
-    if (currentSeqNum < 0 || currentSeqItem == NULL) return;
+    if (currentSeqNum < 0 || currentSeqItem == NULL)
+    {
+        ui->listID->clear();
+        return;
+    }
 
     ui->tblSequence->setCurrentCell(currentSeqNum, 0);
 
@@ -461,6 +465,7 @@ void FramePlaybackWindow::btnDeleteCurrSeq()
         currentSeqNum = -1;
         currentSeqItem = NULL;
     }
+    refreshIDList();
     updateFrameLabel();
 }
 


### PR DESCRIPTION
Hi!
Problem of Exception in Playback window.

If you check / uncheck an item that exists in ID Filtering with all sources in the Playback Sequence deleted, Null pointer access occurs and the program crashes at Segmentation fault.
This is because "currentSeqItem" is null in changeIDFiltering.
Changing the code in two places will fix this problem.