### PR TITLE
Fix custom frame sender crashing

### DIFF
--- a/canframemodel.h
+++ b/canframemodel.h
@@ -78,7 +78,7 @@ signals:
 private:
     void qSortCANFrameAsc(QVector<CANFrame>* frames, Column column, int lowerBound, int upperBound);
     void qSortCANFrameDesc(QVector<CANFrame>* frames, Column column, int lowerBound, int upperBound);
-    uint64_t getCANFrameVal(int row, Column col);
+    uint64_t getCANFrameVal(QVector<CANFrame> *frames, int row, Column col);
     bool any_filters_are_configured(void);
     bool any_busfilters_are_configured(void);
 

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -228,10 +228,44 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
                 workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, mElapsedTimer.nsecsElapsed() / 1000));
                 //workingFrame.timestamp -= mTimestampBasis;
             }
-            txFrame = conn->getQueue().get();
+            //txFrame = conn->getQueue().get();
             QCoreApplication::processEvents();
-            *txFrame = workingFrame;
-            conn->getQueue().queue();
+            //*txFrame = workingFrame;
+            //conn->getQueue().queue();
+
+
+
+            //copy pframe so the stack can be used while we send, prevents needing BlockingQueuedConnection
+//            CANFrame frameCopy;
+//            frameCopy.bus = workingFrame.bus;
+//            //cFrame.timedelta
+
+//            /////////////////////////////////////////////
+//            QByteArray copiedData;
+//            for(int i=0; i<workingFrame.payload().length(); i++)
+//                copiedData.append(workingFrame.payload()[i]);
+//            frameCopy.setPayload(copiedData);
+//            //frameCopy.setPayload(pFrame.payload());
+//            frameCopy.bus = workingFrame.bus;
+//            if (workingFrame.frameType() == workingFrame.ErrorFrame)
+//            {
+//                frameCopy.setExtendedFrameFormat(workingFrame.hasExtendedFrameFormat());
+//                frameCopy.setFrameId(workingFrame.frameId() + 0x20000000ull);
+//                frameCopy.isReceived = true;
+//            }
+//            else
+//            {
+//                frameCopy.setExtendedFrameFormat(workingFrame.hasExtendedFrameFormat());
+//                frameCopy.setFrameId(workingFrame.frameId());
+//            }
+//            frameCopy.setTimeStamp(workingFrame.timeStamp());
+//            frameCopy.setFrameType(workingFrame.frameType());
+//            frameCopy.setError(workingFrame.error());
+//                ///* If recorded frame has a local echo, it is a Tx message, and thus should not be marked as Rx */
+//            frameCopy.isReceived = workingFrame.isReceived;
+            ////////////////////////////////////////////
+
+
             return conn->sendFrame(workingFrame);
         }
         busBase += conn->getNumBuses();

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -204,7 +204,6 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
 {
     int busBase = 0;
     CANFrame workingFrame = pFrame;
-    CANFrame *txFrame;
 
     if (mConns.count() == 0)
     {
@@ -228,45 +227,6 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
                 workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, mElapsedTimer.nsecsElapsed() / 1000));
                 //workingFrame.timestamp -= mTimestampBasis;
             }
-
-
-
-
-//            CANFrame frameCopy;
-//            frameCopy.bus = workingFrame.bus;
-//            //cFrame.timedelta
-
-//            /////////////////////////////////////////////
-//            QByteArray copiedData;
-//            for(int i=0; i<workingFrame.payload().length(); i++)
-//                copiedData.append(workingFrame.payload()[i]);
-//            frameCopy.setPayload(copiedData);
-//            //frameCopy.setPayload(pFrame.payload());
-//            frameCopy.bus = workingFrame.bus;
-//            if (workingFrame.frameType() == workingFrame.ErrorFrame)
-//            {
-//                frameCopy.setExtendedFrameFormat(workingFrame.hasExtendedFrameFormat());
-//                frameCopy.setFrameId(workingFrame.frameId() + 0x20000000ull);
-//                frameCopy.isReceived = true;
-//            }
-//            else
-//            {
-//                frameCopy.setExtendedFrameFormat(workingFrame.hasExtendedFrameFormat());
-//                frameCopy.setFrameId(workingFrame.frameId());
-//            }
-//            frameCopy.setTimeStamp(workingFrame.timeStamp());
-//            frameCopy.setFrameType(workingFrame.frameType());
-//            frameCopy.setError(workingFrame.error());
-//                ///* If recorded frame has a local echo, it is a Tx message, and thus should not be marked as Rx */
-//            frameCopy.isReceived = workingFrame.isReceived;
-//            ////////////////////////////////////////////
-
-
-//            txFrame = conn->getQueue().get();
-//            QCoreApplication::processEvents();
-//            *txFrame = frameCopy;  //workingFrame
-//            conn->getQueue().queue();
-
 
             return conn->sendFrame(workingFrame);
         }

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -228,14 +228,10 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
                 workingFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, mElapsedTimer.nsecsElapsed() / 1000));
                 //workingFrame.timestamp -= mTimestampBasis;
             }
