### PR TITLE
Use enums from `Qt::ItemFlags`

### DIFF
--- a/re/sniffer/sniffermodel.cpp
+++ b/re/sniffer/sniffermodel.cpp
@@ -137,7 +137,7 @@ QVariant SnifferModel::data(const QModelIndex &index, int role) const
 Qt::ItemFlags SnifferModel::flags(const QModelIndex &index) const
 {
     if (!index.isValid())
-        return 0;
+        return Qt::NoItemFlags;
 
     return QAbstractItemModel::flags(index);
 }


### PR DESCRIPTION
It seems that on my compiler we need to use an explicit enum instead of the constant it represents.
It shouldn't cause any issue as the value is the same.