### PR TITLE
Allow overriding PREFIX on qmake

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -225,8 +225,7 @@ win32-g++ {
 }
 
 unix {
-   isEmpty(PREFIX)
-   {
+   isEmpty(PREFIX) {
       PREFIX=/usr/local
    }
    target.path = $$PREFIX/bin


### PR DESCRIPTION
I tried to build SavvyCAN for Alpine Linux and ran `qtmake-qt5 PREFIX=/usr`. I got errors because Alpine's packaging tool does not allow placing any files in `/usr/local`; it turns out the prefix I set was ignored because `isEmpty(PREFIX)` was not directly followed by a block, so the block statement gets treated as a separate statement and the `isEmpty` just does nothing.

You can test this by just adding a `message(blah)` inside the block; with the opening brace on a new line, the message always displays, and with the opening brace on the same line, the message is not shown if i set PREFIX on the command line.