-            //txFrame = conn->getQueue().get();
-            QCoreApplication::processEvents();
-            //*txFrame = workingFrame;
-            //conn->getQueue().queue();
 
 
 
-            //copy pframe so the stack can be used while we send, prevents needing BlockingQueuedConnection
+
 //            CANFrame frameCopy;
 //            frameCopy.bus = workingFrame.bus;
 //            //cFrame.timedelta
@@ -263,7 +259,13 @@ bool CANConManager::sendFrame(const CANFrame& pFrame)
 //            frameCopy.setError(workingFrame.error());
 //                ///* If recorded frame has a local echo, it is a Tx message, and thus should not be marked as Rx */
 //            frameCopy.isReceived = workingFrame.isReceived;
-            ////////////////////////////////////////////
+//            ////////////////////////////////////////////
+
+
+//            txFrame = conn->getQueue().get();
+//            QCoreApplication::processEvents();
+//            *txFrame = frameCopy;  //workingFrame
+//            conn->getQueue().queue();
 
 
             return conn->sendFrame(workingFrame);

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -173,6 +173,8 @@ bool CANConnection::sendFrame(const CANFrame& pFrame)
         return ret;
     }
 
+
+
     return piSendFrame(pFrame);
 }
 

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -173,7 +173,10 @@ bool CANConnection::sendFrame(const CANFrame& pFrame)
         return ret;
     }
 
-
+    CANFrame *txFrame;
+    txFrame = getQueue().get();
+    *txFrame = pFrame;
+    getQueue().queue();
 
     return piSendFrame(pFrame);
 }

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -418,13 +418,11 @@ void ConnectionWindow::currentTabChanged(int newIdx)
 
 void ConnectionWindow::currentRowChanged(const QModelIndex &current, const QModelIndex &previous)
 {
-    Q_UNUSED(previous);
-
     int selIdx = current.row();
-
-    disconnect(connModel->getAtIdx(previous.row()), SIGNAL(debugOutput(QString)), nullptr, nullptr);
+    CANConnection* prevConn = connModel->getAtIdx(previous.row());
+    if(prevConn != nullptr)
+        disconnect(prevConn, SIGNAL(debugOutput(QString)), nullptr, nullptr);
     disconnect(this, SIGNAL(sendDebugData(QByteArray)), nullptr, nullptr);
-
 
     /* set parameters */
     if (selIdx == -1) {

--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -64,7 +64,7 @@ void SocketCANd::sendBytesToTCP(const QByteArray &bytes, int busNum)
         byt = (unsigned char)byt;
         buildDebug = buildDebug % QString::number(byt, 16) % " ";
     }
-    sendDebug(buildDebug);
+    //sendDebug(buildDebug);
 
     if (tcpClient[busNum]) tcpClient[busNum]->write(bytes);
 }
@@ -77,9 +77,9 @@ void SocketCANd::sendStringToTCP(const char* data, int busNum)
         return;
     }
 
-    QString buildDebug;
-    buildDebug = "Send data to " + hostIP.toString() + ":" + QString::number(hostPort) + " -> " + data;
-    sendDebug(buildDebug);
+    //QString buildDebug;
+    //buildDebug = "Send data to " + hostIP.toString() + ":" + QString::number(hostPort) + " -> " + data;
+    //sendDebug(buildDebug);
     //qInfo() << buildDebug;
 
     if (tcpClient[busNum]) tcpClient[busNum]->write(data);
