### PR TITLE
Comments should come before attributes in DBC files

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -1521,6 +1521,9 @@ bool DBCFile::saveFile(QString fileName)
         msgOutput.clear(); //got to reset it after writing
     }
 
+    outFile->write(commentsOutput.toUtf8());
+    commentsOutput.clear();
+
     //Now dump out all of the stored attributes
     for (int x = 0; x < dbc_attributes.count(); x++)
     {
@@ -1624,7 +1627,6 @@ bool DBCFile::saveFile(QString fileName)
     }
 
     //now write out all of the accumulated comments and value tables from above
-    outFile->write(commentsOutput.toUtf8());
     outFile->write(defaultsOutput.toUtf8());
     outFile->write(attrValOutput.toUtf8());    
     outFile->write(valuesOutput.toUtf8());
@@ -1632,7 +1634,6 @@ bool DBCFile::saveFile(QString fileName)
 
     attrValOutput.clear();
     defaultsOutput.clear();
-    commentsOutput.clear();
     valuesOutput.clear();
     extMultiplexOutput.clear();
 


### PR DESCRIPTION
The comments should come before attributes in generated DBC files, according to:

- http://mcu.so/Microcontroller/Automotive/DBC_File_Format_Documentation.pdf
- Examples from http://socialledge.com/sjsu/index.php/DBC_Format

This incorrect ordering was tripping up the string parsing grammar of https://github.com/howerj/dbcc which resulted in content after the comments not being parsed at all for me.


**End of generated DBC before:**
![image](https://user-images.githubusercontent.com/7203144/218011627-cc2e446f-1532-4a8d-97e2-bb63e1cf0bc3.png)

**End of generated DBC after:**
![image](https://user-images.githubusercontent.com/7203144/218011574-b1070e6d-ea3c-4eb9-bc77-6c5ba54beb2f.png)
