### PR TITLE
fix compile errors on newer Qt versions

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -257,7 +257,7 @@ uint64_t CANFrameModel::getCANFrameVal(QVector<CANFrame> *frames, int row, Colum
         return static_cast<uint64_t>(frame.payload().length());
     case Column::ASCII: //sort both the same for now
     case Column::Data:
-        for (int i = 0; i < std::min(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
+        for (int i = 0; i < std::min(frame.payload().length(), static_cast<qsizetype>(8)); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
         //qDebug() << temp;
         return temp;
     case Column::NUM_COLUMN:

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -343,15 +343,15 @@ void LAWICELSerial::serialError(QSerialPort::SerialPortError err)
         killConnection = true;
         piStop();
         break;
-    case QSerialPort::ParityError:
-        errMessage = "Parity error on serial port";
-        break;
-    case QSerialPort::FramingError:
-        errMessage = "Framing error on serial port";
-        break;
-    case QSerialPort::BreakConditionError:
-        errMessage = "Break error on serial port";
-        break;
+    // case QSerialPort::ParityError:
+    //     errMessage = "Parity error on serial port";
+    //     break;
+    // case QSerialPort::FramingError:
+    //     errMessage = "Framing error on serial port";
+    //     break;
+    // case QSerialPort::BreakConditionError:
+    //     errMessage = "Break error on serial port";
+    //     break;
     case QSerialPort::WriteError:
         errMessage = "Write error on serial port";
         piStop();
@@ -441,7 +441,7 @@ void LAWICELSerial::readSerialData()
         //qDebug() << c << "    " << QString::number(c, 16) << "     " << QString(c);
         debugBuild = debugBuild % QString::number(c, 16).rightJustified(2,'0') % " ";
         //procRXChar(c);
-        mBuildLine.append(c);
+        mBuildLine.append(static_cast<QChar>(c));
         if (c == 13) //all lawicel commands end in CR
         {
             qDebug() << "Got CR!";

--- a/re/sniffer/snifferwindow.cpp
+++ b/re/sniffer/snifferwindow.cpp
@@ -181,7 +181,7 @@ void SnifferWindow::notchTick()
     }
     else
     {
-        ui->lblNotch->setBackgroundRole(QPalette::Background);
+        ui->lblNotch->setBackgroundRole(QPalette::Window);
         ui->lblNotch->repaint();
         //qDebug() << "Tock";
     }


### PR DESCRIPTION
Just addresses issues I got when compiling with Qt 6.7.0 dev and GCC 13.2.1 on arm64. I commented the serialport errors in case they are added back later, as I see no reason for them to have been removed. I should note that there are numerous deprication warnings, so things will continue breaking in the future.