### PR TITLE
replace qrand/qsrand with QRandomGenerator (qt6)

### DIFF
--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -4,6 +4,9 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QSettings>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#include <QtCore/QRandomGenerator>
+#endif
 
 #include "connections/canconmanager.h"
 #include "helpwindow.h"
@@ -234,7 +237,13 @@ void ScriptingWindow::createNewScript()
 
     container = new ScriptContainer();
 
-    container->fileName = "UNNAMED_" + QString::number((qrand() % 10000)) + ".js";
+    QString randomPart;
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
+    randomPart = QString::number((qrand() % 10000));
+#else
+    randomPart = QString::number((QRandomGenerator::global()->bounded(10000)));
+#endif
+    container->fileName = "UNNAMED_" + randomPart + ".js";
     container->filePath = QString();
     container->scriptText = QString();
     container->setScriptWindow(this);

--- a/simplecrypt.cpp
+++ b/simplecrypt.cpp
@@ -31,6 +31,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDataStream>
+#include <QIODevice>
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+#include <QtCore/QRandomGenerator>
+#endif
 
 SimpleCrypt::SimpleCrypt():
     m_key(0),
@@ -38,7 +42,9 @@ SimpleCrypt::SimpleCrypt():
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
     qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
+#endif
 }
 
 SimpleCrypt::SimpleCrypt(quint64 key):
@@ -47,7 +53,9 @@ SimpleCrypt::SimpleCrypt(quint64 key):
     m_protectionMode(ProtectionChecksum),
     m_lastError(ErrorNoError)
 {
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
     qsrand(uint(QDateTime::currentMSecsSinceEpoch() & 0xFFFF));
+#endif
     splitKey();
 }
 
@@ -113,7 +121,11 @@ QByteArray SimpleCrypt::encryptToByteArray(QByteArray plaintext)
     }
 
     //prepend a random char to the string
+#if QT_VERSION < QT_VERSION_CHECK( 5, 10, 0 )
     char randomChar = char(qrand() & 0xFF);
+#else
+    char randomChar = char(QRandomGenerator::global()->bounded(256));
+#endif
     ba = randomChar + integrityProtection + ba;
 
     int pos(0);


### PR DESCRIPTION
Since Qt5, qrand/qsrand methods [are deprecated](https://doc.qt.io/qt-5/qtglobal-obsolete.html#qrand).

Qt6 remove those methods, thus we need to use instead a [QRandomGenerator](https://doc.qt.io/qt-6/qrandomgenerator.html).

QElapsedTimer is available since Qt5.10, and is already used in the source code.