### PR TITLE
Use integer formatting where possible when interpreting signal.

### DIFF
--- a/dbc/dbc_classes.h
+++ b/dbc/dbc_classes.h
@@ -104,7 +104,7 @@ public: //TODO: this is sloppy. It shouldn't all be public!
     bool processAsText(const CANFrame &frame, QString &outString, bool outputName = true);
     bool processAsInt(const CANFrame &frame, int32_t &outValue);
     bool processAsDouble(const CANFrame &frame, double &outValue);
-    QString makePrettyOutput(double floatVal, int64_t intVal, bool outputName = true);
+    QString makePrettyOutput(double floatVal, int64_t intVal, bool outputName = true, bool isInteger = false);
     DBC_ATTRIBUTE_VALUE *findAttrValByName(QString name);
     DBC_ATTRIBUTE_VALUE *findAttrValByIdx(int idx);
 };


### PR DESCRIPTION
Numbers are formatted as floating point numbers, which looks
a bit crap for things like e.g. serial numbers (we don't need
mantissa and exponent). This change checks the scaling factor,
and if it is integer representable, the resulting number is
formatted as an integer number as that's most likely what's
intended, particularly if the factor is 1.