### PR TITLE
DBC configuration saving, GMLAN 29bit Arbitration ID Matching, Filter labeling

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -68,7 +68,8 @@ SOURCES += main.cpp\
     blfhandler.cpp \
     re/sniffer/SnifferDelegate.cpp \
     connections/newconnectiondialog.cpp \
-    re/temporalgraphwindow.cpp
+    re/temporalgraphwindow.cpp \
+    filterutility.cpp
 
 HEADERS  += mainwindow.h \
     can_structs.h \
@@ -127,7 +128,8 @@ HEADERS  += mainwindow.h \
     blfhandler.h \
     re/sniffer/SnifferDelegate.h \
     connections/newconnectiondialog.h \
-    re/temporalgraphwindow.h
+    re/temporalgraphwindow.h \
+    filterutility.h
 
 FORMS    += ui/candatagrid.ui \
     ui/connectionwindow.ui \

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -102,7 +102,7 @@ void CANFrameModel::setSysTimeMode(bool mode)
     }
 }
 
-void CANFrameModel::setInterpetMode(bool mode)
+void CANFrameModel::setInterpretMode(bool mode)
 {
     //if the state of interpretFrames changes then we need to reset the model
     //so that QT will refresh the view properly
@@ -112,6 +112,11 @@ void CANFrameModel::setInterpetMode(bool mode)
         interpretFrames = mode;
         this->endResetModel();
     }
+}
+
+bool CANFrameModel::getInterpretMode()
+{
+    return interpretFrames;
 }
 
 void CANFrameModel::setTimeFormat(QString format)

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -42,7 +42,8 @@ public:
     void sendRefresh(int);
     int  sendBulkRefresh();
     void clearFrames();
-    void setInterpetMode(bool);
+    void setInterpretMode(bool);
+    bool getInterpretMode();
     void setOverwriteMode(bool);
     void setHexMode(bool);
     void setSysTimeMode(bool);

--- a/dbc/dbchandler.h
+++ b/dbc/dbchandler.h
@@ -5,6 +5,13 @@
 #include "dbc_classes.h"
 #include "can_structs.h"
 
