### PR TITLE
dbc signal editor: Allow undo of clicks on bitfield

### DIFF
--- a/dbc/dbcsignaleditor.cpp
+++ b/dbc/dbcsignaleditor.cpp
@@ -778,6 +778,8 @@ void DBCSignalEditor::fillValueTable(DBC_SIGNAL *sig)
 void DBCSignalEditor::bitfieldLeftClicked(int bit)
 {
     if (currentSignal == nullptr) return;
+
+    pushToUndoBuffer();
     currentSignal->startBit = bit;
     if (currentSignal->valType == SP_FLOAT)
     {
@@ -812,6 +814,9 @@ void DBCSignalEditor::bitfieldRightClicked(int bit)
     //which is quite luckily also the index into the signal handler table
     int sigNum = ui->bitfield->getUsedSignalNum(bit);
     if (sigNum < 0) return;
+
+    pushToUndoBuffer(); // undo to resume editing the previous signal
+
     currentSignal = dbcMessage->sigHandler->findSignalByIdx(sigNum);
 
     if (currentSignal)


### PR DESCRIPTION
Small usability tweak, allow Ctrl-Z Undo after clicking on the bitfields in the DBC signal editor.

Thanks for all your work on this project @collin80, it's very handy. :)