### PR TITLE
fix comparison with string literal

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -108,15 +108,15 @@ void ConnectionWindow::readPendingDatagrams()
         while(!CANBeaconXml.atEnd() && !CANBeaconXml.hasError())
         {
           CANBeaconXml.readNext();
-          if(CANBeaconXml.name() == "CANBeacon" && !CANBeaconXml.isEndElement())
+          if(CANBeaconXml.name() == QString("CANBeacon") && !CANBeaconXml.isEndElement())
                 KayakHost.append(CANBeaconXml.attributes().value("name"));
 
-          if(CANBeaconXml.name() == "URL")
+          if(CANBeaconXml.name() == QString("URL"))
                 KayakHost.append(" (" + CANBeaconXml.readElementText() + ')');
 
           //Kayak can theoretically send multiple busses over one ports
           //TODO: implement this case in socketcand.cpp
-          if(CANBeaconXml.name() == "Bus" && !CANBeaconXml.isEndElement())
+          if(CANBeaconXml.name() == QString("Bus") && !CANBeaconXml.isEndElement())
                 KayakBus.append(CANBeaconXml.attributes().value("name") + ",");
 
         }


### PR DESCRIPTION
Error message:
```
connections/connectionwindow.cpp:111:34: warning: result of comparison against a string literal is unspecified (use an explicit string comparison function instead) [-Wstring-compare]
          if(CANBeaconXml.name() == "CANBeacon" && !CANBeaconXml.isEndElement())
                                 ^  ~~~~~~~~~~~
connections/connectionwindow.cpp:111:34: error: invalid operands to binary expression ('QStringView' and 'const char [10]')
          if(CANBeaconXml.name() == "CANBeacon" && !CANBeaconXml.isEndElement())
```