### PR TITLE
ConnectionWindow: fix Device Console duplicates

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -79,12 +79,12 @@ ConnectionWindow::ConnectionWindow(QWidget *parent) :
     //Need to make sure it tries to share the address in case there are
     //multiple instances of SavvyCAN running.
     rxBroadcastGVRET->bind(QHostAddress::AnyIPv4, 17222, QAbstractSocket::ShareAddress);
-    connect(rxBroadcastGVRET, SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()));
+    connect(rxBroadcastGVRET, &QUdpSocket::readyRead, this, &ConnectionWindow::readPendingDatagrams);
 
     //Doing the same for socketcand/kayak hosts:
     rxBroadcastKayak = new QUdpSocket(this);
     rxBroadcastKayak->bind(QHostAddress::AnyIPv4, 42000, QAbstractSocket::ShareAddress);
-    connect(rxBroadcastKayak, SIGNAL(readyRead()), this, SLOT(readPendingDatagrams()));
+    connect(rxBroadcastKayak, &QUdpSocket::readyRead, this, &ConnectionWindow::readPendingDatagrams);
 
 }
 
@@ -236,12 +236,12 @@ void ConnectionWindow::consoleEnableChanged(bool checked) {
     CANConnection* conn_p = connModel->getAtIdx(selIdx);
 
     if (checked) { //enable console
-        connect(conn_p, SIGNAL(debugOutput(QString)), this, SLOT(getDebugText(QString)));
-        connect(this, SIGNAL(sendDebugData(QByteArray)), conn_p, SLOT(debugInput(QByteArray)));
+        connect(conn_p, &CANConnection::debugOutput, this, &ConnectionWindow::getDebugText, Qt::UniqueConnection);
+        connect(this, &ConnectionWindow::sendDebugData, conn_p, &CANConnection::debugInput, Qt::UniqueConnection);
     }
     else { //turn it off
-        disconnect(conn_p, SIGNAL(debugOutput(QString)), nullptr, nullptr);
-        disconnect(this, SIGNAL(sendDebugData(QByteArray)), conn_p, SLOT(debugInput(QByteArray)));
+        disconnect(conn_p, &CANConnection::debugOutput, nullptr, nullptr);
+        disconnect(this, &ConnectionWindow::sendDebugData, conn_p, &CANConnection::debugInput);
     }
 }
 
@@ -454,8 +454,8 @@ void ConnectionWindow::currentRowChanged(const QModelIndex &current, const QMode
     int selIdx = current.row();
     CANConnection* prevConn = connModel->getAtIdx(previous.row());
     if(prevConn != nullptr)
-        disconnect(prevConn, SIGNAL(debugOutput(QString)), nullptr, nullptr);
-    disconnect(this, SIGNAL(sendDebugData(QByteArray)), nullptr, nullptr);
+        disconnect(prevConn, &CANConnection::debugOutput, nullptr, nullptr);
+    disconnect(this, &ConnectionWindow::sendDebugData, nullptr, nullptr);
 
     /* set parameters */
     if (selIdx == -1) {
@@ -472,7 +472,7 @@ void ConnectionWindow::currentRowChanged(const QModelIndex &current, const QMode
         if(!conn_p) return;
 
         //because this might have already been setup during the initial setup so tear that one down and then create the normal one.
-        //disconnect(conn_p, SIGNAL(debugOutput(QString)), 0, 0);
+        //disconnect(conn_p, &CANConnection::debugOutput, 0, 0);
 
         numBuses = conn_p->getNumBuses();
         int numB = ui->tabBuses->count();
@@ -485,8 +485,8 @@ void ConnectionWindow::currentRowChanged(const QModelIndex &current, const QMode
         populateBusDetails(0);
         if (ui->ckEnableConsole->isChecked())
         {
-            connect(conn_p, SIGNAL(debugOutput(QString)), this, SLOT(getDebugText(QString)));
-            connect(this, SIGNAL(sendDebugData(QByteArray)), conn_p, SLOT(debugInput(QByteArray)));
+            connect(conn_p, &CANConnection::debugOutput, this, &ConnectionWindow::getDebugText, Qt::UniqueConnection);
+            connect(this, &ConnectionWindow::sendDebugData, conn_p, &CANConnection::debugInput, Qt::UniqueConnection);
         }
     }
 }
@@ -524,12 +524,11 @@ CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QS
     if(conn_p)
     {
         /* connect signal */
-        connect(conn_p, SIGNAL(status(CANConStatus)),
-                this, SLOT(connectionStatus(CANConStatus)));
+        connect(conn_p, &CANConnection::status, this, &ConnectionWindow::connectionStatus);
         if (ui->ckEnableConsole->isChecked())
         {            
             //set up the debug console to operate if we've selected it. Doing so here allows debugging right away during set up
-            connect(conn_p, SIGNAL(debugOutput(QString)), this, SLOT(getDebugText(QString)));
+            connect(conn_p, &CANConnection::debugOutput, this, &ConnectionWindow::getDebugText, Qt::UniqueConnection);
         }
         /*TODO add return value and checks */
         conn_p->start();


### PR DESCRIPTION
In some cases connection between `CANConnection::debugOutput` and `ConnectionWindow::getDebugText` can be requested several times, that lead to string duplication in the window (for example, #713).
Easiest way to fix it - declare connection as unique.