### PR TITLE
Fix frames and filteredFrames from growing until out of memory

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -4,6 +4,7 @@
 #include <QApplication>
 #include <QPalette>
 #include <QDateTime>
+#include <QSettings>
 #include "utility.h"
 
 CANFrameModel::~CANFrameModel()
@@ -45,17 +46,20 @@ int CANFrameModel::columnCount(const QModelIndex &index) const
 CANFrameModel::CANFrameModel(QObject *parent)
     : QAbstractTableModel(parent)
 {
-
+    int maxFramesDefault;
     if (QSysInfo::WordSize > 32)
     {
         qDebug() << "64 bit OS detected. Requesting a large preallocation";
-        preallocSize = 10000000;
+        maxFramesDefault = 10000000;
     }
     else //if compiling for 32 bit you can't ask for gigabytes of preallocation so tone it down.
     {
         qDebug() << "32 bit OS detected. Requesting a much restricted prealloc";
-        preallocSize = 2000000;
+        maxFramesDefault = 2000000;
     }
+
+    QSettings settings;
+    int preallocSize = settings.value("Main/MaximumFrames", maxFramesDefault).toInt();
 
     frames.reserve(preallocSize);
     filteredFrames.reserve(preallocSize); //the goal is to prevent a reallocation from ever happening

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -49,7 +49,7 @@ CANFrameModel::CANFrameModel(QObject *parent)
     if (QSysInfo::WordSize > 32)
     {
         qDebug() << "64 bit OS detected. Requesting a large preallocation";
-        preallocSize = 10000; //000;
+        preallocSize = 10000000;
     }
     else //if compiling for 32 bit you can't ask for gigabytes of preallocation so tone it down.
     {
@@ -679,14 +679,6 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
         {
             try
             {
-                if(alloc_ok == false)
-                {
-                    qDebug() << "Trying to remove " << (frames.length() >> 3) << " from frames. Try #" << i ;
-                    frames.remove(0, frames.length() >> 3);
-                    qDebug() << "frames length now: " << (frames.length()) << "trying to alloc again" ;
-                    alloc_ok = true;
-                }
-
                 frames.append(tempFrame);
                 break;
             }
@@ -754,6 +746,20 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
 
 void CANFrameModel::addFrames(const CANConnection*, const QVector<CANFrame>& pFrames)
 {
+    if(frames.length() > frames.capacity() * 0.99)
+    {
+        qDebug() << "Frames count: " << frames.length() << " of " << frames.capacity() << " capacity, removing first " << frames.capacity() * 0.05 << " frames";
+        frames.remove(0, frames.capacity() * 0.05);
+        qDebug() << "Frames removed, new count: " << frames.length();
+    }
+
+    if(filteredFrames.length() > filteredFrames.capacity() * 0.99)
+    {
+        qDebug() << "filteredFrames count: " << filteredFrames.length() << " of " << filteredFrames.capacity() << " capacity, removing first " << filteredFrames.capacity() * 0.05 << " frames";
+        filteredFrames.remove(0, filteredFrames.capacity() * 0.05);
+        qDebug() << "filteredFrames removed, new count: " << filteredFrames.length();
+    }
+
     foreach(const CANFrame& frame, pFrames)
     {
         addFrame(frame);

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -59,7 +59,7 @@ CANFrameModel::CANFrameModel(QObject *parent)
     }
 
     QSettings settings;
-    int preallocSize = settings.value("Main/MaximumFrames", maxFramesDefault).toInt();
+    preallocSize = settings.value("Main/MaximumFrames", maxFramesDefault).toInt();
 
     frames.reserve(preallocSize);
     filteredFrames.reserve(preallocSize); //the goal is to prevent a reallocation from ever happening
@@ -752,15 +752,15 @@ void CANFrameModel::addFrames(const CANConnection*, const QVector<CANFrame>& pFr
 {
     if(frames.length() > frames.capacity() * 0.99)
     {
-        qDebug() << "Frames count: " << frames.length() << " of " << frames.capacity() << " capacity, removing first " << frames.capacity() * 0.05 << " frames";
-        frames.remove(0, frames.capacity() * 0.05);
+        qDebug() << "Frames count: " << frames.length() << " of " << frames.capacity() << " capacity, removing first " << (int)(frames.capacity() * 0.05) << " frames";
+        frames.remove(0, (int)(frames.capacity() * 0.05));
         qDebug() << "Frames removed, new count: " << frames.length();
     }
 
     if(filteredFrames.length() > filteredFrames.capacity() * 0.99)
     {
-        qDebug() << "filteredFrames count: " << filteredFrames.length() << " of " << filteredFrames.capacity() << " capacity, removing first " << filteredFrames.capacity() * 0.05 << " frames";
-        filteredFrames.remove(0, filteredFrames.capacity() * 0.05);
+        qDebug() << "filteredFrames count: " << filteredFrames.length() << " of " << filteredFrames.capacity() << " capacity, removing first " << (int)(filteredFrames.capacity() * 0.05) << " frames";
+        filteredFrames.remove(0, (int)(filteredFrames.capacity() * 0.05));
         qDebug() << "filteredFrames removed, new count: " << filteredFrames.length();
     }
 
@@ -790,8 +790,8 @@ void CANFrameModel::sendRefresh()
     mutex.lock();
     beginResetModel();
     filteredFrames.clear();
-    filteredFrames.reserve(preallocSize);
     filteredFrames.append(tempContainer);
+    filteredFrames.reserve(preallocSize);
 
     lastUpdateNumFrames = 0;
     endResetModel();

--- a/mainsettingsdialog.cpp
+++ b/mainsettingsdialog.cpp
@@ -90,6 +90,20 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     ui->cbFilterLabeling->setChecked(settings.value("Main/FilterLabeling", true).toBool());
     ui->cbIgnoreDBCColors->setChecked(settings.value("Main/IgnoreDBCColors", false).toBool());
 
+    int maxFramesDefault;
+    if (QSysInfo::WordSize > 32)
+    {
+        qDebug() << "64 bit OS detected. Requesting a large preallocation";
+        maxFramesDefault = 10000000;
+    }
+    else //if compiling for 32 bit you can't ask for gigabytes of preallocation so tone it down.
+    {
+        qDebug() << "32 bit OS detected. Requesting a much restricted prealloc";
+        maxFramesDefault = 2000000;
+    }
+
+    ui->spinMaximumFrames->setValue(settings.value("Main/MaximumFrames", maxFramesDefault).toInt());
+
     //just for simplicity they all call the same function and that function updates all settings at once
     connect(ui->cbDisplayHex, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbFlowAutoRef, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
@@ -117,6 +131,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     connect(ui->cbHexGraphFlow, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbHexGraphInfo, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbIgnoreDBCColors, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
+    connect(ui->spinMaximumFrames, SIGNAL(valueChanged(int)), this, SLOT(updateSettings()));
 
     installEventFilter(this);
 }
@@ -183,6 +198,7 @@ void MainSettingsDialog::updateSettings()
     settings.setValue("Remote/Pass", encPass);
     settings.setValue("Main/FilterLabeling", ui->cbFilterLabeling->isChecked());
     settings.setValue("Main/IgnoreDBCColors", ui->cbIgnoreDBCColors->isChecked());
+    settings.setValue("Main/MaximumFrames", ui->spinMaximumFrames->value());
 
     settings.sync();
     emit updatedSettings();

--- a/ui/mainsettingsdialog.ui
+++ b/ui/mainsettingsdialog.ui
@@ -81,6 +81,39 @@
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Maximum Frames to Capture</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="spinMaximumFrames">
+            <property name="minimum">
+             <number>100000</number>
+            </property>
+            <property name="maximum">
+             <number>1000000000</number>
+            </property>
+            <property name="singleStep">
+             <number>100000</number>
+            </property>
+            <property name="value">
+             <number>10000000</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QGroupBox" name="groupBox_6">
           <property name="title">
            <string>Time Keeping</string>


### PR DESCRIPTION
Made max # of frames an option in preferences, restart to take effect

Prevent bad_alloc crash by limiting size and capacity of frames and filteredFrames to the user selected size.  Can still crash if this number is set too large, but at least user has control now.

When 99% capacity is reached then remove the first 5% of items in the two vectors.  
This causes the mainWindow table view to automatically renumber the rows.
Size is checked and adjusted in addFrames is called.