### PR TITLE
Fix dbc delete node non-function and dbc delete message occasional crash

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -337,7 +337,22 @@ DBC_NODE* DBCFile::findNodeByName(QString name)
     if (dbc_nodes.length() == 0) return nullptr;
     for (int i = 0; i < dbc_nodes.length(); i++)
     {
-        if (dbc_nodes[i].name.compare(name, Qt::CaseInsensitive) == 0)
+        if (name.compare(dbc_nodes[i].name, Qt::CaseInsensitive) == 0)
+        {
+            return &dbc_nodes[i];
+        }
+    }
+    return nullptr;
+}
+
+DBC_NODE* DBCFile::findNodeByNameAndComment(QString fullname)
+{
+    QString nameAndComment;
+    if (dbc_nodes.length() == 0) return nullptr;
+    for (int i = 0; i < dbc_nodes.length(); i++)
+    {
+        nameAndComment = dbc_nodes[i].name + " - " + dbc_nodes[i].comment;
+        if (fullname.compare(nameAndComment, Qt::CaseInsensitive) == 0)
         {
             return &dbc_nodes[i];
         }

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -192,6 +192,7 @@ bool DBCMessageHandler::removeMessage(DBC_MESSAGE *msg)
         {
             messages.removeAt(i);
             qDebug() << "Removed message at idx " << i;
+            break;
         }
     }
     return true;

--- a/dbc/dbchandler.h
+++ b/dbc/dbchandler.h
@@ -72,6 +72,7 @@ public:
     DBCFile(const DBCFile& cpy);
     DBCFile& operator=(const DBCFile& cpy);
     DBC_NODE *findNodeByName(QString name);
+    DBC_NODE *findNodeByNameAndComment(QString fullname);
     DBC_NODE *findNodeByIdx(int idx);
     DBC_ATTRIBUTE *findAttributeByName(QString name, DBC_ATTRIBUTE_TYPE type = ATTR_TYPE_ANY);
     DBC_ATTRIBUTE *findAttributeByIdx(int idx);

--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -631,7 +631,7 @@ void DBCMainEditor::deleteCurrentTreeItem()
 {
     QTreeWidgetItem *currItem = ui->treeDBC->currentItem();
     int typ = currItem->data(0, Qt::UserRole).toInt();
-    QString idString;
+    QString idString, columnText;
     int msgID;
     DBC_MESSAGE *msg;
     DBC_NODE *node;
@@ -642,7 +642,8 @@ void DBCMainEditor::deleteCurrentTreeItem()
     switch (typ)
     {
     case 1: //deleting a node cascades deletion down to messages and signals
-        node = dbcFile->findNodeByName(currItem->text(0));
+        columnText = currItem->text(0);
+        node = dbcFile->findNodeByNameAndComment(columnText);
         if (!node) return;
         for (int x = 0; x < dbcFile->messageHandler->getCount(); x++)
         {


### PR DESCRIPTION
These issues were very repeatable, the delete node issue would fail trying to remove any node that contained a comment and the delete message issue came from deleting messages that weren't last in the list and the code continuing to go through the list comparing message name to the deleted message name which was no longer allocated/valid.