### PR TITLE
Modify the parsing of the 'id' trigger to match help

### DIFF
--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -694,7 +694,7 @@ void FrameSenderWindow::processTriggerText(int line)
                 QString tok = trigToks.at(x);
                 if (tok.left(2) == "ID")
                 {
-                    thisTrigger.ID = Utility::ParseStringToNum(tok.right(tok.length() - 3));
+                    thisTrigger.ID = Utility::ParseStringToNum(tok.right(tok.length() - 2));
                     if (thisTrigger.maxCount == -1) thisTrigger.maxCount = 10000000;
 
                     if (thisTrigger.milliseconds == -1) thisTrigger.milliseconds = 0; //by default don't count, just send it upon trigger


### PR DESCRIPTION
Documentation says that trigger should be 'id' followed by the ID and gives the example 'id0x200'. This PR changes parsing to match the docs, previously the character between prefix and number was ignored, so that 'id:0x200' would work, but 'id0x200' would not.
