### PR TITLE
Added support for CAN FD frames to the SERIALBUS

### DIFF
--- a/connections/canbus.cpp
+++ b/connections/canbus.cpp
@@ -8,6 +8,7 @@ CANBus::CANBus()
     listenOnly  = false;
     singleWire  = false;
     active      = false;
+    canFD       = false;
 }
 
 
@@ -15,14 +16,16 @@ CANBus::CANBus(const CANBus& pBus) :
     speed(pBus.speed),
     listenOnly(pBus.listenOnly),
     singleWire(pBus.singleWire),
-    active(pBus.active) {}
+    active(pBus.active),
+    canFD(pBus.canFD) {}
 
 
 bool CANBus::operator==(const CANBus& bus) const{
     return  speed == bus.speed &&
             listenOnly == bus.listenOnly &&
             singleWire == bus.singleWire &&
-            active == bus.active;
+            active == bus.active &&
+            canFD == bus.canFD;
 }
 
 void CANBus::setSpeed(int newSpeed){
@@ -45,6 +48,11 @@ void CANBus::setActive(bool mode){
     active = mode;
 }
 
+void CANBus::setCanFD(bool mode){
+    //qDebug() << "CANBUS setCanFD = " << mode;
+    canFD = mode;
+}
+
 int CANBus::getSpeed(){
     return speed;
 }
@@ -59,6 +67,10 @@ bool CANBus::isSingleWire(){
 
 bool CANBus::isActive(){
     return active;
+}
+
+bool CANBus::isCanFD(){
+    return canFD;
 }
 
 

--- a/connections/canbus.h
+++ b/connections/canbus.h
@@ -16,16 +16,18 @@ public:
     bool listenOnly;
     bool singleWire;
     bool active; //is this bus turned on?
-
+    bool canFD;
 
     void setSpeed(int); // new speed
     void setListenOnly(bool); //bool for whether to only listen
     void setSingleWire(bool); //bool for whether to use single wire mode
     void setActive(bool); //whether this bus should be enabled or not.
+    void setCanFD(bool); // enable or disable CANFD support
     int getSpeed();
     bool isListenOnly();
     bool isSingleWire();
     bool isActive();
+    bool isCanFD();
 };
 
 QDataStream& operator<<( QDataStream & pStream, const CANBus& pCanBus );

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -365,6 +365,7 @@ void ConnectionWindow::saveBusSettings()
         bus.setSpeed(ui->cbBusSpeed->currentText().toInt());
         bus.setActive(ui->ckEnable->isChecked());
         bus.setListenOnly(ui->ckListenOnly->isChecked());
+        bus.setCanFD(ui->canFDEnable->isChecked());
         conn_p->setBusSettings(offset, bus);
     }
 }
@@ -381,7 +382,8 @@ void ConnectionWindow::populateBusDetails(int offset)
     {
         //bool ret;
         //int numBuses;
-
+        ui->canFDEnable->setVisible(false);
+        ui->canFDEnable_label->setVisible(false);
         CANConnection* conn_p = connModel->getAtIdx(selIdx);
         CANBus bus;
         if(!conn_p) return;
@@ -396,6 +398,12 @@ void ConnectionWindow::populateBusDetails(int offset)
         //ui->lblBusNum->setText(QString::number(busBase + offset));
         ui->ckListenOnly->setChecked(bus.isListenOnly());
         ui->ckEnable->setChecked(bus.isActive());
+        if (conn_p->getType() == CANCon::type::SERIALBUS)
+        {
+            ui->canFDEnable->setVisible(true);
+            ui->canFDEnable_label->setVisible(true);
+            ui->canFDEnable->setChecked(bus.isCanFD());
+        }
 
         bool found = false;
         for (int i = 0; i < ui->cbBusSpeed->count(); i++)

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -47,6 +47,7 @@ void SerialBusConnection::piStarted()
     mTimer.setSingleShot(false); //keep ticking
     mTimer.start();
     mBusData[0].mBus.setActive(true);
+    mBusData[0].mBus.setCanFD(false);
     mBusData[0].mConfigured = true;
 }
 
@@ -103,6 +104,7 @@ void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
     //You cannot set the speed of a socketcan interface, it has to be set with console commands.
     //But, you can probabaly set the speed of many of the other serialbus devices so go ahead and try
     mDev_p->setConfigurationParameter(QCanBusDevice::BitRateKey, bus.speed);
+    mDev_p->setConfigurationParameter(QCanBusDevice::CanFdKey, bus.canFD);
 
     /* connect device */
     if (!mDev_p->connectDevice()) {

--- a/ui/connectionwindow.ui
+++ b/ui/connectionwindow.ui
@@ -65,9 +65,6 @@
        </property>
        <layout class="QVBoxLayout" name="qhBox20">
         <item>
-         <widget class="QTabBar" name="tabBuses" native="true"/>
-        </item>
-        <item>
          <layout class="QFormLayout" name="formLayout_2">
           <item row="0" column="0">
            <widget class="QLabel" name="label_10">
@@ -107,14 +104,27 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QPushButton" name="btnSaveBus">
             <property name="text">
              <string>Save Bus Settings</string>
             </property>
            </widget>
           </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="canFDEnable"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="canFDEnable_label">
+            <property name="text">
+             <string>Enable CAN FD:</string>
+            </property>
+           </widget>
+          </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QTabBar" name="tabBuses" native="true"/>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
Added support for CAN FD frames to the SERIALBUS.
Now CAN FD frames will be displayed.
Example to check:
`❯ cansend vcan0 123##3112233445566778899aabbccddeeff`