### PR TITLE
fix QMqtt ambiguous conversion

### DIFF
--- a/mqtt/qmqtt_client.h
+++ b/mqtt/qmqtt_client.h
@@ -129,7 +129,7 @@ class Q_MQTT_EXPORT Client : public QObject
     Q_PROPERTY(quint8 _willQos READ willQos WRITE setWillQos)
     Q_PROPERTY(bool _willRetain READ willRetain WRITE setWillRetain)
     Q_PROPERTY(QByteArray _willMessage READ willMessage WRITE setWillMessage)
-    Q_PROPERTY(QString _connectionState READ connectionState)
+    Q_PROPERTY(ConnectionState _connectionState READ connectionState)
 #ifndef QT_NO_SSL
     Q_PROPERTY(QSslConfiguration _sslConfiguration READ sslConfiguration WRITE setSslConfiguration)
 #endif // QT_NO_SSL


### PR DESCRIPTION
Prevent error:
```
moc_qmqtt_client.cpp:459:53: error: conversion from 'QMQTT::ConnectionState' to 'QChar' is ambiguous
```