### PR TITLE
fix compilation under Qt 6.6

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -257,7 +257,7 @@ uint64_t CANFrameModel::getCANFrameVal(QVector<CANFrame> *frames, int row, Colum
         return static_cast<uint64_t>(frame.payload().length());
     case Column::ASCII: //sort both the same for now
     case Column::Data:
-        for (int i = 0; i < std::min(frame.payload().length(), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
+        for (int i = 0; i < std::min(static_cast<int>(frame.payload().length()), 8); i++) temp += (static_cast<uint64_t>(frame.payload()[i]) << (56 - (8 * i)));
         //qDebug() << temp;
         return temp;
     case Column::NUM_COLUMN:

--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -388,6 +388,7 @@ void LAWICELSerial::serialError(QSerialPort::SerialPortError err)
         killConnection = true;
         piStop();
         break;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     case QSerialPort::ParityError:
         errMessage = "Parity error on serial port";
         break;
@@ -397,6 +398,7 @@ void LAWICELSerial::serialError(QSerialPort::SerialPortError err)
     case QSerialPort::BreakConditionError:
         errMessage = "Break error on serial port";
         break;
+#endif
     case QSerialPort::WriteError:
         errMessage = "Write error on serial port";
         piStop();
@@ -486,7 +488,7 @@ void LAWICELSerial::readSerialData()
         //qDebug() << c << "    " << QString::number(c, 16) << "     " << QString(c);
         debugBuild = debugBuild % QString::number(c, 16).rightJustified(2,'0') % " ";
         //procRXChar(c);
-        mBuildLine.append(c);
+        mBuildLine.append(static_cast<char>(c));
         if (c == 13) //all lawicel commands end in CR
         {
             qDebug() << "Got CR!";

--- a/re/graphingwindow.cpp
+++ b/re/graphingwindow.cpp
@@ -782,7 +782,7 @@ void GraphingWindow::saveSpreadsheet()
         for (auto && graph : graphParams) {
             xMin = std::min(xMin, graph.x[0]);
             xMax = std::max(xMax, graph.x[graph.x.count() - 1]);
-            maxCount = std::max(maxCount, graph.x.count());
+            maxCount = std::max(maxCount, static_cast<int>(graph.x.count()));
         }
         qDebug() << "xMin: " << xMin;
         qDebug() << "xMax: " << xMax;


### PR DESCRIPTION
fix: few static cast call to pass simple errors
comp: conditional compilation for version 6+ removing deprecated ```QSerialPort``` error types