### PR TITLE
replace `QString::SkipEmptyParts` with `Qt::SkipEmptyParts` (qt6)

### DIFF
--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -898,7 +898,11 @@ void FrameSenderWindow::processCellChange(int line, int col)
         case 6: //Data bytes
             for (int i = 0; i < 8; i++) sendingData[line].payload().data()[i] = 0;
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+            tokens = ui->tableSender->item(line, 6)->text().split(" ", Qt::SkipEmptyParts);
+#else
             tokens = ui->tableSender->item(line, 6)->text().split(" ", QString::SkipEmptyParts);
+#endif
             arr.clear();
             arr.reserve(tokens.count());
             for (int j = 0; j < tokens.count(); j++)


### PR DESCRIPTION
`QString::SkipEmptyParts` is [deprecated since around Qt5.14](https://doc.qt.io/qt-5/qstring-obsolete.html), and has been removed in Qt6.

We replace it with `Qt::SkipEmptyParts` for Qt >= 5.14