### PR TITLE
DBC settings and bugfixes

### DIFF
--- a/dbc/dbcloadsavewindow.h
+++ b/dbc/dbcloadsavewindow.h
@@ -31,6 +31,9 @@ private slots:
     void matchingCriteriaChanged(int index);
     void newFile();
 
+signals:
+    void updatedDBCSettings();
+
 private:
     Ui::DBCLoadSaveWindow *ui;
     DBCHandler *dbcHandler;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1029,11 +1029,19 @@ void MainWindow::showFlowViewWindow()
     flowViewWindow->show();
 }
 
+
+void MainWindow::DBCSettingsUpdated()
+    {
+    updateFilterList();
+    model->sendRefresh();
+    }
+
 void MainWindow::showDBCFileWindow()
 {
     if (!dbcFileWindow)
     {
         dbcFileWindow = new DBCLoadSaveWindow(model->getListReference());
+        connect(dbcFileWindow, &DBCLoadSaveWindow::updatedDBCSettings, this, &MainWindow::DBCSettingsUpdated);
     }
     dbcFileWindow->show();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -98,6 +98,7 @@ private slots:
     void filterSetAll();
     void filterClearAll();
     void headerClicked (int logicalIndex);
+    void DBCSettingsUpdated();
 
 public slots:
     void gotFrames(int);


### PR DESCRIPTION
- Changes in DBC file manager (such as changing the bus, matching criteria, filter labeling) are immediately propagated to the main window (frame interpreting, filter labeling)
- Prevent DBC file manager from saving settings too often and too early (this also fixes a bug where sometimes the settings of all but the first DBC file are lost)