### PR TITLE
Fix device deselection after connecting

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -336,7 +336,9 @@ void ConnectionWindow::connectionStatus(CANConStatus pStatus)
     Q_UNUSED(pStatus);
 
     qDebug() << "Connectionstatus changed";
+    int selIdx = ui->tableConnections->selectionModel()->currentIndex().row();
     connModel->refresh();
+    ui->tableConnections->selectRow(selIdx);
 }
 
 void ConnectionWindow::setSuspendAll(bool pSuspend)


### PR DESCRIPTION
By following these steps:

1. Connect to device through Connection -> Add New Device Connection
2. Wait until device is connected
3. Change baudrate
4. Save Bus Settings

The changes would not persist, and you would need to change baudrate again.
This was happening because after running `connModel->refresh();`, the selection of `ui->tableConnections` would be lost.