### PR TITLE
fix ambiguous int to QChar conversion

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -2207,14 +2207,14 @@ DBCHandler::DBCHandler()
     qDebug() << "Previously loaded DBC file count: " << filecount;
     for (int i=0; i<filecount; i++)
     {
-        QString filename = settings.value("DBC/Filename_" + QString(i),"").toString();
+        QString filename = settings.value("DBC/Filename_" + QString::number(i),"").toString();
         DBCFile * file = loadDBCFile(filename);
         if (file)
         {
-            int bus = settings.value("DBC/AssocBus_" + QString(i),0).toInt();
+            int bus = settings.value("DBC/AssocBus_" + QString::number(i),0).toInt();
             file->setAssocBus(bus);
 
-            MatchingCriteria_t matchingCriteria = (MatchingCriteria_t)settings.value("DBC/MatchingCriteria_" + QString(i),0).toInt();
+            MatchingCriteria_t matchingCriteria = (MatchingCriteria_t)settings.value("DBC/MatchingCriteria_" + QString::number(i),0).toInt();
 
             DBC_ATTRIBUTE attr;
 
@@ -2228,7 +2228,7 @@ DBCHandler::DBCHandler()
             file->dbc_attributes.append(attr);
             file->messageHandler->setMatchingCriteria(matchingCriteria);
 
-            bool filterLabeling = settings.value("DBC/FilterLabeling_" + QString(i),0).toBool();
+            bool filterLabeling = settings.value("DBC/FilterLabeling_" + QString::number(i),0).toBool();
             attr.attrType = ATTR_TYPE_MESSAGE;
             attr.defaultValue = filterLabeling;
             attr.enumVals.clear();

--- a/dbc/dbcloadsavewindow.cpp
+++ b/dbc/dbcloadsavewindow.cpp
@@ -108,10 +108,10 @@ void DBCLoadSaveWindow::updateSettings()
             qDebug() << "Save DBC settings #" << i << " File: " << file->getFullFilename() 
                 << "Bus: " << file->getAssocBus() << "MC: " << file->messageHandler->getMatchingCriteria()
                 << "Filter Labeling: " << (file->messageHandler->filterLabeling() ? "enabled" : "disabled");
-            settings.setValue("DBC/Filename_" + QString(i), file->getFullFilename());
-            settings.setValue("DBC/AssocBus_" + QString(i), file->getAssocBus());
-            settings.setValue("DBC/MatchingCriteria_" + QString(i), file->messageHandler->getMatchingCriteria());            
-            settings.setValue("DBC/FilterLabeling_" + QString(i), file->messageHandler->filterLabeling());   
+            settings.setValue("DBC/Filename_" + QString::number(i), file->getFullFilename());
+            settings.setValue("DBC/AssocBus_" + QString::number(i), file->getAssocBus());
+            settings.setValue("DBC/MatchingCriteria_" + QString::number(i), file->messageHandler->getMatchingCriteria());
+            settings.setValue("DBC/FilterLabeling_" + QString::number(i), file->messageHandler->filterLabeling());
         }
     }
     emit updatedDBCSettings();


### PR DESCRIPTION
Error message:
```
dbc/dbcloadsavewindow.cpp:111:57: error: conversion from 'int' to 'QChar' is ambiguous
```