### PR TITLE
Highlight changed bytes in Frames view when Overwrite mode is enabled

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -100,7 +100,8 @@ SOURCES += main.cpp\
     connections/newconnectiondialog.cpp \
     re/temporalgraphwindow.cpp \
     filterutility.cpp \
-    pcaplite.cpp
+    pcaplite.cpp \
+    candataitemdelegate.cpp
 
 HEADERS  += mainwindow.h \
     can_structs.h \
@@ -194,7 +195,8 @@ HEADERS  += mainwindow.h \
     connections/newconnectiondialog.h \
     re/temporalgraphwindow.h \
     filterutility.h \
-    pcaplite.h
+    pcaplite.h \
+    candataitemdelegate.h
 
 FORMS    += ui/candatagrid.ui \
     triggerdialog.ui \

--- a/can_structs.h
+++ b/can_structs.h
@@ -5,6 +5,7 @@
 #include <QVector>
 #include <stdint.h>
 #include <QCanBusFrame>
+#include <QMetaType>
 
 //Now inherits from the built-in CAN frame class from Qt. This should be more future proof and easier to integrate with other code
 
@@ -14,7 +15,10 @@ public:
     int bus;
     bool isReceived; //did we receive this or send it?
     uint64_t timedelta;
-    uint32_t frameCount; //used in overwrite mode
+
+    //used in overwrite mode
+    uint32_t frameCount;
+    uint8_t changedPayloadBytes;
 
     friend bool operator<(const CANFrame& l, const CANFrame& r)
     {
@@ -34,6 +38,8 @@ public:
         frameCount = 1;
     }
 };
