### PR TITLE
Remember busspeed

### DIFF
--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -167,7 +167,7 @@ void CANConnection::updateBusSpeed(int pBusIdx, int speed)
     }
 
 
-    if (pBusIdx > mNumBuses) return;
+    if (pBusIdx >= mNumBuses || pBusIdx >= mBusData.length()) return;
 
     mBusData[pBusIdx].mBus.setSpeed(speed);
 }

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -155,6 +155,24 @@ void CANConnection::setBusSettings(int pBusIdx, CANBus pBus)
 }
 
 
+void CANConnection::updateBusSpeed(int pBusIdx, int speed)
+{
+    /* make sure we execute in mThread context */
+    if( mThread_p && (mThread_p != QThread::currentThread()) ) {
+        QMetaObject::invokeMethod(this, "updateBusSpeed",
+                                  Qt::BlockingQueuedConnection,
+                                  Q_ARG(int, pBusIdx),
+                                  Q_ARG(int, speed));
+        return;
+    }
+
+
+    if (pBusIdx > mNumBuses) return;
+
+    mBusData[pBusIdx].mBus.setSpeed(speed);
+}
+
+
 bool CANConnection::sendFrame(const CANFrame& pFrame)
 {
     /* make sure we execute in mThread context */

--- a/connections/canconnection.h
+++ b/connections/canconnection.h
@@ -144,6 +144,11 @@ public slots:
     bool getBusSettings(int pBusIdx, CANBus& pBus);
 
     /**
+     * updateBusSpeed
+     */
+    void updateBusSpeed(int pBusIdx, int speed);
+
+    /**
      * @brief suspends/restarts data capture
      * @param pSuspend: suspends capture if true else restarts it
      * @note this calls piSuspend (in the working thread context if one has been started)

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -532,6 +532,13 @@ void ConnectionWindow::loadConnections()
     QVector<int>    busNums = settings.value("connections/busNums").value<QVector<int>>();
     QVector<int>    busSpeedsT = settings.value("connections/busSpeeds").value<QVector<int>>();
     QVector<QVector<int>> busSpeeds;
+
+    // if values not present (e.g. when you update the program)
+    if (busNums.count() != driverNames.count()) {
+        busNums = QVector<int>(driverNames.count());
+        busSpeedsT = QVector<int>(0);
+    }
+
     //don't load the connections if the three setting arrays above aren't all the same size.
     if (portNames.count() != driverNames.count() || devTypes.count() != driverNames.count() || driverNames.count() != busNums.count()) return;
 

--- a/connections/connectionwindow.h
+++ b/connections/connectionwindow.h
@@ -34,6 +34,7 @@ signals:
     void updateBusSettings(CANBus *bus);
     void updatePortName(QString port);
     void sendDebugData(QByteArray bytes);
+    void updateBusSpeed(int, int);
 
 public slots:
     void getDebugText(QString debugText);
@@ -65,7 +66,7 @@ private:
     QVector<QString> remoteDeviceIPGVRET;
     QVector<QString> remoteDeviceKayak;
 
-    CANConnection* create(CANCon::type pTye, QString pPortName, QString pDriver);
+    CANConnection* create(CANCon::type pTye, QString pPortName, QString pDriver, int portNum, QVector<int> portSpeeds);
     void populateBusDetails(int offset);
     void loadConnections();
     void saveConnections();


### PR DESCRIPTION
As discussed in https://github.com/collin80/SavvyCAN/discussions/445 .

It's a bit crude but the bus speed update has to take place after initialization of the connection on most devices hence the different update method. The bus speed is only saved if the change was successful in the configuration screen so for some users it might look like nothing is working due to that failing. My familiarity with the QT Threading system is poor at best, maybe this was not the best way to do it but for me it works and it might be of use to others. I have no way to test it with the current supported devices so YMMV with those implementations.

Not tested on Windows/OSX as I have no working setup for those OS's. 