+    typedef enum
+    {
+        EXACT,
+        J1939,
+        GMLAN
+    } MatchingCriteria_t;
+
 /*
  * TODO:
  * Finish coding up the decoupled design
@@ -40,11 +47,14 @@ public:
     bool removeMessage(QString name);
     void removeAllMessages();
     int getCount();
-    bool isJ1939();
-    void setJ1939(bool j1939);
+    MatchingCriteria_t getMatchingCriteria();
+    void setMatchingCriteria(MatchingCriteria_t mc);
+    void setFilterLabeling( bool labelFiltering );
+    bool filterLabeling();
 private:
     QList<DBC_MESSAGE> messages;
-    bool isJ1939Handler;
+    MatchingCriteria_t matchingCriteria;
+    bool filterLabelingEnabled;
 };
 
 //technically there should be a node handler too but I'm sort of treating nodes as second class
@@ -90,6 +100,7 @@ class DBCHandler: public QObject
 {
     Q_OBJECT
 public:
+    DBCFile* loadDBCFile(QString filename);
     DBCFile* loadDBCFile(int);
     void saveDBCFile(int);
     void removeDBCFile(int);
@@ -97,6 +108,7 @@ public:
     void swapFiles(int pos1, int pos2);
     DBC_MESSAGE* findMessage(const CANFrame &frame);
     DBC_MESSAGE* findMessage(const QString msgName);
+    DBC_MESSAGE* findMessageForFilter(uint32_t id, MatchingCriteria_t * matchingCriteria);
     int getFileCount();
     DBCFile* getFileByIdx(int idx);
     DBCFile* getFileByName(QString name);

--- a/dbc/dbcloadsavewindow.h
+++ b/dbc/dbcloadsavewindow.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include <QTableWidget>
+#include <QComboBox>
 #include "dbchandler.h"
 #include "dbcmaineditor.h"
 
@@ -27,6 +28,7 @@ private slots:
     void editFile();
     void cellChanged(int row, int col);
     void cellDoubleClicked(int row, int col);
+    void matchingCriteriaChanged(int index);
     void newFile();
 
 private:
@@ -41,6 +43,8 @@ private:
     QList<QTableWidgetItem*> takeRow(int row);
     void setRow(int row, const QList<QTableWidgetItem*>& rowItems);
     bool eventFilter(QObject *obj, QEvent *event);
+    void updateSettings();
+    QComboBox * addMatchingCriteriaCombobox(int row);
 };
 
 #endif // DBCLOADSAVEWINDOW_H

--- a/filterutility.cpp
+++ b/filterutility.cpp
@@ -1,0 +1,80 @@
+#include "utility.h"
+#include "filterutility.h"
+#include "dbc/dbchandler.h"
+#include <QSettings>
+
+uint32_t FilterUtility::getIdAsInt( QListWidgetItem * item )
+{
+    return Utility::ParseStringToNum(getId(item));
+}
+
+QString FilterUtility::getId( QString itemText )
+{
+    if (itemText.contains(" "))
+        // Strip away the filter label
+        return itemText.left(itemText.indexOf(" "));
+    else
+        return itemText;
+}
+
+QString FilterUtility::getId( QListWidgetItem * item )
+{
+    return getId(item->text());
+}
+
+uint32_t FilterUtility::getGMLanArbitrationId(uint32_t id)
+{
+    return (id  >> 13) & 0x1FFF;
+}
+
+uint32_t FilterUtility::getGMLanPriorityBits(uint32_t id)
+{
+    return (id  >> 26) & 0x7;
+}
+
+uint32_t FilterUtility::getGMLanSenderId(uint32_t id)
+{
+    return id & 0x1FFF;
+}
+
+QListWidgetItem * FilterUtility::createCheckableFilterItem(uint32_t id, bool checked, QListWidget* parent)
+{
+    QListWidgetItem * thisItem = createFilterItem(id,parent);
+    thisItem->setFlags(thisItem->flags() | Qt::ItemIsUserCheckable);
+    if (checked) 
+        thisItem->setCheckState(Qt::Checked);
+    else 
+        thisItem->setCheckState(Qt::Unchecked);
+    return thisItem;
+}
+
+QListWidgetItem * FilterUtility::createFilterItem(uint32_t id, QListWidget* parent)
+{
+    QSettings settings;
+    DBCHandler * dbcHandler = DBCHandler::getReference();
+    QListWidgetItem *thisItem = new QListWidgetItem(parent);
+    QString filterItemName = Utility::formatCANID(id);
+
+    if (settings.value("Main/FilterLabeling", false).toBool())
+    {    
+        // Filter labeling (show interpreted frame names next to the CAN addr ID)
+        MatchingCriteria_t matchingCriteria;
+        DBC_MESSAGE *msg = dbcHandler->findMessageForFilter(id,&matchingCriteria);
+        if (msg != NULL)
+        {
+            filterItemName.append(" ");
+            filterItemName.append(msg->name);
+
+            // Create tooltip to show the whole name just in case it's too long to fit in the filter window.
+            // Also if the matching criteria is set to GMLAN, show the Arbitration ID as well
+            QString tooltip;
+            if (matchingCriteria == GMLAN)
+                tooltip.append("0x" + QString::number(FilterUtility::getGMLanArbitrationId(id), 16).toUpper().rightJustified(4,'0') + ": ");
+            tooltip.append(msg->name);
+            thisItem->setToolTip(tooltip);
+        }
+    }
+
+    thisItem->setText(filterItemName);
+    return thisItem;
+}

--- a/filterutility.h
+++ b/filterutility.h
@@ -1,0 +1,23 @@
+#ifndef FILTERUTILITY_H
+#define FILTERUTILITY_H
+
+#include <QListWidget>
+
+
+class FilterUtility
+{
+
+public:
+    static QListWidgetItem * createFilterItem(uint32_t id, QListWidget* parent=NULL);   // if parent is given, add item automatically to listwidget
+    static QListWidgetItem * createCheckableFilterItem(uint32_t id, bool checked, QListWidget* parent=NULL);
+
+    static uint32_t getIdAsInt( QListWidgetItem * item );
+    static QString getId( QListWidgetItem * item );
+    static QString getId( QString itemText );
+
+    static uint32_t getGMLanArbitrationId(uint32_t id);
+    static uint32_t getGMLanSenderId(uint32_t id);
+    static uint32_t getGMLanPriorityBits(uint32_t id);
+};
+
+#endif // DBCLOADSAVEWINDOW_H

--- a/mainsettingsdialog.cpp
+++ b/mainsettingsdialog.cpp
@@ -61,6 +61,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     ui->comboSendingBus->setCurrentIndex(settings.value("Playback/SendingBus", 4).toInt());
     ui->cbUseFiltered->setChecked(settings.value("Main/UseFiltered", false).toBool());
     ui->cbUseOpenGL->setChecked(settings.value("Main/UseOpenGL", false).toBool());
+    ui->cbFilterLabeling->setChecked(settings.value("Main/FilterLabeling", false).toBool());
 
     //just for simplicity they all call the same function and that function updates all settings at once
     connect(ui->cbDisplayHex, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
@@ -83,6 +84,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     connect(ui->lineRemoteHost, SIGNAL(editingFinished()), this, SLOT(updateSettings()));
     connect(ui->lineRemotePort, SIGNAL(editingFinished()), this, SLOT(updateSettings()));
     connect(ui->cbLoadConnections, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
+    connect(ui->cbFilterLabeling, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     installEventFilter(this);
 }
 
@@ -141,6 +143,7 @@ void MainSettingsDialog::updateSettings()
     settings.setValue("Remote/Host", ui->lineRemoteHost->text());
     settings.setValue("Remote/Port", ui->lineRemotePort->text());
     settings.setValue("Remote/AutoStart", ui->cbAutoStartRemote->isChecked());
+    settings.setValue("Main/FilterLabeling", ui->cbFilterLabeling->isChecked());
 
     settings.sync();
     emit updatedSettings();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -432,6 +432,8 @@ void MainWindow::updateFilterList()
 
     qDebug() << "updateFilterList called on MainWindow";
 
+    inhibitFilterUpdate = true;
+
     ui->listFilters->clear();
 
     if (filters->isEmpty()) return;
@@ -441,6 +443,7 @@ void MainWindow::updateFilterList()
     {
         QListWidgetItem *thisItem = FilterUtility::createCheckableFilterItem(filterIter.key(), filterIter.value(), ui->listFilters);
     }
+    inhibitFilterUpdate = false;
 }
 
 void MainWindow::filterListItemChanged(QListWidgetItem *item)

--- a/ui/dbcloadsavewindow.ui
+++ b/ui/dbcloadsavewindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>506</width>
+    <width>680</width>
     <height>665</height>
    </rect>
   </property>

--- a/ui/mainsettingsdialog.ui
+++ b/ui/mainsettingsdialog.ui
@@ -74,6 +74,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="cbFilterLabeling">
+          <property name="text">
+           <string>Label filters using messages from DBC files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="cbUseOpenGL">
           <property name="text">
            <string>OpenGL Accelerated AntiAliased Graphing</string>


### PR DESCRIPTION
- Save DBC file configuration when changed, and restore it when restarting the application (no need for manual entry everytime app is launched)

- Add GMLAN 29bit filtering feature. In addition to J1939 matching, it is now possible to match DBC messages using only the Arbitration Id (bits 14-26 of CAN Address), since  Priority id (higher bits) and Sender Id (lowest 13 bits) are not relevant when interpreting the CAN message content. This allows to use the excellent GM Global A DBC files on https://github.com/commaai/opendbc. Just remember to select the "GMLAN" matching criteria on DBC File manager.

- Add "Filter labeling" feature. Using loaded DBC files, it matches the filter Ids with DBC messages and shows them in filter windows. Labeling works in the main window (no need to set "Frame interpret" on, since this is a separate feature), as well as in Flow view, Frame data analysis, Playback and Fuzzzing windows. This makes it so much easier to concentrate on those CAN messages that matter. To use this feature, select global "Label filters using messages from DBC files" on Main Configuration page, and then enable the feature on individual DBC files (on DBC file manager) as needed. This is needed if there's overlap in CAN addresses between DBC files, and because the filter labeler cannot tell apart anymore which Filter ID is associated to which bus, it might label them incorrectly. But usually it's ok to just enable the labeling with all the DBC files.

- Tooltips are added to each filter label to better see the whole label in case it's too long for the filter window. Filter labeler also appends the GMLAN Arbitration ID to the tooltip if the filter was matched with GMLAN enabled DBC message.

- In Frame data analysis window, in addition to showing J1939 decoding also GMLAN (Priority bits, 
Arbitration Id, Sender Id) decoding is shown.

- FilterUtility static class used for centralized ListWidgetItem creation and for other helper functions

- DBC handler: To allow setting bus numbers even before connection is configured, do not enforce "valid" bus numbers
