### PR TITLE
CLX000: Allow for shorter IDs, flip direction

### DIFF
--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -4375,7 +4375,7 @@ bool FrameFileIO::loadCLX000File(QString filename, QVector<CANFrame>* frames) {
         pattern += valueSeparator;
     }
     if(presentFields.contains("ID")) {
-        pattern += "(?<id>[a-fA-F\\d]{3,8})";
+        pattern += "(?<id>[a-fA-F\\d]{1,8})";
         pattern += valueSeparator;
     }
     if(presentFields.contains("Length")) {
@@ -4418,7 +4418,7 @@ bool FrameFileIO::loadCLX000File(QString filename, QVector<CANFrame>* frames) {
             if(res.captured("type").length() != 0) {
                 auto frameType = res.captured("type").toUInt();
 
-                currentFrame.isReceived = (frameType & 0x08);
+                currentFrame.isReceived = !(frameType & 0x08);
                 currentFrame.setExtendedFrameFormat(frameType & 0x01);
             }
 


### PR DESCRIPTION
Seems I was a bit too stringent with the parser rules at first.