### PR TITLE
Avoid undefined behavior if FD frame datalengths are present in sorting

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -252,7 +252,7 @@ uint64_t CANFrameModel::getCANFrameVal(int row, Column col)
         return static_cast<uint64_t>(frame.payload().length());
     case Column::ASCII: //sort both the same for now
     case Column::Data:
-        for (int i = 0; i < frame.payload().length(); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
+        for (int i = 0; i < std::min(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
         //qDebug() << temp;
         return temp;
     case Column::NUM_COLUMN:


### PR DESCRIPTION
Currently, sorting loops all data bytes in a CAN frame into a 64 bit comparison value. In case of CAN FD frames, this will result in a negative bitshift, resulting in undefined behavior.

This selects up to the first 8 bytes, such that the bitshift never is a negative value.