### PR TITLE
Update required C++ standard to C++17

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -8,7 +8,7 @@ QT = core gui printsupport qml serialbus serialport widgets help network opengl
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
 
-CONFIG += c++11
+CONFIG += c++17
 CONFIG += NO_UNIT_TESTS
 
 DEFINES += QCUSTOMPLOT_USE_OPENGL

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -551,6 +551,7 @@ void LAWICELSerial::readSerialData()
                 break;
             case 'b':
                 buildFrame.setBitrateSwitch(true); //BRS enabled
+                [[fallthrough]];
             case 'd': //standard fd frame, BRS disabled
                 //tIIILDD
                 buildFrame.setFlexibleDataRateFormat(true);
@@ -581,6 +582,7 @@ void LAWICELSerial::readSerialData()
                 break;
             case 'B':
                 buildFrame.setBitrateSwitch(true); //BRS enabled
+                [[fallthrough]];
             case 'D': //extended fd frame
                 //TIIIIIIIILDD.
                 buildFrame.setFlexibleDataRateFormat(true);


### PR DESCRIPTION
I have updated project properties, because there are a few `[[fallthrough]]` attributes in the code, that requires support of C++17.

Also I fixed gcc complains about it in the Lawicel protocol.

I hope in 2024 all alive compilers able to support it ;-)