@@ -300,6 +300,8 @@ QString SocketCANd::decodeFrames(QString data, int busNum)
 
     int framelength = frameParsed[3].length() * 0.5;
 
+
+    QByteArray buildData;
     buildData.resize(framelength);
 
     int c;
@@ -371,14 +373,14 @@ void SocketCANd::invokeReadTCPData()
 
 void SocketCANd::readTCPData(int busNum)
 {
-    QByteArray data;
+    QString data;
 
-    if (tcpClient[busNum]) data = tcpClient[busNum]->readAll();
+    if (tcpClient[busNum])
+        data = QString(tcpClient[busNum]->readAll());
     //sendDebug("Got data from TCP. Len = " % QString::number(data.length()));
     //qDebug() << "Received datagramm: " << data;
     procRXData(data, busNum);
 }
-
 
 void SocketCANd::procRXData(QString data, int busNum)
 {

--- a/connections/socketcand.h
+++ b/connections/socketcand.h
@@ -73,7 +73,6 @@ protected:
     int hostPort;
     QList<QString> hostCanIDs;
     int framesRapid;
-    QByteArray buildData;
     QVarLengthArray<MODE> rx_state;
     CANFrame buildFrame;
     QVarLengthArray<QString> unprocessedData;

--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -821,12 +821,13 @@ void FrameSenderWindow::updateGridRow(int idx)
 
     if (item == nullptr)
     {
-        //item = new QTableWidgetItem();
-        //item->setText(QString::number(temp->count));  //crashes here  ---qt_Static_metacall -> handleTick ->here
+        item = new QTableWidgetItem();
+        item->setText(QString::number(temp->count));
+        ui->tableSender->setItem(gridLine, 9, item);
     }
     else
     {
-        item->setText(QString::number(temp->count));  //crashes here  ---qt_Static_metacall -> handleTick ->here
+        item->setText(QString::number(temp->count));
     }
 
     if (temp->frameType() != QCanBusFrame::RemoteRequestFrame)

--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -32,13 +32,13 @@ FrameSenderWindow::FrameSenderWindow(const QVector<CANFrame> *frames, QWidget *p
     createBlankRow();
 
     connect(ui->tableSender, SIGNAL(cellChanged(int,int)), this, SLOT(onCellChanged(int,int)));
-    connect(intervalTimer, SIGNAL(timeout()), this, SLOT(handleTick()));
+    connect(intervalTimer, SIGNAL(timeout()), this, SLOT(handleTick()), Qt::QueuedConnection);
     connect(ui->btnClearGrid, SIGNAL(clicked(bool)), this, SLOT(clearGrid()));
     connect(ui->btnDisableAll, SIGNAL(clicked(bool)), this, SLOT(disableAll()));
     connect(ui->btnEnableAll, SIGNAL(clicked(bool)), this, SLOT(enableAll()));
     connect(ui->btnLoadGrid, SIGNAL(clicked(bool)), this, SLOT(loadGrid()));
     connect(ui->btnSaveGrid, SIGNAL(clicked(bool)), this, SLOT(saveGrid()));
-    connect(MainWindow::getReference(), SIGNAL(framesUpdated(int)), this, SLOT(updatedFrames(int)));
+    connect(MainWindow::getReference(), SIGNAL(framesUpdated(int)), this, SLOT(updatedFrames(int)), Qt::QueuedConnection);
 
     intervalTimer->start();
     elapsedTimer.start();
@@ -181,8 +181,8 @@ void FrameSenderWindow::processIncomingFrame(CANFrame *frame)
         for (int trig = 0; trig < sendingData[sd].triggers.count(); trig++)
         {
             Trigger *thisTrigger = &sendingData[sd].triggers[trig];
-            qDebug() << "Trigger ID: " << thisTrigger->ID;
-            qDebug() << "Frame ID: " << frame->frameId();
+            //qDebug() << "Trigger ID: " << thisTrigger->ID;
+            //qDebug() << "Frame ID: " << frame->frameId();
             if (thisTrigger->ID > 0 && (uint32_t)thisTrigger->ID == frame->frameId())
             {
                 if (thisTrigger->bus == frame->bus || thisTrigger->bus == -1)
@@ -195,7 +195,7 @@ void FrameSenderWindow::processIncomingFrame(CANFrame *frame)
                             sendingData[sd].count++;
                             doModifiers(sd);
                             updateGridRow(sd);
-                            CANConManager::getInstance()->sendFrame(sendingData[sd]);
+                            CANConManager::getInstance()->sendFrame(CANFrame(sendingData[sd]));
                         }
                         else //delayed sending frame
                         {
@@ -289,6 +289,8 @@ void FrameSenderWindow::loadGrid()
             settings.setValue("FrameSender/LoadSaveDirectory", dialog.directory().path());
         }
     }
+
+    createBlankRow();
 
     setupGrid();
 }
@@ -424,44 +426,54 @@ void FrameSenderWindow::handleTick()
 {
     FrameSendData *sendData;
     Trigger *trigger;
-    int elapsed = elapsedTimer.restart();
-    if (elapsed == 0) elapsed = 1;
-    //Modifier modifier;
-    for (int i = 0; i < sendingData.count(); i++)
+    if(mutex.tryLock())
     {
-        sendData = &sendingData[i];
-        if (!sendData->enabled)
+        int elapsed = elapsedTimer.restart();
+        if (elapsed == 0) elapsed = 1;
+        //Modifier modifier;
+        for (int i = 0; i < sendingData.count(); i++)
         {
-            if (sendData->triggers.count() > 0)
+            sendData = &sendingData[i];
+            if (!sendData->enabled)
             {
-                for (int j = 0; j < sendData->triggers.count(); j++)    //resetting currCount when line is disabled
+                if (sendData->triggers.count() > 0)
                 {
-                  sendData->triggers[j].currCount = 0;
+                    for (int j = 0; j < sendData->triggers.count(); j++)    //resetting currCount when line is disabled
+                    {
+                      sendData->triggers[j].currCount = 0;
+                    }
+                }
+                continue; //abort any processing on this if it is not enabled.
+            }
+            if (sendData->triggers.count() == 0) break;
+            for (int j = 0; j < sendData->triggers.count(); j++)
+            {
+                trigger = &sendData->triggers[j];
+                if (trigger->currCount >= trigger->maxCount) continue; //don't process if we've sent max frames we were supposed to
+                if (!trigger->readyCount) continue; //don't tick if not ready to tick
+                //is it time to fire?
+                trigger->msCounter += elapsed; //gives proper tracking even if timer doesn't fire as fast as it should
+                if (trigger->msCounter >= trigger->milliseconds)
+                {
+                    trigger->msCounter = 0;
+                    sendData->count++;
+                    trigger->currCount++;
+                    doModifiers(i);
+                    updateGridRow(i);
+                    //qDebug() << "About to try to send a frame";
+                    CANConManager::getInstance()->sendFrame(sendingData[i]);
+                    if (trigger->ID > 0) trigger->readyCount = false; //reset flag if this is a timed ID trigger
                 }
             }
-            continue; //abort any processing on this if it is not enabled.
         }
-        if (sendData->triggers.count() == 0) return;
-        for (int j = 0; j < sendData->triggers.count(); j++)
-        {
-            trigger = &sendData->triggers[j];
-            if (trigger->currCount >= trigger->maxCount) continue; //don't process if we've sent max frames we were supposed to
-            if (!trigger->readyCount) continue; //don't tick if not ready to tick
-            //is it time to fire?
-            trigger->msCounter += elapsed; //gives proper tracking even if timer doesn't fire as fast as it should
-            if (trigger->msCounter >= trigger->milliseconds)
-            {
-                trigger->msCounter = 0;
-                sendData->count++;
-                trigger->currCount++;
-                doModifiers(i);
-                updateGridRow(i);
-                qDebug() << "About to try to send a frame";
-                CANConManager::getInstance()->sendFrame(sendingData[i]);
-                if (trigger->ID > 0) trigger->readyCount = false; //reset flag if this is a timed ID trigger
-            }
-        }
+
+        mutex.unlock();
     }
+    else
+    {
+        qDebug() << "framesenderwindow::handleTick() couldn't get mutex, elapsed is: " << elapsedTimer.elapsed();
+    }
+
 }
 
 /// <summary>
@@ -479,7 +491,7 @@ void FrameSenderWindow::doModifiers(int idx)
 
     if (sendData->modifiers.count() == 0) return; //if no modifiers just leave right now
 
-    qDebug() << "Executing mods";
+    //qDebug() << "Executing mods";
 
     for (int i = 0; i < sendData->modifiers.count(); i++)
     {
@@ -648,10 +660,10 @@ void FrameSenderWindow::processModifierText(int line)
                 {
                     thisOp.operation = parseOperation(operation);
                     QString secondOp = Utility::grabAlphaNumeric(mods[i]);
-                    if (mods[i][0] == '~')
+                    if (secondOp.length() > 0 && secondOp[0] == '~')
                     {
                         thisOp.second.notOper = true;
-                        mods[i] = mods[i].remove(0, 1); //remove the ~ character
+                        secondOp = secondOp.remove(0, 1); //remove the ~ character
                     }
                     else thisOp.second.notOper = false;
                     thisOp.second.bus = sendingData[line].bus;
@@ -797,7 +809,7 @@ ModifierOperationType FrameSenderWindow::parseOperation(QString op)
 /// <param name="idx"></param>
 void FrameSenderWindow::updateGridRow(int idx)
 {
-    qDebug() << "updateGridRow";
+    //qDebug() << "updateGridRow";
 
     inhibitChanged = true;
     FrameSendData *temp = &sendingData[idx];
@@ -807,16 +819,27 @@ void FrameSenderWindow::updateGridRow(int idx)
     const unsigned char *data = reinterpret_cast<const unsigned char *>(temp->payload().constData());
     int dataLen = temp->payload().length();
 
-    if (item == nullptr) item = new QTableWidgetItem();
-    item->setText(QString::number(temp->count));
-    if (temp->frameType() != QCanBusFrame::RemoteRequestFrame) {
+    if (item == nullptr)
+    {
+        //item = new QTableWidgetItem();
+        //item->setText(QString::number(temp->count));  //crashes here  ---qt_Static_metacall -> handleTick ->here
+    }
+    else
+    {
+        item->setText(QString::number(temp->count));  //crashes here  ---qt_Static_metacall -> handleTick ->here
+    }
+
+    if (temp->frameType() != QCanBusFrame::RemoteRequestFrame)
+    {
         for (int i = 0; i < dataLen; i++)
         {
             dataString.append(Utility::formatNumber(data[i]));
             dataString.append(" ");
         }
         ui->tableSender->item(gridLine, 6)->setText(dataString);
-    } else {
+    }
+    else
+    {
         ui->tableSender->item(gridLine, 6)->setText("");
     }
     inhibitChanged = false;

--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -32,13 +32,13 @@ FrameSenderWindow::FrameSenderWindow(const QVector<CANFrame> *frames, QWidget *p
     createBlankRow();
 
     connect(ui->tableSender, SIGNAL(cellChanged(int,int)), this, SLOT(onCellChanged(int,int)));
-    connect(intervalTimer, SIGNAL(timeout()), this, SLOT(handleTick()), Qt::QueuedConnection);
+    connect(intervalTimer, SIGNAL(timeout()), this, SLOT(handleTick()));
     connect(ui->btnClearGrid, SIGNAL(clicked(bool)), this, SLOT(clearGrid()));
     connect(ui->btnDisableAll, SIGNAL(clicked(bool)), this, SLOT(disableAll()));
     connect(ui->btnEnableAll, SIGNAL(clicked(bool)), this, SLOT(enableAll()));
     connect(ui->btnLoadGrid, SIGNAL(clicked(bool)), this, SLOT(loadGrid()));
     connect(ui->btnSaveGrid, SIGNAL(clicked(bool)), this, SLOT(saveGrid()));
-    connect(MainWindow::getReference(), SIGNAL(framesUpdated(int)), this, SLOT(updatedFrames(int)), Qt::QueuedConnection);
+    connect(MainWindow::getReference(), SIGNAL(framesUpdated(int)), this, SLOT(updatedFrames(int)));
 
     intervalTimer->start();
     elapsedTimer.start();
@@ -195,7 +195,7 @@ void FrameSenderWindow::processIncomingFrame(CANFrame *frame)
                             sendingData[sd].count++;
                             doModifiers(sd);
                             updateGridRow(sd);
-                            CANConManager::getInstance()->sendFrame(CANFrame(sendingData[sd]));
+                            CANConManager::getInstance()->sendFrame(sendingData[sd]);
                         }
                         else //delayed sending frame
                         {

--- a/framesenderwindow.h
+++ b/framesenderwindow.h
@@ -5,6 +5,7 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QTime>
+#include <QMutex>
 #include "can_structs.h"
 #include "can_trigger_structs.h"
 
@@ -38,6 +39,7 @@ private:
     QTimer *intervalTimer;
     QElapsedTimer elapsedTimer;
     bool inhibitChanged = false;
+    QMutex mutex;
 
     void createBlankRow();
     void doModifiers(int);

--- a/framesenderwindow.h
+++ b/framesenderwindow.h
@@ -5,7 +5,6 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QTime>
-#include <QMutex>
 #include "can_structs.h"
 #include "can_trigger_structs.h"
 

--- a/framesenderwindow.h
+++ b/framesenderwindow.h
@@ -5,6 +5,7 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QTime>
+#include <QMutex>
 #include "can_structs.h"
 #include "can_trigger_structs.h"
 

--- a/main.cpp
+++ b/main.cpp
@@ -25,9 +25,9 @@ public:
 int main(int argc, char *argv[])
 {
 #ifdef QT_DEBUG
-    qputenv("QT_FATAL_WARNINGS", "1");
-    //qputenv("QT_MESSAGE_PATTERN", "Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
-    qSetMessagePattern("Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
+    //uncomment for verbose debug data in application output
+    //qputenv("QT_FATAL_WARNINGS", "1");
+    //qSetMessagePattern("Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
 #endif
 
     SavvyCANApplication a(argc, argv);

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,12 @@ public:
 
 int main(int argc, char *argv[])
 {
+#ifdef QT_DEBUG
+    qputenv("QT_FATAL_WARNINGS", "1");
+    //qputenv("QT_MESSAGE_PATTERN", "Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
+    qSetMessagePattern("Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
+#endif
+
     SavvyCANApplication a(argc, argv);
 
     //Add a local path for Qt extensions, to allow for per-application extensions.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -442,8 +442,7 @@ void MainWindow::headerClicked(int logicalIndex)
     //ui->canFramesView->sortByColumn(logicalIndex);
     model->sortByColumn(logicalIndex);
 
-    if(rowExpansionActive && model->getInterpretMode())
-        ui->canFramesView->resizeRowsToContents();
+    manageRowExpansion();
 }
 
 void MainWindow::expandAllRows()
@@ -467,6 +466,12 @@ void MainWindow::expandAllRows()
 
         rowExpansionActive = true;
     }
+}
+
+void MainWindow::manageRowExpansion()
+{
+    if(rowExpansionActive && model->getInterpretMode())
+        ui->canFramesView->resizeRowsToContents();
 }
 
 void MainWindow::collapseAllRows()
@@ -628,6 +633,7 @@ void MainWindow::overwriteToggled(bool state)
     }
     else
     {
+        rowExpansionActive = false;
         model->setOverwriteMode(false);
     }
 }
@@ -687,8 +693,7 @@ void MainWindow::filterListItemChanged(QListWidgetItem *item)
 
     model->setFilterState(ID, isSet);
 
-    if(rowExpansionActive && model->getInterpretMode())
-        ui->canFramesView->resizeRowsToContents();
+    manageRowExpansion();
 }
 
 void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
@@ -703,8 +708,7 @@ void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
 
     model->setBusFilterState(ID, isSet);
 
-    if(rowExpansionActive && model->getInterpretMode())
-        ui->canFramesView->resizeRowsToContents();
+    manageRowExpansion();
 }
 
 void MainWindow::filterSetAll()
@@ -717,8 +721,7 @@ void MainWindow::filterSetAll()
     inhibitFilterUpdate = false;
     model->setAllFilters(true);
 
-    if(rowExpansionActive && model->getInterpretMode())
-        ui->canFramesView->resizeRowsToContents();
+    manageRowExpansion();
 }
 
 void MainWindow::filterClearAll()
@@ -754,12 +757,14 @@ void MainWindow::tickGUIUpdate()
             framesPerSec = 0;
 
         ui->lbNumFrames->setText(QString::number(model->rowCount()));
-        if (rxFrames > 0 && /*allowCapture && */ ui->cbAutoScroll->isChecked()) ui->canFramesView->scrollToBottom();
+        if (rxFrames > 0 && /*allowCapture && */ ui->cbAutoScroll->isChecked())
+                ui->canFramesView->scrollToBottom();
         ui->lbFPS->setText(QString::number(framesPerSec));
         if (rxFrames > 0)
         {
             bDirty = true;
             emit framesUpdated(rxFrames); //anyone care that frames were updated?
+            manageRowExpansion();
         }
 
         if (model->needsFilterRefresh()) updateFilterList();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -441,6 +441,9 @@ void MainWindow::headerClicked(int logicalIndex)
 {
     //ui->canFramesView->sortByColumn(logicalIndex);
     model->sortByColumn(logicalIndex);
+
+    if(rowExpansionActive && model->getInterpretMode())
+        ui->canFramesView->resizeRowsToContents();
 }
 
 void MainWindow::expandAllRows()
@@ -461,6 +464,8 @@ void MainWindow::expandAllRows()
     if (goAhead)
     {
         ui->canFramesView->resizeRowsToContents();
+
+        rowExpansionActive = true;
     }
 }
 
@@ -482,6 +487,8 @@ void MainWindow::collapseAllRows()
     if (goAhead)
     {
         for (int i = 0; i < numRows; i++) ui->canFramesView->setRowHeight(i, normalRowHeight);
+
+        rowExpansionActive = false;
     }
 }
 
