### PR TITLE
uds scan tool improvements

### DIFF
--- a/re/udsscanwindow.h
+++ b/re/udsscanwindow.h
@@ -108,5 +108,7 @@ private:
     void setupNodes(uint32_t replyID);
     void dumpNode(QTreeWidgetItem* item, QFile *file, int indent);
     bool eventFilter(QObject *obj, QEvent *event);
+
+    static void setControlState(QWidget & widget, bool valid);
 };
 #endif // UDSSCANWINDOW_H


### PR DESCRIPTION
https://github.com/collin80/SavvyCAN/issues/587

- color id,subfunc and service fields red if they caontain invalid ranges
- do not change user input anymore
- set default extension when saving
- allow setting lower bounds for subfuncs > 0xFF
- make sure the scan doesn't hang when selecting invalid ranges