### PR TITLE
GraphWindow: support rescaling the view or each axis to the data

### DIFF
--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -68,7 +68,7 @@ GraphingWindow::GraphingWindow(const QVector<CANFrame> *frames, QWidget *parent)
     connect(ui->graphingView->yAxis, SIGNAL(rangeChanged(QCPRange)), ui->graphingView->yAxis2, SLOT(setRange(QCPRange)));
 
     //connect(ui->graphingView, SIGNAL(titleDoubleClick(QMouseEvent*,QCPTextElement*)), this, SLOT(titleDoubleClick(QMouseEvent*,QCPTextElement*)));
-    connect(ui->graphingView, SIGNAL(axisDoubleClick(QCPAxis*,QCPAxis::SelectablePart,QMouseEvent*)), this, SLOT(axisLabelDoubleClick(QCPAxis*,QCPAxis::SelectablePart)));
+    connect(ui->graphingView, SIGNAL(axisDoubleClick(QCPAxis*,QCPAxis::SelectablePart,QMouseEvent*)), this, SLOT(axisDoubleClick(QCPAxis*,QCPAxis::SelectablePart)));
     connect(ui->graphingView, SIGNAL(legendDoubleClick(QCPLegend*,QCPAbstractLegendItem*,QMouseEvent*)), this, SLOT(legendDoubleClick(QCPLegend*,QCPAbstractLegendItem*)));
     connect(ui->graphingView, SIGNAL(legendClick(QCPLegend*,QCPAbstractLegendItem*,QMouseEvent*)), this, SLOT(legendSingleClick(QCPLegend*,QCPAbstractLegendItem*)));
 
@@ -294,11 +294,10 @@ void GraphingWindow::titleDoubleClick(QMouseEvent* event, QCPTextElement* title)
   editSelectedGraph();
 }
 
-void GraphingWindow::axisLabelDoubleClick(QCPAxis *axis, QCPAxis::SelectablePart part)
+void GraphingWindow::axisDoubleClick(QCPAxis *axis, QCPAxis::SelectablePart part)
 {
-  qDebug() << "axisLabelDoubleClick";
-  // Set an axis label by double clicking on it
-  if (part == QCPAxis::spAxisLabel) // only react when the actual axis label is clicked, not tick label or axis backbone
+  qDebug() << "axisDoubleClick";
+  if (part == QCPAxis::spAxisLabel) // Set an axis label by double clicking on it
   {
     bool ok;
     QString newLabel = QInputDialog::getText(this, "SavvyCAN Graphing", "New axis label:", QLineEdit::Normal, axis->label(), &ok);
@@ -307,6 +306,10 @@ void GraphingWindow::axisLabelDoubleClick(QCPAxis *axis, QCPAxis::SelectablePart
       axis->setLabel(newLabel);
       ui->graphingView->replot();
     }
+  } else if (part == QCPAxis::spAxis) // Resize an axis to fit by double clicking it
+  {
+    axis->rescale(true);
+    ui->graphingView->replot();
   }
 }
 

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -586,6 +586,13 @@ void GraphingWindow::removeAllGraphs()
     }
 }
 
+void GraphingWindow::rescaleToData()
+{
+    ui->graphingView->xAxis->rescale(true);
+    ui->graphingView->yAxis->rescale(true);
+    ui->graphingView->replot();
+}
+
 void GraphingWindow::toggleFollowMode()
 {
     followGraphEnd = !followGraphEnd;
@@ -627,6 +634,10 @@ void GraphingWindow::contextMenuRequest(QPoint pos)
     }
     menu->addSeparator();
     menu->addAction(tr("Reset View"), this, SLOT(resetView()));
+    if (ui->graphingView->graphCount() > 0)
+    {
+      menu->addAction(tr("Rescale to data"), this, SLOT(rescaleToData()));
+    }
     menu->addAction(tr("Zoom In"), this, SLOT(zoomIn()));
     menu->addAction(tr("Zoom Out"), this, SLOT(zoomOut()));
   }

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -308,7 +308,7 @@ void GraphingWindow::axisDoubleClick(QCPAxis *axis, QCPAxis::SelectablePart part
     }
   } else if (part == QCPAxis::spAxis) // Resize an axis to fit by double clicking it
   {
-    axis->rescale(true);
+    this->rescaleAxis(axis);
     ui->graphingView->replot();
   }
 }
@@ -586,10 +586,15 @@ void GraphingWindow::removeAllGraphs()
     }
 }
 
+void GraphingWindow::rescaleAxis(QCPAxis *axis)
+{
+    axis->rescale(true);
+}
+
 void GraphingWindow::rescaleToData()
 {
-    ui->graphingView->xAxis->rescale(true);
-    ui->graphingView->yAxis->rescale(true);
+    this->rescaleAxis(ui->graphingView->xAxis);
+    this->rescaleAxis(ui->graphingView->yAxis);
     ui->graphingView->replot();
 }
 

--- a/re/graphingwindow.h
+++ b/re/graphingwindow.h
@@ -47,7 +47,7 @@ public:
 
 private slots:
     void titleDoubleClick(QMouseEvent *event, QCPTextElement *title);
-    void axisLabelDoubleClick(QCPAxis* axis, QCPAxis::SelectablePart part);
+    void axisDoubleClick(QCPAxis* axis, QCPAxis::SelectablePart part);
     void legendDoubleClick(QCPLegend* legend, QCPAbstractLegendItem* item);
     void legendSingleClick(QCPLegend* legend, QCPAbstractLegendItem* item);
     void plottableDoubleClick(QCPAbstractPlottable* plottable,int dataIdx, QMouseEvent* event);

--- a/re/graphingwindow.h
+++ b/re/graphingwindow.h
@@ -63,6 +63,7 @@ private slots:
     void saveSpreadsheet();
     void saveDefinitions();
     void loadDefinitions();
+    void rescaleToData();
     void toggleFollowMode();
     void addNewGraph();
     void createGraph(GraphParams &params, bool createGraphParam = true);

--- a/re/graphingwindow.h
+++ b/re/graphingwindow.h
@@ -63,6 +63,7 @@ private slots:
     void saveSpreadsheet();
     void saveDefinitions();
     void loadDefinitions();
+    void rescaleAxis(QCPAxis* axis);
     void rescaleToData();
     void toggleFollowMode();
     void addNewGraph();


### PR DESCRIPTION
I'm a new user on OS X, and have had a bit of trouble zooming on the graph window when dealing with logfile data. (I use the recent CLX support!)

This implements: https://github.com/collin80/SavvyCAN/issues/300 as:
- Double-clicking an axis now resizes that axis to the available data.
- When at least one graph is plotted, offers an action in the context menu to rescale the view to the data.

I would be glad to update the helpfile appropriately; just indicate how you'd like it done.