### PR TITLE
ignore more build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,15 @@ build/
 *.out
 *.app
 *.user
+SavvyCAN
 
 # Generated files
 **/moc_*
 **/ui_*.h
 **/qrc_*.cpp
 SavvyCAN.pro.user.*
+.qmake.stash
+Makefile
+
+# Editor files
+*.code-workspace


### PR DESCRIPTION
- `.qmkae.stash` and `Makefile` are generated by `qmake` command
- `SaavyCan` is default executable name for linux builds
- ignore a local VS code config file