### PR TITLE
readme: fix QT module dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ when you installed Qt.
 
 ### What to do if `qmake` fails with error `Project ERROR: Unknown module(s) in QT: qml serialbus help` on Ubuntu? :
 
-`sudo apt install libqt5serialbus5-dev qtdeclarative5-dev qttools5-dev`
+`sudo apt install libqt5serialbus5-dev libqt5serialport5-dev qtdeclarative5-dev qttools5-dev`
 
 ### Used Items Requiring Attribution
 


### PR DESCRIPTION
When building from source `qmake` failed, so I installed the stated dependencies. However it still failed.

Some little search gave the missing package: `libqt5serialport5-dev``
In this PR I added it to the list.