### PR TITLE
Add node name to signal name in signal viewer

### DIFF
--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -898,7 +898,7 @@ void FrameSenderWindow::processCellChange(int line, int col)
         case 6: //Data bytes
             for (int i = 0; i < 8; i++) sendingData[line].payload().data()[i] = 0;
 
-            tokens = ui->tableSender->item(line, 6)->text().split(" ");
+            tokens = ui->tableSender->item(line, 6)->text().split(" ", QString::SkipEmptyParts);
             arr.clear();
             arr.reserve(tokens.count());
             for (int j = 0; j < tokens.count(); j++)

--- a/signalviewerwindow.cpp
+++ b/signalviewerwindow.cpp
@@ -105,6 +105,7 @@ void SignalViewerWindow::loadMessages()
     for (int f = 0; f < numFiles; f++)
     {
         qDebug() << dbcHandler->getFileByIdx(f)->messageHandler->getCount();
+
         for (int x = 0; x < dbcHandler->getFileByIdx(f)->messageHandler->getCount(); x++)
         {
             ui->cbMessages->addItem(dbcHandler->getFileByIdx(f)->messageHandler->findMsgByIdx(x)->name);
@@ -140,7 +141,7 @@ void SignalViewerWindow::addSignal()
 
     int rowIdx = ui->tableViewer->rowCount();
     ui->tableViewer->insertRow(rowIdx);
-    QTableWidgetItem *item = new QTableWidgetItem(sig->name);
+    QTableWidgetItem *item = new QTableWidgetItem(msg->sender->name + " - " + sig->name);
     ui->tableViewer->setItem(rowIdx, 0, item);
 
 }


### PR DESCRIPTION
With many signals it can get unclear which signals are related, so added node name to string in first column.

Could make this user selectable.  