### PR TITLE
Do not add extra trailing newline on the decoded message texts

### DIFF
--- a/dbc/dbc_classes.cpp
+++ b/dbc/dbc_classes.cpp
@@ -76,12 +76,16 @@ QString DBC_SIGNAL::processSignalTree(const CANFrame &frame)
             if (sig->processAsText(frame, sigString))
             {
                 qDebug() << "Returned value: " << sigString;
+                if (!build.isEmpty() && !sigString.isEmpty())
+                    build.append("\n");
                 build.append(sigString);
-                build.append("\n");
                 if (sig->isMultiplexor)
                 {
                     qDebug() << "Spelunkin!";
-                    build.append(sig->processSignalTree(frame));
+                    auto subTreeString = sig->processSignalTree(frame);
+                    if (!build.isEmpty() && !subTreeString.isEmpty())
+                        build.append("\n");
+                    build.append(subTreeString);
                 }
             }
         }


### PR DESCRIPTION
These extra newlines could consume a lot of screen estate if multiple rows are "highlighted":
![kép](https://github.com/collin80/SavvyCAN/assets/1609182/5675cabd-1d00-47dd-ac27-9302562ca3c9)
so I added some logic to remove them.