### PR TITLE
Fix up double sized opengl graph rendering on high res screens

### DIFF
--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -86,6 +86,9 @@ GraphingWindow::GraphingWindow(const QVector<CANFrame> *frames, QWidget *parent)
 
     if (useOpenGL)
     {
+        //Fix the device pixel ratio for openGL so the graph doesn't render double sized
+        ui->graphingView->setBufferDevicePixelRatio(1);
+        
         ui->graphingView->setAntialiasedElements(QCP::aeAll);
         //ui->graphingView->setNoAntialiasingOnDrag(true);
         ui->graphingView->setOpenGl(true);


### PR DESCRIPTION
This fixes up the graphing windows on high-res displays (tested on macOS) when OpenGL rendering is turned on.

This more then likely needs to be tested on Windows and Linux.