### PR TITLE
Scripting Interface Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Makefile
 SavvyCAN.pro.qtds
 .xcode
 SavvyCAN.xcodeproj
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "files.associations": {
-        "thread": "cpp",
-        "*.tcc": "cpp",
-        "chrono": "cpp",
-        "algorithm": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "thread": "cpp",
+        "*.tcc": "cpp",
+        "chrono": "cpp",
+        "algorithm": "cpp"
+    }
+}

--- a/scriptingwindow.h
+++ b/scriptingwindow.h
@@ -37,7 +37,9 @@ private slots:
     void deleteCurrentScript();
     void refreshSourceWindow();
     void saveScript();
+    void saveAsScript();
     void revertScript();
+    void reloadScript();
     void recompileScript();
     void changeCurrentScript();
     void newFrames(const CANConnection*, const QVector<CANFrame>&);
@@ -49,6 +51,7 @@ private:
     void closeEvent(QCloseEvent *event);
     void readSettings();
     void writeSettings();
+    void saveLog();
     bool eventFilter(QObject *obj, QEvent *event);
 
     Ui::ScriptingWindow *ui;

--- a/ui/scriptingwindow.ui
+++ b/ui/scriptingwindow.ui
@@ -109,9 +109,23 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="btnSaveAsScript">
+         <property name="text">
+          <string>Sa&amp;ve As</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="btnRevertScript">
          <property name="text">
           <string>&amp;Revert</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnReloadScript">
+         <property name="text">
+          <string>R&amp;eload</string>
          </property>
         </widget>
        </item>
@@ -151,11 +165,26 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnClearLog">
-       <property name="text">
-        <string>Clear Log &amp;Window</string>
-       </property>
-      </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_log">
+            <property name="alignment">
+                <set>Qt::AlignCenter</set>
+            </property>
+            <property name="contentsMargins">10, 0, 10, 0</property>
+            <item>
+                <widget class="QPushButton" name="btnClearLog">
+                    <property name="text">
+                        <string>Clear Log &amp;Window</string>
+                    </property>
+                </widget>
+            </item>
+            <item>
+                <widget class="QPushButton" name="btnSaveLog">
+                    <property name="text">
+                        <string>Save L&amp;og</string>
+                    </property>
+                </widget>
+            </item>
+        </layout>
      </item>
     </layout>
    </item>
@@ -169,10 +198,13 @@
   <tabstop>listLoadedScripts</tabstop>
   <tabstop>tableVariables</tabstop>
   <tabstop>btnSaveScript</tabstop>
+  <tabstop>btnSaveAsScript</tabstop>
   <tabstop>btnRevertScript</tabstop>
+  <tabstop>btnReloadScript</tabstop>
   <tabstop>btnRecompile</tabstop>
   <tabstop>cbAutoScroll</tabstop>
   <tabstop>btnClearLog</tabstop>
+  <tabstop>btnSaveLog</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Enhancements to the scripting interface to improve usability

1. Added a "Save As" button which does what "Save" used to do (prompt for a filename and save to it) and changed "Save" to write to the filename we already know for the current script. This makes saving as you work easier, and still allows making a copy if you don't want to overwrite the original
2. Added a "Reload" button that reloads the script from disk (prompting for verification) and then recompiles it. This makes it easy to use an external editor and just reload in SavvyCAN (otherwise you have to delete/load)
3. Added a "Save Log" button to save the current log window contents to a file

All buttons are in the tab order/index and have quick keys.