### PR TITLE
Fix socketcand connection unexpectedly reconnecting;

### DIFF
--- a/connections/newconnectiondialog.cpp
+++ b/connections/newconnectiondialog.cpp
@@ -200,7 +200,7 @@ void NewConnectionDialog::selectRemote()
 
 void NewConnectionDialog::selectKayak()
 {
-    ui->lPort->setText("Available Bus(ses):");
+    ui->lPort->setText("Available Bus(<bus,...>@can://<ip>:<port>):");
 
     ui->lblDeviceType->setHidden(true);
     ui->cbDeviceType->setHidden(true);

--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -53,6 +53,19 @@ SocketCANd::SocketCANd(QString portName) :
 SocketCANd::~SocketCANd()
 {
     stop();
+    for (int i = 0; i < tcpClient.length(); i++)
+    {
+        if (tcpClient[i])
+        {
+            if (tcpClient[i]->isOpen())
+            {
+                tcpClient[i]->close();
+            }
+            tcpClient[i]->disconnect();
+            delete tcpClient[i];
+            tcpClient[i] = nullptr;
+        }
+    }
     tcpClient.clear();
     sendDebug("~SocketCANd()");
 }
@@ -354,7 +367,6 @@ void SocketCANd::disconnectDevice() {
             tcpClient[i] = nullptr;
         }
     }
-
 
     setStatus(CANCon::NOT_CONNECTED);
     CANConStatus stats;


### PR DESCRIPTION
When socketcand reconnecting, it will always failed because not reset socketcand mode.
At the same time, a strange problem that required adding ")" at the end of bus to work was removed.