### PR TITLE
[Simple] Initialize extendedId when creating new messages in the DBC editor

### DIFF
--- a/can_structs.h
+++ b/can_structs.h
@@ -33,6 +33,14 @@ public:
         timedelta = 0;
         frameCount = 1;
     }
+
+    uint8_t getDeviceId() const {
+        return (frameId() & 0x1FE00000) >> 21;
+    }
+
+    uint32_t getMessageId() const {
+        return frameId() & 0x1FFFFF;
+    }
 };
 
 class CANFltObserver

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -436,6 +436,7 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
         {
         case Column::TimeStamp:
             return Qt::AlignRight;
+        case Column::DeviceId:
         case Column::FrameId:
         case Column::Direction:
         case Column::Extended:
@@ -480,6 +481,10 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
             return Utility::formatCANID(thisFrame.frameId(), thisFrame.hasExtendedFrameFormat());
         case Column::Extended:
             return QString::number(thisFrame.hasExtendedFrameFormat());
+        case Column::DeviceId:
+            return QString::number(thisFrame.getDeviceId());
+        case Column::MessageId:
+            return Utility::formatCANID(thisFrame.getMessageId(), thisFrame.hasExtendedFrameFormat());
         case Column::Remote:
             if (!overwriteDups) return QString::number(thisFrame.frameType() == QCanBusFrame::RemoteRequestFrame);
             return QString::number(thisFrame.frameCount);
@@ -599,9 +604,13 @@ QVariant CANFrameModel::headerData(int section, Qt::Orientation orientation,
             if (overwriteDups) return QString(tr("Time Delta"));
             return QString(tr("Timestamp"));
         case Column::FrameId:
-            return QString(tr("ID"));
+            return QString(tr("Frame ID"));
         case Column::Extended:
             return QString(tr("Ext"));
+        case Column::DeviceId:
+            return QString(tr("Device ID"));
+        case Column::MessageId:
+            return QString(tr("Message ID"));
         case Column::Remote:
             if (!overwriteDups) return QString(tr("RTR"));
             return QString(tr("Cnt"));

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -12,15 +12,17 @@
 #include "utility.h"
 
 enum class Column {
-    TimeStamp = 0, ///< The timestamp when the frame was transmitted or received
-    FrameId   = 1, ///< The frames CAN identifier (Standard: 11 or Extended: 29 bit)
-    Extended  = 2, ///< True if the frames CAN identifier is 29 bit
-    Remote    = 3, ///< True if the frames is a remote frame
-    Direction = 4, ///< Whether the frame was transmitted or received
-    Bus       = 5, ///< The bus where the frame was transmitted or received
-    Length    = 6, ///< The frames payload data length
-    ASCII     = 7, ///< The payload interpreted as ASCII characters
-    Data      = 8, ///< The frames payload data
+    TimeStamp  , ///< The timestamp when the frame was transmitted or received
+    FrameId    , ///< The frames CAN identifier (Standard: 11 or Extended: 29 bit)
+    Extended  , ///< True if the frames CAN identifier is 29 bit
+    DeviceId   ,
+    MessageId  ,
+    Remote     , ///< True if the frames is a remote frame
+    Direction  , ///< Whether the frame was transmitted or received
+    Bus        , ///< The bus where the frame was transmitted or received
+    Length     , ///< The frames payload data length
+    ASCII      , ///< The payload interpreted as ASCII characters
+    Data       , ///< The frames payload data
     NUM_COLUMN
 };
 

--- a/dbc/dbc_classes.h
+++ b/dbc/dbc_classes.h
@@ -137,7 +137,7 @@ public:
     DBC_MESSAGE();
 
     uint32_t ID;
-    bool extendedID;
+    bool extendedID = false;
     QString name;
     QString comment;
     unsigned int len;

--- a/dbc/dbc_classes.h
+++ b/dbc/dbc_classes.h
@@ -137,7 +137,7 @@ public:
     DBC_MESSAGE();
 
     uint32_t ID;
-    bool extendedID = false;
+    bool extendedID;
     QString name;
     QString comment;
     unsigned int len;

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -2158,7 +2158,7 @@ DBC_MESSAGE* DBCHandler::findMessage(const CANFrame &frame)
     {
         if (loadedFiles[i].getAssocBus() == -1 || frame.bus == loadedFiles[i].getAssocBus())
         {
-            DBC_MESSAGE* msg = loadedFiles[i].messageHandler->findMsgByID(frame.frameId());
+            DBC_MESSAGE* msg = loadedFiles[i].messageHandler->findMsgByID(frame.getMessageId());
             if (msg != nullptr) return msg;
         }
     }

--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -699,6 +699,7 @@ void DBCMainEditor::newMessage()
             msg.bgColor = oldMsg->bgColor;
             msg.fgColor = oldMsg->fgColor;
             msg.comment = oldMsg->comment;
+            msg.extendedID = oldMsg->extendedID;
         }
         else
         {
@@ -706,6 +707,7 @@ void DBCMainEditor::newMessage()
             msg.ID = 0;
             msg.len = 8;
             msg.bgColor = QApplication::palette().color(QPalette::Base);
+            msg.extendedID = false;
         }
     }
     else
@@ -713,6 +715,7 @@ void DBCMainEditor::newMessage()
         msg.name = nodeName + "Msg" + QString::number(randGen.bounded(500));
         msg.ID = 0;
         msg.len = 8;
+        msg.extendedID = false;
     }    
     msg.sender = node;
 

--- a/filterutility.cpp
+++ b/filterutility.cpp
@@ -67,6 +67,9 @@ QListWidgetItem * FilterUtility::createFilterItem(uint32_t id, QListWidget* pare
     QListWidgetItem *thisItem = new QListWidgetItem(parent);
     QString filterItemName = Utility::formatCANID(id);
 
+    uint8_t deviceId = (id & 0x1FE00000) >> 21;
+    uint32_t messageId = id & 0x1FFFFF;
+
     //Note, there are multiple filter labeling preferences. There is one in main settings to globally
     //enable or disable them all. Then each loaded DBC file also can be selected on/off
     //Both must be enabled for you to see labeling.
@@ -74,10 +77,11 @@ QListWidgetItem * FilterUtility::createFilterItem(uint32_t id, QListWidget* pare
     {
         // Filter labeling (show interpreted frame names next to the CAN addr ID)
         MatchingCriteria_t matchingCriteria;
-        DBC_MESSAGE *msg = dbcHandler->findMessageForFilter(id,&matchingCriteria);
+        DBC_MESSAGE *msg = dbcHandler->findMessageForFilter(messageId,&matchingCriteria);
         if (msg != nullptr)
         {
             filterItemName.append(" ");
+            filterItemName.append(QString::number(deviceId).append(":").leftJustified(5, ' '));
             filterItemName.append(msg->name);
 
             // Create tooltip to show the whole name just in case it's too long to fit in the filter window.

--- a/install
+++ b/install
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+CURDIR=`pwd`
+
+# Set absolute path
+sed -e "s,<DIR>,$CURDIR,g" SavvyCAN.desktop > SavvyCAN.desktop.temp
+
+cp SavvyCAN.desktop.temp ~/.local/share/applications/SavvyCAN.desktop
+cp SavvyCAN.desktop.temp ~/Desktop/SavvyCAN.desktop
+rm SavvyCAN.desktop.temp
+
+echo "Installed SavvyCAN icons on menu and desktop !"


### PR DESCRIPTION
When creating new messages in the DBC editor, they sometimes end up being extendedID's due the uninitialized variable, which you don't realize until you look inside the generated .dbc file after saving.