### PR TITLE
fix: update msg node color when adding a new message to dbc

### DIFF
--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -675,6 +675,9 @@ void DBCMainEditor::newMessage()
         msgItem = nodeItem->parent();
         nodeItem = msgItem->parent();
     }
+    if (typ == DBCItemTypes::NODE){
+        msgItem = nodeItem;
+    }
 
     //if there was a comment this will find the location of the comment and snip it out.
     QString nodeName = nodeItem->data(0, Qt::DisplayRole).toString().split(" - ")[0];
@@ -702,6 +705,7 @@ void DBCMainEditor::newMessage()
             msg.name = nodeName + "Msg" + QString::number(randGen.bounded(500));
             msg.ID = 0;
             msg.len = 8;
+            msg.bgColor = QApplication::palette().color(QPalette::Base);
         }
     }
     else


### PR DESCRIPTION
It seems like when adding a new message it is not setting the background color right away, only after reloading the program. I've added this new state to support new msg and signal 