### PR TITLE
replace QAtomicInt load()/store() with loadRelaxed()/storeRelaxed()

### DIFF
--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -245,11 +245,11 @@ CANCon::type CANConnection::getType() {
 
 
 CANCon::status CANConnection::getStatus() {
-    return (CANCon::status) mStatus.load();
+    return (CANCon::status) mStatus.loadRelaxed();
 }
 
 void CANConnection::setStatus(CANCon::status pStatus) {
-    mStatus.store(pStatus);
+    mStatus.storeRelaxed(pStatus);
 }
 
 bool CANConnection::isCapSuspended() {


### PR DESCRIPTION
Since Qt5, some methods of QAtomicInteger [are deprecated](https://doc.qt.io/qt-5/qatomicinteger-obsolete.html).

Qt6 remove those methods, thus we need to replace them.