### PR TITLE
remove obsolete `QWheelEvent::delta()` (qt6)

### DIFF
--- a/jsedit.cpp
+++ b/jsedit.cpp
@@ -931,7 +931,8 @@ void JSEdit::resizeEvent(QResizeEvent *e)
 void JSEdit::wheelEvent(QWheelEvent *e)
 {
     if (e->modifiers() == Qt::ControlModifier) {
-        int steps = e->delta() / 20;
+        QPoint numDegrees = e->angleDelta();
+        int steps = numDegrees.y() / 20;
         steps = qBound(-3, steps, 3);
         QFont textFont = font();
         int pointSize = textFont.pointSize() + steps;


### PR DESCRIPTION
The function `QWheelEvent::delta()` is [deprecated in Qt5](https://doc.qt.io/qt-5/qwheelevent-obsolete.html#delta), and has been removed in Qt6.

We port it to `QWheelEvent::angleDelta()`.