### PR TITLE
fix some static cast errors in QMqtt

### DIFF
--- a/mqtt/qmqtt_socket.cpp
+++ b/mqtt/qmqtt_socket.cpp
@@ -41,9 +41,9 @@ QMQTT::Socket::Socket(QObject* parent)
     connect(_socket.data(), &QTcpSocket::connected,    this, &SocketInterface::connected);
     connect(_socket.data(), &QTcpSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
-            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),
+            SIGNAL(error(QTcpSocket::error)),
             this,
-            static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
+            SLOT(errorHandler(SocketInterface::error)));
 }
 
 QMQTT::Socket::~Socket()

--- a/mqtt/qmqtt_ssl_socket.cpp
+++ b/mqtt/qmqtt_ssl_socket.cpp
@@ -46,9 +46,9 @@ QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
     connect(_socket.data(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
     connect(_socket.data(), &QSslSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
-            static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::error),
+            SIGNAL(error(QSslSocket::error)),
             this,
-            static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
+            SLOT(errorHandler(SocketInterface::error)));
     connect(_socket.data(),
             static_cast<void (QSslSocket::*)(const QList<QSslError>&)>(&QSslSocket::sslErrors),
             this,


### PR DESCRIPTION
The following error occurs twice:
```
mqtt/qmqtt_ssl_socket.cpp:49:13: error: static_cast from 'QAbstractSocket::SocketError (QAbstractSocket::*)() const' to 'void (QSslSocket::*)(QAbstractSocket::SocketError)' is not allowed
```

It may not be the cleanest fix but the it is the only one I could come with...