### PR TITLE
Add mainmenu option to export decoded data as csv

### DIFF
--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -326,8 +326,8 @@ QString SocketCANd::decodeFrames(QString data, int busNum)
             getQueue().queue();
         }
     }
-    else
-        qDebug() << "can't get a frame, capture suspended";
+    //else
+    //    qDebug() << "can't get a frame, capture suspended";
 
     //take out the data that we just processed and anything that is in front of it
     //this should keep broken frames from accumulating at in the data buffer

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -119,6 +119,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionFuzzy_Scope, &QAction::triggered, this, &MainWindow::showFuzzyScopeWindow);
     connect(ui->actionRange_State_2, &QAction::triggered, this, &MainWindow::showRangeWindow);
     connect(ui->actionSave_Decoded_Frames, &QAction::triggered, this, &MainWindow::handleSaveDecoded);
+    connect(ui->actionSave_Decoded_Frames_CSV, &QAction::triggered, this, &MainWindow::handleSaveDecodedCsv);
     connect(ui->actionSingle_Multi_State_2, &QAction::triggered, this, &MainWindow::showSingleMultiWindow);
     connect(ui->actionFile_Comparison, &QAction::triggered, this, &MainWindow::showComparisonWindow);
     connect(ui->actionDBC_Comparison, &QAction::triggered, this, &MainWindow::showDBCComparisonWindow);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -989,6 +989,16 @@ void MainWindow::handleLoadFilters()
 
 void MainWindow::handleSaveDecoded()
 {
+    handleSaveDecodedMethod(false);
+}
+
+void MainWindow::handleSaveDecodedCsv()
+{
+    handleSaveDecodedMethod(true);
+}
+
+void MainWindow::handleSaveDecodedMethod(bool csv)
+{
     QString filename;
     QFileDialog dialog(this);
     QSettings settings;
@@ -1006,8 +1016,12 @@ void MainWindow::handleSaveDecoded()
     {
         filename = dialog.selectedFiles()[0];
         if (!filename.contains('.')) filename += ".txt";
-        //saveDecodedTextFile(filename);
-        saveDecodedTextFileAsColumns(filename);
+
+        if(csv)
+            saveDecodedTextFileAsColumns(filename);
+        else
+            saveDecodedTextFile(filename);
+
         settings.setValue("FileIO/LoadSaveDirectory", dialog.directory().path());
     }
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -196,6 +196,7 @@ private:
     QString getSignalNameFromPosition(QPoint pos);
     uint32_t getMessageIDFromPosition(QPoint pos);
     void saveDecodedTextFile(QString);
+    void saveDecodedTextFileAsColumns(QString);
     void addFrameToDisplay(CANFrame &, bool);
     void updateFileStatus();
     void closeEvent(QCloseEvent *event);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -91,6 +91,7 @@ private slots:
     void showDBCComparisonWindow();
     void exitApp();
     void handleSaveDecoded();
+    void handleSaveDecodedCsv();
     void connectionStatusUpdated(int conns);
     void gridClicked(QModelIndex);
     void gridDoubleClicked(QModelIndex);
@@ -195,6 +196,7 @@ private:
     //private methods
     QString getSignalNameFromPosition(QPoint pos);
     uint32_t getMessageIDFromPosition(QPoint pos);
+    void handleSaveDecodedMethod(bool csv);
     void saveDecodedTextFile(QString);
     void saveDecodedTextFileAsColumns(QString);
     void addFrameToDisplay(CANFrame &, bool);

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -136,7 +136,7 @@ void GraphingWindow::changeEvent(QEvent *event)
         }
         else
         {
-            setWindowOpacity(0.25);
+            //setWindowOpacity(0.25);
             // widget is now inactive
             qDebug() << "Hide";
         }
@@ -199,7 +199,7 @@ void GraphingWindow::updatedFrames(int numFrames)
         ui->graphingView->replot(); //now, redisplay them all
     }
     else //just got some new frames. See if they are relevant.
-    {
+    {  
         if (numFrames > modelFrames->count()) return;
 
         for (int j = 0; j < graphParams.count(); j++)

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -368,7 +368,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_RE_Tools">
@@ -415,6 +415,7 @@
     <addaction name="separator"/>
     <addaction name="actionDBC_File_Manager"/>
     <addaction name="actionSave_Decoded_Frames"/>
+    <addaction name="actionSave_Decoded_Frames_CSV"/>
     <addaction name="separator"/>
     <addaction name="actionPreferences"/>
     <addaction name="separator"/>
@@ -613,6 +614,11 @@
   <action name="actionDBC_Comparison">
    <property name="text">
     <string>DBC Comparison</string>
+   </property>
+  </action>
+  <action name="actionSave_Decoded_Frames_CSV">
+   <property name="text">
+    <string>Save Decoded Frames CSV</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
More standard way of looking at parsed data

Handles multiple message types. Each message gets its own columns.
With many message types there are a lot of blank cells but its easy to
analyze.