### PR TITLE
fix concatenation between a `QStringView` and a `const char [2]`

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -117,7 +117,7 @@ void ConnectionWindow::readPendingDatagrams()
           //Kayak can theoretically send multiple busses over one ports
           //TODO: implement this case in socketcand.cpp
           if(CANBeaconXml.name() == "Bus" && !CANBeaconXml.isEndElement())
-                KayakBus.append(CANBeaconXml.attributes().value("name") + ",");
+                KayakBus.append(CANBeaconXml.attributes().value("name").toUtf8() + ",");
 
         }
         KayakHost = KayakBus.left(KayakBus.length() - 1) + "@" + KayakHost;


### PR DESCRIPTION
Error Message:
```
connections/connectionwindow.cpp:120:73: error: invalid operands to binary expression ('QStringView' and 'const char [2]')
                KayakBus.append(CANBeaconXml.attributes().value("name") + ",");
                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~
```