### PR TITLE
take care of obsolete `QSet::toList()` (qt6)

### DIFF
--- a/jsedit.cpp
+++ b/jsedit.cpp
@@ -481,12 +481,12 @@ void JSHighlighter::mark(const QString &str, Qt::CaseSensitivity caseSensitivity
 
 QStringList JSHighlighter::keywords() const
 {
-    return m_keywords.toList();
+    return m_keywords.values();
 }
 
 void JSHighlighter::setKeywords(const QStringList &keywords)
 {
-    m_keywords = QSet<QString>::fromList(keywords);
+    m_keywords = QSet<QString>(keywords.begin(), keywords.end());
     rehighlight();
 }
 


### PR DESCRIPTION
`QSet::toList()` is [obsolete in Qt5](https://doc.qt.io/qt-5/qset-obsolete.html#toList) and has been removed in Qt6.

We replace it with the suggested replacement.