### PR TITLE
replace BackgroundColorRole/TextColorRole with BackgroundRole/ForegroundRole (qt6)

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -408,7 +408,7 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
     const unsigned char *data = reinterpret_cast<const unsigned char *>(thisFrame.payload().constData());
     int dataLen = thisFrame.payload().count();
 
-    if (role == Qt::BackgroundColorRole)
+    if (role == Qt::BackgroundRole)
     {
         if (dbcHandler != nullptr && interpretFrames && !ignoreDBCColors)
         {
@@ -441,7 +441,7 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
         }
     }
 
-    if (role == Qt::TextColorRole)
+    if (role == Qt::ForegroundRole)
     {
         if (dbcHandler != nullptr && interpretFrames && !ignoreDBCColors)
         {


### PR DESCRIPTION
Since long time ago (12yrs), Qt::BackgroundColorRole/Qt::TextColorRole are aliased by Qt::BackgroundRole/Qt::ForegroundRole and raise a deprecation warning.

Qt6 remove those values, thus we need to use Qt::BackgroundRole/Qt::ForegroundRole.