### PR TITLE
replace `QRegExp` with `QRegularExpression` (qt6)

### DIFF
--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -261,7 +261,7 @@ void SocketCANd::decodeFrames(QString data, int busNum)
         QString framePart = data.mid(data.indexOf("< frame "), data.length()); //remove starting beginning of payload if not < frame >
         const QString frameStrConst = framePart.left(framePart.indexOf(">")+1);
         QString frameStr = frameStrConst;
-        QStringList frameParsed = (frameStr.remove(QRegExp("^<")).remove(QRegExp(">$"))).simplified().split(' ');
+        QStringList frameParsed = (frameStr.remove(QRegularExpression("^<")).remove(QRegularExpression(">$"))).simplified().split(' ');
 
         if(frameParsed.length() < 2)
         {

--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -867,7 +867,7 @@ bool FrameFileIO::loadCARBUSAnalyzerFile(QString filename, QVector<CANFrame>* fr
         line = txt.readLine().simplified();
         if (line.length() > 2)
         {
-            QList<QString> tokens = line.split(QRegExp("\\s+"));
+            QList<QString> tokens = line.split(QRegularExpression("\\s+"));
             if (tokens.length() > 3)
             {
                 QString time = tokens[0].replace(",", "");
@@ -3477,9 +3477,9 @@ bool FrameFileIO::isCanDumpFile(QString filename)
     QFile *inFile = new QFile(filename);
     QByteArray line;
     QList<QByteArray> tokens;
-    QRegExp timeExp("^\\((\\S+)\\)$");
-    QRegExp IdValExp("^(\\S+)#(\\S+)$");
-    QRegExp valExp("(\\S{2})");
+    QRegularExpression timeExp(QRegularExpression::anchoredPattern("^\\((\\S+)\\)$"));
+    QRegularExpression IdValExp(QRegularExpression::anchoredPattern("^(\\S+)#(\\S+)$"));
+    QRegularExpression valExp("(\\S{2})");
     int lineCounter = 0;
     int pos = 0;
     bool isMatch = true;
@@ -3505,10 +3505,12 @@ bool FrameFileIO::isCanDumpFile(QString filename)
                 if(tokens.count() < 3) isMatch = false;
 
                 /* timestamp */
-                ret = timeExp.exactMatch(tokens[0]);
-                if(!ret) isMatch = false;
+                QRegularExpressionMatch timeExpMatched = timeExp.match(tokens[0]);
+                if(!timeExpMatched.hasMatch()) {
+                    isMatch = false;
+                }
 
-                /*uint64_t timestamp = (uint64_t)*/(timeExp.cap(1).toDouble(&ret) /** (double)1000000.0*/);
+                /*uint64_t timestamp = (uint64_t)*/(timeExpMatched.captured(1).toDouble(&ret) /** (double)1000000.0*/);
                 if(!ret) isMatch = false;
 
                 if (line.contains('[')) //the expanded format
@@ -3538,17 +3540,16 @@ bool FrameFileIO::isCanDumpFile(QString filename)
                         isMatch = false;
                         continue;
                     }
-                    ret = IdValExp.exactMatch(tokens[2]);
-                    if(!ret)
-                    {
+                    QRegularExpressionMatch IdValExpMatched = IdValExp.match(tokens[2]);
+                    if(!IdValExpMatched.hasMatch()) {
                         isMatch = false;
                         continue;
                     }
 
                     /* ID */
-                    /*int ID = */IdValExp.cap(1).toInt(&ret, 16);
+                    /*int ID = */IdValExpMatched.captured(1).toInt(&ret, 16);
 
-                    QString val= IdValExp.cap(2);
+                    QString val= IdValExpMatched.captured(2);
 
                     pos = 0;
                     int len = 0;
@@ -3562,22 +3563,22 @@ bool FrameFileIO::isCanDumpFile(QString filename)
                     } else {
                         /* val byte per byte */
                         int lng = 0;
-                        while ((pos = valExp.indexIn(val, pos)) != -1)
-                        {
+                        QRegularExpressionMatch valExpMatch;
+                        QRegularExpressionMatchIterator i = valExp.globalMatch(val);
+                        while (i.hasNext()) {
+                            valExpMatch = i.next();
                             lng++;
                             if (lng > 8)
                             {
                                 isMatch = false;
                                 break;
                             }
-                            /*int data = */valExp.cap(1).toInt(&ret, 16);
+                            /*int data = */valExpMatch.captured(1).toInt(&ret, 16);
                             if(!ret)
                             {
                                 isMatch = false;
                                 break;
                             }
-
-                            pos += valExp.matchedLength();
                         }
                     }
                 }
@@ -3604,9 +3605,9 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
     CANFrame thisFrame;
     QByteArray line;
     QList<QByteArray> tokens;
-    QRegExp timeExp("^\\((\\S+)\\)$");
-    QRegExp IdValExp("^(\\S+)#(\\S+)$");
-    QRegExp valExp("(\\S{2})");
+    QRegularExpression timeExp(QRegularExpression::anchoredPattern("^\\((\\S+)\\)$"));
+    QRegularExpression IdValExp(QRegularExpression::anchoredPattern("^(\\S+)#(\\S+)$"));
+    QRegularExpression valExp("(\\S{2})");
     int lineCounter = 0;
     int pos = 0;
     bool ret;
@@ -3634,8 +3635,10 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
             if(tokens.count()<3) continue;
 
             /* timestamp */
-            ret = timeExp.exactMatch(tokens[0]);
-            if(!ret) continue;
+            QRegularExpressionMatch timeExpMatched = timeExp.match(tokens[0]);
+            if(!timeExpMatched.hasMatch()) {
+                continue;
+            }
             
             //Sort out the bus
             std::string busString = tokens[1].toStdString();
@@ -3656,7 +3659,7 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
             
             thisFrame.bus = busNum;
             
-            thisFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, (uint64_t)(timeExp.cap(1).toDouble(&ret) * (double)1000000.0)));
+            thisFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, (uint64_t)(timeExpMatched.captured(1).toDouble(&ret) * (double)1000000.0)));
             if(!ret) continue;
 
             if (line.contains('[')) //the expanded format (second one from the above list)
