### PR TITLE
Add support for Little Endian Floats

### DIFF
--- a/dbc/dbc_classes.cpp
+++ b/dbc/dbc_classes.cpp
@@ -79,7 +79,7 @@ bool DBC_SIGNAL::processAsText(const CANFrame &frame, QString &outString, bool o
         //that the bytes that make up the integer are instead treated as having made up
         //a 32 bit single precision float. That's evil incarnate but it is very fast and small
         //in terms of new code.
-        result = Utility::processIntegerSignal(frame.data, startBit, 32, false, false);
+        result = Utility::processIntegerSignal(frame.data, startBit, 32, intelByteOrder, false);
         endResult = (*((float *)(&result)) * factor) + bias;
     }
     else //double precision float
@@ -91,7 +91,7 @@ bool DBC_SIGNAL::processAsText(const CANFrame &frame, QString &outString, bool o
         }
         //like the above, this is rotten and evil and wrong in so many ways. Force
         //calculation of a 64 bit integer and then cast it into a double.
-        result = Utility::processIntegerSignal(frame.data, 0, 64, false, false);
+        result = Utility::processIntegerSignal(frame.data, 0, 64, intelByteOrder, false);
         endResult = (*((double *)(&result)) * factor) + bias;
     }
 

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -465,6 +465,14 @@ DBC_SIGNAL* DBCFile::parseSignalLine(QString line, DBC_MESSAGE *msg)
         case 4:
             sig.valType = STRING;
             break;
+        case 5: //single point float in little endian
+            sig.valType = SP_FLOAT;
+            sig.intelByteOrder = true;
+            break;
+        case 6: //double point float in little endian
+            sig.valType = DP_FLOAT;
+            sig.intelByteOrder = true;
+            break;
         }
         sig.factor = match.captured(6 + offset).toDouble();
         sig.bias = match.captured(7 + offset).toDouble();
@@ -1230,10 +1238,12 @@ void DBCFile::saveFile(QString fileName)
                 else msgOutput.append("0-");
                 break;
             case SP_FLOAT:
-                msgOutput.append("2-");
+                if (sig->intelByteOrder) msgOutput.append("5-");
+                else msgOutput.append("2-");
                 break;
             case DP_FLOAT:
-                msgOutput.append("3-");
+                if (sig->intelByteOrder) msgOutput.append("6-");
+                else msgOutput.append("3-");
                 break;
             case STRING:
                 msgOutput.append("4-");

--- a/dbc/dbcsignaleditor.cpp
+++ b/dbc/dbcsignaleditor.cpp
@@ -49,8 +49,6 @@ DBCSignalEditor::DBCSignalEditor(QWidget *parent) :
             {
                 if (currentSignal == nullptr) return;
                 currentSignal->intelByteOrder = ui->cbIntelFormat->isChecked();
-                if (currentSignal->valType == SP_FLOAT || currentSignal->valType == DP_FLOAT)
-                    currentSignal->intelByteOrder = false;
                 fillSignalForm(currentSignal);
             });
 
@@ -74,13 +72,11 @@ DBCSignalEditor::DBCSignalEditor(QWidget *parent) :
                     break;
                 case 2:
                     currentSignal->valType = SP_FLOAT;
-                    currentSignal->intelByteOrder = false;
                     if (currentSignal->startBit > 39) currentSignal->startBit = 39;
                     currentSignal->signalSize = 32;
                     break;
                 case 3:
                     currentSignal->valType = DP_FLOAT;
-                    currentSignal->intelByteOrder = false;
                     currentSignal->startBit = 7; //has to be!
                     currentSignal->signalSize = 64;
                     break;


### PR DESCRIPTION
I have an application where data is packed into canframes as little endian floats.
This PR has minor modifications to allow for floating point endianness:
- Removes the explicit deselection of endian checkbox when float types are set.
- Passes the endianess into the processIntegerSignal function when decoding floats.

In order to allow for loading and saving from DBC files, I have added new cases (5- and 6-) for `sig.valType`. This isn't the most elegant solution, but it maintains backward compatibility. 

Another option is to add support for the SIG_VALTYPE_ token. I am very familiar with what specifications are around for DBC but I have seen this implementation:
`SIG_VALTYPE_ <frame_id> <signal_name> : <type ex. 1 for float, 2 for double>;`

This may be a better option for supporting alternate data types. 