### PR TITLE
Fix two socketcand issues: start up switch to raw mode, crash due to partial frame

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -779,7 +779,7 @@ int CANFrameModel::sendBulkRefresh()
     if (lastUpdateNumFrames == 0 && !overwriteDups) return 0;
     if (filteredFrames.count() == 0) return 0;
 
-    qDebug() << "Bulk refresh of " << lastUpdateNumFrames;
+    //qDebug() << "Bulk refresh of " << lastUpdateNumFrames;
 
     beginResetModel();
     endResetModel();

--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -402,6 +402,12 @@ void SocketCANd::procRXData(QString data, int busNum)
             rx_state[busNum] = RAWMODE;
             decodeFrames(data, busNum);
         }
+        else if(data.indexOf("< ok >", 0, Qt::CaseSensitivity::CaseInsensitive) > 0)
+        {
+            qDebug() << "Ok found at in middle of compound message, switching to RAW and decoding immediately";
+            rx_state[busNum] = RAWMODE;
+            decodeFrames(data, busNum);
+        }
         break;
     case RAWMODE:
         decodeFrames(data, busNum);

--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -263,6 +263,12 @@ void SocketCANd::decodeFrames(QString data, int busNum)
         QString frameStr = frameStrConst;
         QStringList frameParsed = (frameStr.remove(QRegExp("^<")).remove(QRegExp(">$"))).simplified().split(' ');
 
+        if(frameParsed.length() < 2)
+        {
+            qDebug() << "Received datagramm is an incomplete frame: " << data;
+            return;
+        }
+
         buildFrame.setFrameId(frameParsed[1].toUInt(nullptr, 16));
         buildFrame.bus = busNum;
 
@@ -271,6 +277,13 @@ void SocketCANd::decodeFrames(QString data, int busNum)
 
         buildFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, frameParsed[2].toDouble() * 1000000l));
         //buildFrame.len =  frameParsed[3].length() * 0.5;
+
+        if(frameParsed.length() < 4)
+        {
+            qDebug() << "Received frame doesn't contain any data: " << data;
+            return;
+        }
+
         int framelength = frameParsed[3].length() * 0.5;
 
         buildData.resize(framelength);

--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -396,6 +396,12 @@ void SocketCANd::procRXData(QString data, int busNum)
         {
             rx_state[busNum] = RAWMODE;
         }
+        else if(data.indexOf("< ok >", 0, Qt::CaseSensitivity::CaseInsensitive) == 0)
+        {
+            qDebug() << "Ok found at start of compound message, switching to RAW and decoding immediately";
+            rx_state[busNum] = RAWMODE;
+            decodeFrames(data, busNum);
+        }
         break;
     case RAWMODE:
         decodeFrames(data, busNum);


### PR DESCRIPTION
The startup failure to switch to raw mode was due to data frames coming in the same message as the "< ok >" ack message for the switch to raw, so added parsing to check for these cases

The partial frame failure was an index out of bounds crash that came from assuming only complete frames would be received and the parser would always return a certian number of substrings, so added some sanity checking