### PR TITLE
make qmake check Qt version

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -4,6 +4,10 @@
 #
 #-------------------------------------------------
 
+!versionAtLeast(QT_VERSION, 5.14.0) {
+    error("Current version of Qt ($${QT_VERSION}) is too old, this project requires Qt 5.14 or newer")
+}
+
 QT = core gui printsupport qml serialbus serialport widgets help network opengl
 
 CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT


### PR DESCRIPTION
This provides a more helpful compile-time error
message, hopefully preventing issues like #727
(https://github.com/collin80/SavvyCAN/issues/727).