### PR TITLE
main window: Fix error on "add to a graphing window" if !filter labels

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -588,7 +588,7 @@ void MainWindow::setupSendToLatestGraphWindow()
     GraphParams param;
     QString signalName = getSignalNameFromPosition(contextMenuPosition);
     param.ID = getMessageIDFromPosition(contextMenuPosition);
-    DBC_MESSAGE *msg = dbcHandler->findMessageForFilter(param.ID, nullptr);
+    DBC_MESSAGE *msg = dbcHandler->findMessage(param.ID);
     if(msg)
     {
         DBC_SIGNAL *sig = msg->sigHandler->findSignalByName(signalName);


### PR DESCRIPTION
I think this is the right fix here, but of course please let me know if SavvyCAN should do something different:

Right-clicking and trying to graph a signal from a DBC file with "Label filters" unset would result in an error "Cannot find ID 0xNNN in DBC files(). Not adding graph".

Filter labels unset is the default state when adding a new DBC file. Signals from DBC files with "filter labels" unset are still shown in the main CAN messages view when "Interpet Frames" is enabled.