+
+Q_DECLARE_METATYPE(CANFrame);
 
 class CANFltObserver
 {

--- a/candataitemdelegate.cpp
+++ b/candataitemdelegate.cpp
@@ -1,0 +1,146 @@
+
+
+#include "candataitemdelegate.h"
+#include <QPainter>
+#include <QDebug>
+#include "can_structs.h"
+
+#define DATA_ITEM_LEFT_PADDING 5
+
+CanDataItemDelegate::CanDataItemDelegate(CANFrameModel *_model) : QItemDelegate() {
+
+    dbcHandler = DBCHandler::getReference();
+    model = _model;
+}
+
+void CanDataItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const
+{
+    const auto frame = index.data().value<CANFrame>();
+    const unsigned char *data = reinterpret_cast<const unsigned char *>(frame.payload().constData());
+
+    bool overwriteDups = model->getOverwriteMode();
+    int bytesPerLine = model->getBytesPerLine();
+    bool useHexMode = model->getHexMode();
+
+    // cache the painter state so it can be restored after this item is done painting
+    painter->save();
+    QStyleOptionViewItem opt = setOptions(index, option);
+    drawBackground(painter, opt, index);
+    
+    auto pen = painter->pen();
+    const auto defaultColor = pen.color();
+
+    // FontMetrics are used to measure the bounding rects for drawn text, allowing 
+    // us to properly position subsequent draw calls
+    const auto fm = painter->fontMetrics();
+    
+    int dataLen = frame.payload().count();
+    if (dataLen < 0) dataLen = 0;
+    if (frame.frameType() != QCanBusFrame::RemoteRequestFrame) {
+        QRect boundingRect;
+        QPoint startPoint = option.rect.topLeft();
+        const auto charBounds = fm.boundingRect("0");
+        int x = startPoint.x() + DATA_ITEM_LEFT_PADDING;
+        int y = startPoint.y() + charBounds.height();
+
+        // Draw each data byte manually, advancing the start point as we go
+        // This allows us to change the styling of individual draw calls.
+        // We use this to highlight data bytes that have changed since the last
+        // frame when overwriteDups mode is on.
+        for (int i = 0; i < dataLen; i++)
+        {
+            if((frame.changedPayloadBytes & (1 << i)) && overwriteDups) {
+                painter->setPen(Qt::red);
+            }
+            else {
+                painter->setPen(defaultColor);
+            }
+
+            QString dataStr = 
+                useHexMode ? 
+                    QString::number(data[i], 16).toUpper().rightJustified(2, '0') : 
+                    QString::number(data[i], 10);
+            const auto bounds = fm.boundingRect(dataStr);
+
+            painter->drawText(x, y, dataStr);
+
+            x += bounds.width();
+
+            if (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) {
+                // Wrap to next line
+                y += bounds.height();
+                x = startPoint.x() + DATA_ITEM_LEFT_PADDING;
+            }
+            else {
+                // Advance a character width for a space
+                x += charBounds.width();
+            }
+        }
+        
+        painter->setPen(defaultColor);
+
+        QString tempString;
+        buildStringFromFrame(frame, tempString);
+
+        if (tempString.length())
+            painter->drawText(x, y, tempString);
+    }
+    
+    drawFocus(painter, opt, option.rect);
+    painter->restore();
+}
+
+void CanDataItemDelegate::buildStringFromFrame(CANFrame frame, QString &tempString) const {
+    bool interpretFrames = model->getInterpretMode();
+    bool overwriteDups = model->getOverwriteMode();
+    tempString.append("");
+    if (frame.frameType() == frame.ErrorFrame)
+    {
+        if (frame.error() & frame.TransmissionTimeoutError) tempString.append("\nTX Timeout");
+        if (frame.error() & frame.LostArbitrationError) tempString.append("\nLost Arbitration");
+        if (frame.error() & frame.ControllerError) tempString.append("\nController Error");
+        if (frame.error() & frame.ProtocolViolationError) tempString.append("\nProtocol Violation");
+        if (frame.error() & frame.TransceiverError) tempString.append("\nTransceiver Error");
+        if (frame.error() & frame.MissingAcknowledgmentError) tempString.append("\nMissing ACK");
+        if (frame.error() & frame.BusOffError) tempString.append("\nBus OFF");
+        if (frame.error() & frame.BusError) tempString.append("\nBus ERR");
+        if (frame.error() & frame.ControllerRestartError) tempString.append("\nController restart err");
+        if (frame.error() & frame.UnknownError) tempString.append("\nUnknown error type");
+    }
+    //TODO: technically the actual returned bytes for an error frame encode some more info. Not interpreting it yet.
+
+    //now, if we're supposed to interpret the data and the DBC handler is loaded then use it
+    if ( (dbcHandler != nullptr) && interpretFrames && (frame.frameType() == frame.DataFrame) )
+    {
+        DBC_MESSAGE *msg = dbcHandler->findMessage(frame);
+        if (msg != nullptr)
+        {
+            tempString.append("   <" + msg->name + ">\n");
+            if (msg->comment.length() > 1) tempString.append(msg->comment + "\n");
+            for (int j = 0; j < msg->sigHandler->getCount(); j++)
+            {                        
+                QString sigString;
+                DBC_SIGNAL* sig = msg->sigHandler->findSignalByIdx(j);
+
+                if ( (sig->multiplexParent == nullptr) && sig->processAsText(frame, sigString))
+                {
+                    tempString.append(sigString);
+                    tempString.append("\n");
+                    if (sig->isMultiplexor)
+                    {
+                        qDebug() << "Multiplexor. Diving into the tree";
+                        tempString.append(sig->processSignalTree(frame));
+                    }
+                }
+                else if (sig->isMultiplexed && overwriteDups) //wasn't in this exact frame but is in the message. Use cached value
+                {
+                    bool isInteger = false;
+                    if (sig->valType == UNSIGNED_INT || sig->valType == SIGNED_INT) isInteger = true;
+                    tempString.append(sig->makePrettyOutput(sig->cachedValue.toDouble(), sig->cachedValue.toLongLong(), true, isInteger));
+                    tempString.append("\n");
+                }
+            }
+        }
+    }
+}

--- a/candataitemdelegate.h
+++ b/candataitemdelegate.h
@@ -1,0 +1,23 @@
+#ifndef CANDATAITEMDELEGATE_H
+#define CANDATAITEMDELEGATE_H
+
+#include <QItemDelegate>
+#include "dbc/dbchandler.h"
+#include "canframemodel.h"
+
+class CanDataItemDelegate : public QItemDelegate
+{
+public:
+    using QItemDelegate::QItemDelegate;
+    CanDataItemDelegate(CANFrameModel *model);
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+
+private:
+    void buildStringFromFrame(CANFrame frame, QString &tempString) const;
+    DBCHandler *dbcHandler;
+    CANFrameModel *model;
+};
+
+#endif

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -357,7 +357,6 @@ void CANFrameModel::sortByColumn(int column)
 
 //End of custom sorting code
 
-// TODO - update this as well?
 void CANFrameModel::recalcOverwrite()
 {
     if (!overwriteDups) return; //no need to do a thing if mode is disabled

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -90,6 +90,11 @@ void CANFrameModel::setBytesPerLine(int bpl)
     bytesPerLine = bpl;
 }
 
+int CANFrameModel::getBytesPerLine()
+{
+    return bytesPerLine;
+}
+
 void CANFrameModel::setHexMode(bool mode)
 {
     if (useHexMode != mode)
@@ -99,6 +104,11 @@ void CANFrameModel::setHexMode(bool mode)
         Utility::decimalMode = !useHexMode;
         this->endResetModel();
     }
+}
+
+bool CANFrameModel::getHexMode()
+{
+    return useHexMode;
 }
 
 void CANFrameModel::setTimeStyle(TimeStyle newStyle)