@@ -679,6 +686,9 @@ void MainWindow::filterListItemChanged(QListWidgetItem *item)
     if (item->checkState() == Qt::Checked) isSet = true;
 
     model->setFilterState(ID, isSet);
+
+    if(rowExpansionActive && model->getInterpretMode())
+        ui->canFramesView->resizeRowsToContents();
 }
 
 void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
@@ -692,6 +702,9 @@ void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
     if (item->checkState() == Qt::Checked) isSet = true;
 
     model->setBusFilterState(ID, isSet);
+
+    if(rowExpansionActive && model->getInterpretMode())
+        ui->canFramesView->resizeRowsToContents();
 }
 
 void MainWindow::filterSetAll()
@@ -703,6 +716,9 @@ void MainWindow::filterSetAll()
     }
     inhibitFilterUpdate = false;
     model->setAllFilters(true);
+
+    if(rowExpansionActive && model->getInterpretMode())
+        ui->canFramesView->resizeRowsToContents();
 }
 
 void MainWindow::filterClearAll()
@@ -794,7 +810,7 @@ void MainWindow::addFrameToDisplay(CANFrame &frame, bool autoRefresh = false)
 
 //A sub-window is sending us a center on timestamp and ID signal
 //try to find the relevant frame in the list and focus on it.
