### PR TITLE
Add a keyboard shortcut to the open menu

### DIFF
--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -454,6 +454,9 @@
    <property name="text">
     <string>Load Log File</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
   </action>
   <action name="actionSave_Log_File">
    <property name="text">


### PR DESCRIPTION
Simple patch to make Ctrl-O (or Cmd-O on the mac) work for opening files