### PR TITLE
remove qRegisterMetaTypeStreamOperators (qt6)

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -501,8 +501,10 @@ CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QS
 
 void ConnectionWindow::loadConnections()
 {
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
     qRegisterMetaTypeStreamOperators<CANBus>();
     qRegisterMetaTypeStreamOperators<QList<CANBus>>();
+#endif
 
     QSettings settings;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -30,8 +30,10 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
     qRegisterMetaTypeStreamOperators<QVector<QString>>();
     qRegisterMetaTypeStreamOperators<QVector<int>>();
+#endif
 
     useHex = true;
 


### PR DESCRIPTION
Since Qt6, some methods of [QMetaType are removed](https://doc.qt.io/qt-6/qtcore-changes-qt6.html#the-qmetatype-class).

We remove `qRegisterMetaTypeStreamOperators()` calls for Qt >= 6