### PR TITLE
signal makePrettyOutput: add a space between value and unit

### DIFF
--- a/dbc/dbc_classes.cpp
+++ b/dbc/dbc_classes.cpp
@@ -214,12 +214,12 @@ QString DBC_SIGNAL::makePrettyOutput(double floatVal, int64_t intVal, bool outpu
             }
         }
         if (!foundVal) outputString += QString::number(intVal);
-        if (outputUnit) outputString += unitName;
+        if (outputUnit) outputString += " " + unitName;
     }
     else //otherwise display the actual number and unit (if it exists)
     {
        outputString += (isInteger ? QString::number(intVal) : QString::number(floatVal));
-       if (outputUnit) outputString += unitName;
+       if (outputUnit) outputString += " " + unitName;
     }
     return outputString;
 }


### PR DESCRIPTION
Instead of rendering as "45Celsius" it now renders as "45 Celsius".

Before:
![Screenshot from 2024-06-18 13-52-30](https://github.com/collin80/SavvyCAN/assets/400548/838576aa-8f24-4345-9fa6-60cb9ee449ae)

After:
![Screenshot from 2024-06-18 13-57-11](https://github.com/collin80/SavvyCAN/assets/400548/50633d00-ab00-49da-8eee-dfc616092f42)
