### PR TITLE
fixing opengl32 lib for g++ and msvc in windows

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -211,8 +211,12 @@ RESOURCES += \
     icons.qrc \
     images.qrc
 
-win32 {
+win32-msvc* {
    LIBS += opengl32.lib
+}
+
+win32-g++ {
+   LIBS += libopengl32
 }
 
 unix {


### PR DESCRIPTION
this has been bugging me when merging my branches, since I compile in Qt using mingw...
now it should work with both compilers under windows