@@ -193,6 +203,11 @@ void CANFrameModel::setOverwriteMode(bool mode)
     overwriteDups = mode;
     recalcOverwrite();
     endResetModel();
+}
+
+bool CANFrameModel::getOverwriteMode()
+{
+    return overwriteDups;
 }
 
 void CANFrameModel::setClearMode(bool mode)
@@ -342,6 +357,7 @@ void CANFrameModel::sortByColumn(int column)
 
 //End of custom sorting code
 
+// TODO - update this as well?
 void CANFrameModel::recalcOverwrite()
 {
     if (!overwriteDups) return; //no need to do a thing if mode is disabled
@@ -412,7 +428,6 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
 
     thisFrame = filteredFrames.at(index.row());
 
-    const unsigned char *data = reinterpret_cast<const unsigned char *>(thisFrame.payload().constData());
     int dataLen = thisFrame.payload().count();
 
     if (role == Qt::BackgroundRole)
@@ -516,67 +531,7 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
             }
             return tempString;
         case Column::Data:
-            if (dataLen < 0) dataLen = 0;
-            //if (useHexMode) tempString.append("0x ");
-            if (thisFrame.frameType() == QCanBusFrame::RemoteRequestFrame) {
-                return tempString;
-            }
-            for (int i = 0; i < dataLen; i++)
-            {
-                if (useHexMode) tempString.append( QString::number(data[i], 16).toUpper().rightJustified(2, '0'));
-                else tempString.append(QString::number(data[i], 10));
-                if (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) tempString.append("\n");
-                else tempString.append(" ");
-            }
-            if (thisFrame.frameType() == thisFrame.ErrorFrame)
-            {
-                if (thisFrame.error() & thisFrame.TransmissionTimeoutError) tempString.append("\nTX Timeout");
-                if (thisFrame.error() & thisFrame.LostArbitrationError) tempString.append("\nLost Arbitration");
-                if (thisFrame.error() & thisFrame.ControllerError) tempString.append("\nController Error");
-                if (thisFrame.error() & thisFrame.ProtocolViolationError) tempString.append("\nProtocol Violation");
-                if (thisFrame.error() & thisFrame.TransceiverError) tempString.append("\nTransceiver Error");
-                if (thisFrame.error() & thisFrame.MissingAcknowledgmentError) tempString.append("\nMissing ACK");
-                if (thisFrame.error() & thisFrame.BusOffError) tempString.append("\nBus OFF");
-                if (thisFrame.error() & thisFrame.BusError) tempString.append("\nBus ERR");
-                if (thisFrame.error() & thisFrame.ControllerRestartError) tempString.append("\nController restart err");
-                if (thisFrame.error() & thisFrame.UnknownError) tempString.append("\nUnknown error type");
-            }
-            //TODO: technically the actual returned bytes for an error frame encode some more info. Not interpreting it yet.
-
-            //now, if we're supposed to interpret the data and the DBC handler is loaded then use it
-            if ( (dbcHandler != nullptr) && interpretFrames && (thisFrame.frameType() == thisFrame.DataFrame) )
-            {
-                DBC_MESSAGE *msg = dbcHandler->findMessage(thisFrame);
-                if (msg != nullptr)
-                {
-                    tempString.append("   <" + msg->name + ">\n");
-                    if (msg->comment.length() > 1) tempString.append(msg->comment + "\n");
-                    for (int j = 0; j < msg->sigHandler->getCount(); j++)
-                    {                        
-                        QString sigString;
-                        DBC_SIGNAL* sig = msg->sigHandler->findSignalByIdx(j);
-
-                        if ( (sig->multiplexParent == nullptr) && sig->processAsText(thisFrame, sigString))
-                        {
-                            tempString.append(sigString);
-                            tempString.append("\n");
-                            if (sig->isMultiplexor)
-                            {
-                                qDebug() << "Multiplexor. Diving into the tree";
-                                tempString.append(sig->processSignalTree(thisFrame));
-                            }
-                        }
-                        else if (sig->isMultiplexed && overwriteDups) //wasn't in this exact frame but is in the message. Use cached value
-                        {
-                            bool isInteger = false;
-                            if (sig->valType == UNSIGNED_INT || sig->valType == SIGNED_INT) isInteger = true;
-                            tempString.append(sig->makePrettyOutput(sig->cachedValue.toDouble(), sig->cachedValue.toLongLong(), true, isInteger));
-                            tempString.append("\n");
-                        }
-                    }
-                }
-            }
-            return tempString;
+            return QVariant::fromValue(thisFrame);
         default:
             return tempString;
         }