-void MainWindow::gotCenterTimeID(int32_t ID, double timestamp)
+void MainWindow::gotCenterTimeID(uint32_t ID, double timestamp)
 {
     int idx = model->getIndexFromTimeID(ID, timestamp);
     if (idx > -1)
@@ -1150,13 +1166,13 @@ void MainWindow::showGraphingWindow()
     lastGraphingWindow = new GraphingWindow(model->getListReference());
     graphWindows.append(lastGraphingWindow);
 
-    connect(lastGraphingWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), this, SLOT(gotCenterTimeID(int32_t,double)));
-    connect(this, SIGNAL(sendCenterTimeID(uint32_t,double)), lastGraphingWindow, SLOT(gotCenterTimeID(int32_t,double)));
+    connect(lastGraphingWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), this, SLOT(gotCenterTimeID(uint32_t,double)));
+    connect(this, SIGNAL(sendCenterTimeID(uint32_t,double)), lastGraphingWindow, SLOT(gotCenterTimeID(uint32_t,double)));
 
     if (flowViewWindow) //connect the two external windows together
     {
-        connect(lastGraphingWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), flowViewWindow, SLOT(gotCenterTimeID(int32_t,double)));
-        connect(flowViewWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), lastGraphingWindow, SLOT(gotCenterTimeID(int32_t,double)));
+        connect(lastGraphingWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), flowViewWindow, SLOT(gotCenterTimeID(uint32_t,double)));
+        connect(flowViewWindow, SIGNAL(sendCenterTimeID(uint32_t,double)), lastGraphingWindow, SLOT(gotCenterTimeID(uint32_t,double)));
     }
 
     lastGraphingWindow->show();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -205,6 +205,7 @@ private:
     void readSettings();
     void writeSettings();
     bool eventFilter(QObject *obj, QEvent *event);
