### PR TITLE
Changed Windows Build Name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/download-artifact@v2
 
       - name: Display structure of downloaded files
-        run: zip -r SavvyCAN_CIBuild.zip SavvyCAN-Windows_x64
+        run: zip -r SavvyCAN-Windows_x64_CIBuild.zip SavvyCAN-Windows_x64
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -138,7 +138,7 @@ jobs:
           title: "Development Build"
           files: |
             SavvyCAN-Linux_x64.AppImage/SavvyCAN-x86_64.AppImage
-            SavvyCAN_CIBuild.zip
+            SavvyCAN-Windows_x64_CIBuild.zip
             SavvyCAN-macOS_x64.dmg/SavvyCAN.dmg
           
   notify:


### PR DESCRIPTION
Changed the name of the ZIP from SavvyCAN_CIBuild.zip to SavvyCAN-Windows_x64_CIBuild.zip to make it more clearer that it is a Windows Build