### PR TITLE
Enable support for local plugins

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,9 @@ int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
 
+    //Add a local path for Qt extensions, to allow for per-application extensions.
+    a.addLibraryPath("plugins");
+
     //These things are used by QSettings to set up setting storage
     a.setOrganizationName("EVTV");
     a.setApplicationName("SavvyCAN");


### PR DESCRIPTION
Allow for local/per-application support for extensions to the base Qt modules. This allows the end users to place extensions under a local folder named `plugins`.

This could be new QCANBus classes (placed in `plugins/canbus/`), enabling streaming from additional logger hardware.