### PR TITLE
remove `QSerialPort` obsolete enum values (qt6)

### DIFF
--- a/connections/gvretserial.cpp
+++ b/connections/gvretserial.cpp
@@ -485,6 +485,7 @@ void GVRetSerial::serialError(QSerialPort::SerialPortError err)
         killConnection = true;
         piStop();
         break;
+#if QT_VERSION <= QT_VERSION_CHECK( 6, 0, 0 )
     case QSerialPort::ParityError:
         errMessage = "Parity error on serial port";
         break;
@@ -494,6 +495,7 @@ void GVRetSerial::serialError(QSerialPort::SerialPortError err)
     case QSerialPort::BreakConditionError:
         errMessage = "Break error on serial port";
         break;
+#endif
     case QSerialPort::WriteError:
         errMessage = "Write error on serial port";
         piStop();


### PR DESCRIPTION
Three enums (`QSerialPort::ParityError`, `QSerialPort::FramingError`, `QSerialPort::BreakConditionError`) are [deprecated since Qt5.6](https://doc.qt.io/qt-5/qserialport.html) and removed from Qt6.

We remove them, it's unfortunate but I don't know how to replace these - it seems that we need to handle those in an [OS-specific way](https://codereview.qt-project.org/c/qt/qtserialport/+/125517/).