### PR TITLE
Address crash (OSX platform, at least) when deleting empty node or me…

### DIFF
--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -152,7 +152,9 @@ void DBCMainEditor::onCustomMenuMessage(QPoint point)
 void DBCMainEditor::deleteCurrentNode()
 {
     int thisRow = ui->NodesTable->currentRow();
-    QString nodeName = ui->NodesTable->item(thisRow, 0)->text();
+    QTableWidgetItem* thisItem = ui->NodesTable->item(thisRow, 0);
+    if (!thisItem) return;
+    QString nodeName = thisItem->text();
     if (nodeName.length() > 0 && nodeName.compare("Vector__XXX", Qt::CaseInsensitive) != 0)
     {        
         ui->NodesTable->removeRow(thisRow);
@@ -167,7 +169,9 @@ void DBCMainEditor::deleteCurrentNode()
 void DBCMainEditor::deleteCurrentMessage()
 {
     int thisRow = ui->MessagesTable->currentRow();
-    if (ui->MessagesTable->item(thisRow, 0)->text().length() > 0)
+    QTableWidgetItem* thisItem = ui->MessagesTable->item(thisRow, 0);
+    if (!thisItem) return;
+    if (thisItem->text().length() > 0)
     {
         ui->MessagesTable->removeRow(thisRow);
         dbcFile->messageHandler->removeMessageByIndex(thisRow);


### PR DESCRIPTION
OSX platform (maybe others) is crashing when the empty last row is deleted from either the messages or nodes tables.

Steps to reproduce:
1] Menu: File / DBC File Manager
2] Create new DBC
3] Double click on new DBC
4] Select node #2 (just under Vector_XXX) and right click Delete Currently Selected Node -> Crash.
or
5] Select node #1 (Vector_XXX) then in messages table select message #1 and right click Delete Currently Selected Message -> Crash.

This fix simply adds a validation step and silently returns (doing nothing) if the currently selected node or message does not exist.