### PR TITLE
force the type to a `std::min` comparison

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -264,7 +264,7 @@ uint64_t CANFrameModel::getCANFrameVal(int row, Column col)
         return static_cast<uint64_t>(frame.payload().length());
     case Column::ASCII: //sort both the same for now
     case Column::Data:
-        for (int i = 0; i < std::min(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
+        for (int i = 0; i < std::min<uint64_t>(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
         //qDebug() << temp;
         return temp;
     case Column::NUM_COLUMN:


### PR DESCRIPTION
Error message:
```
canframemodel.cpp:267:29: error: no matching function for call to 'min'
        for (int i = 0; i < std::min(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
```