### PR TITLE
Add support ListenOnly feature for Qt SerialBus plugins

### DIFF
--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -78,6 +78,8 @@ bool SerialBusConnection::piGetBusSettings(int pBusIdx, CANBus& pBus)
 
 void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
 {
+    quint32 sbusconfig = 0;
+
     //CANConStatus stats;
     /* sanity checks */
     if(0 != pBusIdx)
@@ -105,6 +107,10 @@ void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
     //But, you can probabaly set the speed of many of the other serialbus devices so go ahead and try
     mDev_p->setConfigurationParameter(QCanBusDevice::BitRateKey, bus.speed);
     mDev_p->setConfigurationParameter(QCanBusDevice::CanFdKey, bus.canFD);
+
+    if(bus.listenOnly)
+        sbusconfig |= EN_SILENT_MODE;
+    mDev_p->setConfigurationParameter(QCanBusDevice::UserKey, sbusconfig);
 
     /* connect device */
     if (!mDev_p->connectDevice()) {

--- a/connections/serialbusconnection.h
+++ b/connections/serialbusconnection.h
@@ -7,6 +7,21 @@
 #include <QCanBusDevice>
 #include <QTimer>
 
+/*
+QCanBusDevice::UserKey
+0x00000001 - enable silent mode
+0x00000002 - enable loopback mode
+0x00000004 - disable auto retransmissions
+0x00000008 - enable terminator
+0x00000010 - enable automatic bus off recovery
+*/
+
+#define EN_SILENT_MODE                  0x00000001
+#define EN_LOOPBACK_MODE                0x00000002
+#define DIS_AUTO_RETRANSMISSIONS        0x00000004
+#define EN_TERMINATOR                   0x00000008
+#define EN_AUTOMATIC_BUSOFF_RECOVERY    0x00000010
+
 class SerialBusConnection : public CANConnection
 {
     Q_OBJECT


### PR DESCRIPTION
Add support ListenOnly feature for a Qt SerialBus plugins.
 QCanBusDevice::UserKey bit 0 now is responsible for a "Listen Only" or "CAN bus silent" mode
