### PR TITLE
replace QTime with QElapsedTimer when possible (qt6)

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -177,7 +177,7 @@ MainWindow::MainWindow(QWidget *parent) :
     updateTimer.setInterval(250);
     updateTimer.start();
 
-    elapsedTime = new QTime;
+    elapsedTime = new QElapsedTimer;
     elapsedTime->start();
 
     isConnected = false;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -137,7 +137,7 @@ private:
     DBCHandler *dbcHandler;
     QByteArray inputBuffer;
     QTimer updateTimer;
-    QTime *elapsedTime;
+    QElapsedTimer *elapsedTime;
     int framesPerSec;
     int rxFrames;
     bool inhibitFilterUpdate;

--- a/re/sniffer/snifferitem.h
+++ b/re/sniffer/snifferitem.h
@@ -2,7 +2,7 @@
 #define SNIFFERITEM_H
 
 #include <QVariant>
-#include <QTime>
+#include <QElapsedTimer>
 #include "can_structs.h"
 
 struct fstCan
@@ -50,7 +50,7 @@ private:
     quint64         mCurrentTime;
     quint64         mCurrSeqVal;
 
-    QTime           mTime;
+    QElapsedTimer   mTime;
 };
 
 #endif // SNIFFERITEM_H


### PR DESCRIPTION
Since Qt5, some methods of QTime [are deprecated](https://doc.qt.io/qt-5/qtime-obsolete.html).

Qt6 remove those methods, thus in two instances we need to use a [QElapsedTimer](https://doc.qt.io/qt-6/qelapsedtimer.html) instead of a QTime.

QElapsedTimer is available since Qt5.4, and is already used in the source code.