+    void manageRowExpansion();
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -116,7 +116,7 @@ public slots:
     void gotFrames(int);
     void updateSettings();
     void readUpdateableSettings();
-    void gotCenterTimeID(int32_t ID, double timestamp);
+    void gotCenterTimeID(uint32_t ID, double timestamp);
     void updateConnectionSettings(QString connectionType, QString port, int speed0, int speed1);
 
 signals:
@@ -191,6 +191,7 @@ private:
     int normalRowHeight;
     bool isConnected;
     QPoint contextMenuPosition;
+    bool rowExpansionActive = false;
 
     //private methods
     QString getSignalNameFromPosition(QPoint pos);

--- a/re/flowviewwindow.cpp
+++ b/re/flowviewwindow.cpp
@@ -298,7 +298,7 @@ void FlowViewWindow::plottableDoubleClick(QCPAbstractPlottable* plottable, QMous
     else emit sendCenterTimeID(id, coord / 1000000.0);
 }
 
-void FlowViewWindow::gotCenterTimeID(int32_t ID, double timestamp)
+void FlowViewWindow::gotCenterTimeID(uint32_t ID, double timestamp)
 {
     int64_t t_stamp;
 

--- a/re/flowviewwindow.h
+++ b/re/flowviewwindow.h
@@ -37,7 +37,7 @@ private slots:
     void saveFileFlow();
     void saveFileGraph();
     void plottableDoubleClick(QCPAbstractPlottable* plottable, QMouseEvent* event);
-    void gotCenterTimeID(int32_t ID, double timestamp);
+    void gotCenterTimeID(uint32_t ID, double timestamp);
     void updateTriggerValues();
     void gotCellClick(int x, int y);
     void graphRangeChanged(int range);

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -281,7 +281,7 @@ void GraphingWindow::plottableDoubleClick(QCPAbstractPlottable* plottable, int d
     locationText->setText("X: " + QString::number(x) + " Y: " + QString::number(itemTracer->position->value()));
 }
 
-void GraphingWindow::gotCenterTimeID(int32_t ID, double timestamp)
+void GraphingWindow::gotCenterTimeID(uint32_t ID, double timestamp)
 {
     Q_UNUSED(ID)
     //its problematic to try to highlight a graph since we get the ID

--- a/re/graphingwindow.h
+++ b/re/graphingwindow.h
@@ -81,7 +81,7 @@ private slots:
     void appendToGraph(GraphParams &params, CANFrame &frame, QVector<double> &x, QVector<double> &y);
     void editSelectedGraph();
     void updatedFrames(int);
-    void gotCenterTimeID(int32_t ID, double timestamp);
+    void gotCenterTimeID(uint32_t ID, double timestamp);
     void resetView();
     void zoomIn();
     void zoomOut();


### PR DESCRIPTION
Main issue was due to queueing the TX frame from the wrong thread.

I originally thought it was due to how frames vs filteredframes was managed, so cleaned that up and while I was at it I changed frames to always contain all history and filteredframes to reflect the filters in the main window.  This obviously didn't fix the issue but it did make it so graphingwindow gets continuous data even when filters are active, and other such things like that.  I liked it so much I decided to keep it.

A couple other minor bug fixes related to doModifiers parsing crash in custom frame sender, fixed count cell not counting if not manually initialized, and a couple other things.