@@ -3679,22 +3682,21 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
             {
                 /* ID & value */
                 //qDebug() << tokens[2];
-                ret = IdValExp.exactMatch(tokens[2]);
-                if(!ret)
-                {
+                QRegularExpressionMatch IdValExpMatched = IdValExp.match(tokens[2]);
+                if(!IdValExpMatched.hasMatch()) {
                     qDebug() << "ID regex didn't match!";
                     continue;
                 }
 
                 /* ID */
-                thisFrame.setFrameId(static_cast<uint32_t>(IdValExp.cap(1).toInt(&ret, 16)));
-                if (IdValExp.cap(1).length() > 3) {
+                thisFrame.setFrameId(static_cast<uint32_t>(IdValExpMatched.captured(1).toInt(&ret, 16)));
+                if (IdValExpMatched.captured(1).length() > 3) {
                     thisFrame.setExtendedFrameFormat(true);
                 } else {
                     thisFrame.setExtendedFrameFormat(false);
                 }
 
-                QString val= IdValExp.cap(2);
+                QString val= IdValExpMatched.captured(2);
 
                 pos = 0;
                 QByteArray bytes;
@@ -3704,12 +3706,12 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
                 } else {
                     thisFrame.setFrameType(QCanBusFrame::DataFrame);
                     /* val byte per byte */
-                    while ((pos = valExp.indexIn(val, pos)) != -1)
-                    {
-                        bytes.append((char)valExp.cap(1).toInt(&ret, 16));
+                    QRegularExpressionMatch valExpMatch;
+                    QRegularExpressionMatchIterator i = valExp.globalMatch(val);
+                    while (i.hasNext()) {
+                        valExpMatch = i.next();
+                        bytes.append((char)valExpMatch.captured(1).toInt(&ret, 16));
                         if(!ret) continue;
-
-                        pos += valExp.matchedLength();
                     }
                 }
                 thisFrame.setPayload(bytes);


### PR DESCRIPTION
`QRegExp` has been retired in Qt6 (Not removed, but moved to Qt5Compat).

I decided to nevertheless "port" the `QRegExp` to `QRegularExpression` - which is however a risky move - Multiple checks are needed.