@@ -719,10 +674,20 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
 //        }
         for (int i = 0; i < filteredFrames.count(); i++)
         {
-            if ( (filteredFrames[i].frameId() == tempFrame.frameId()) && (filteredFrames[i].bus == tempFrame.bus) )
+            CANFrame currentFrame = filteredFrames[i];
+            if ( (currentFrame.frameId() == tempFrame.frameId()) && (currentFrame.bus == tempFrame.bus) )
             {
-                tempFrame.frameCount = filteredFrames[i].frameCount + 1;
-                tempFrame.timedelta = tempFrame.timeStamp().microSeconds() - filteredFrames[i].timeStamp().microSeconds();
+                tempFrame.frameCount = currentFrame.frameCount + 1;
+                tempFrame.timedelta = tempFrame.timeStamp().microSeconds() - currentFrame.timeStamp().microSeconds();
+                
+                // Keep track of changed bytes so we can draw them in a different color in CanDataItemDelegate
+                QByteArray curPayload = currentFrame.payload();
+                QByteArray tempPayload = tempFrame.payload();
+
+                for (int i = 0; i < curPayload.size() && i < tempPayload.size(); i++) {
+                    tempFrame.changedPayloadBytes |= (curPayload[i] != tempPayload[i]) << i;
+                }
+
                 filteredFrames.replace(i, tempFrame);
                 found = true;
                 break;

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -46,7 +46,9 @@ public:
     void setInterpretMode(bool);
     bool getInterpretMode();
     void setOverwriteMode(bool);
+    bool getOverwriteMode();
     void setHexMode(bool);
+    bool getHexMode();
     void setClearMode(bool mode);
     void setTimeStyle(TimeStyle newStyle);
     void setIgnoreDBCColors(bool mode);
@@ -55,6 +57,7 @@ public:
     void setAllFilters(bool state);
     void setTimeFormat(QString);
     void setBytesPerLine(int bpl);
+    int getBytesPerLine();
     void loadFilterFile(QString filename);
     void saveFilterFile(QString filename);
     void normalizeTiming();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -9,6 +9,7 @@
 #include "helpwindow.h"
 #include "utility.h"
 #include "filterutility.h"
+#include "candataitemdelegate.h"
 
 /*
 Some notes on things I'd like to put into the program but haven't put on github (yet)
@@ -47,6 +48,9 @@ MainWindow::MainWindow(QWidget *parent) :
     proxyModel->setSourceModel(model);
 
     ui->canFramesView->setModel(proxyModel);
+
+    CanDataItemDelegate* dataColumnFormatter = new CanDataItemDelegate(model);
+    ui->canFramesView->setItemDelegateForColumn(8, dataColumnFormatter);
 
     settingsDialog = new MainSettingsDialog(); //instantiate the settings dialog so it can initialize settings if this is the first run or the config file was deleted.
     settingsDialog->updateSettings(); //write out all the settings. If this is the first run it'll write defaults out.

--- a/utility.h
+++ b/utility.h
@@ -184,6 +184,7 @@ public:
             return (double)timestamp / 1000.0;
             break;
         case TS_MICROS:
+        default:
             return (unsigned long long)(timestamp);
             break;
         case TS_SECONDS:


### PR DESCRIPTION
## Description:
This change introduces a `QItemDelegate` that is used to paint the Data column of the main window's Frames view.  Before the change, the value of the Data column was calculated as a string by `CANFrameModel::data()` and displayed using the default `QStyledItemDelegate`.  In the current version of the changes, the `CANFrame` is returned as Data instead and the parsing and display logic has been moved to `CanDataItemDelegate`.  Most of the structure of the code was maintained, but now it is orchestrating `QPainter` draw calls rather than building up the string representation of the bytes.

There are a lot of ways this solution could be tweaked (improved?).  For example:
-  `CANFrameModel::data()` could parse the CANFrame into a streamlined data type with just the byte data, changed bytes, error message text, and some settings (like bits per line) and return that as a `QVariant` for the delegate to display rather than this design which returns `QVariant::fromValue(CANFrame)` and moves all of the parsing and display logic to the delegate
- Some other data type for the changed bytes bit field
- This implementation uses `CANFrameModel` to read settings in `CanDataItemDelegate` but this coupling could be reduced with another representation
- etc.

Previously discussed as: #84 Color code changed bits in overwrite mode
While working on this, I found this already closed suggestion for the feature.  I agree the sniffer window can be used to show this data, but I've come to like the visual feedback of having byte diffs in overwrite mode.  Feel free to close this PR if you don't want to add this extra complexity to the project.  

### Screenshot
![SavvyCAN-OverwriteDiff](https://github.com/collin80/SavvyCAN/assets/4406149/e7156017-2096-466a-960a-87efad9ac237)
Example of the UI receiving Fuzzed frames using "Sweep" Bit Scanning

### Validated:
- <=8 byte CAN frames generated from Fuzzing window display properly
  - Hex
  - Decimal
- Bytes per line of 4 splits 8 bytes over 2 lines

### Not tested: 
- Error frame messages 
- DBC mapping text
These should probably work, but I couldn't find good example data. Let me know if there is a good example set for validation.

### Notes:
It's been a little while since I've messed around with someone else's C++ codebase and I don't use it professionally atm.  Please let me know if you have feedback (even if trivial).