### PR TITLE
Add support for > 8 bytes per message in candump format

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - "master"
-      
+  workflow_dispatch:
 jobs:
   buildlinux:
     name: Linux x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-  workflow_dispatch:
 jobs:
   buildlinux:
     name: Linux x64

--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -3784,12 +3784,17 @@ bool FrameFileIO::loadCanDumpFile(QString filename, QVector<CANFrame>* frames)
             if (line.contains('[')) //the expanded format (second one from the above list)
             {
                 //(1551774790.942758) can1 7A8 [8] F4 DC D1 83 0E 02 00 00
+                //(1551774790.942758) can1 7A8 [08] F4 DC D1 83 0E 02 00 00
                 //     0               1     2   3  4 5  6  7  8  9  10 11
                 thisFrame.setFrameId(tokens[2].toLong(nullptr, 16));
                 if (thisFrame.frameId() > 0x7FF) thisFrame.setExtendedFrameFormat(true);
                 else thisFrame.setExtendedFrameFormat(false);
                 thisFrame.setFrameType(QCanBusFrame::DataFrame);
-                int numBytes = tokens[3].at(1) - '0';
+                int numBytes;
+		if (tokens[3].at(2) == ']')
+		    numBytes = tokens[3].at(1) - '0';
+		else
+		    numBytes = (tokens[3].at(1) - '0')*10 + (tokens[3].at(2) - '0');
                 QByteArray bytes(numBytes, 0);
                 for (int c = 0; c < numBytes; c++)
                 {


### PR DESCRIPTION
I have a candump log with the following data:
 (1727438342.368435)  can0       0C0  [32]  03 F5 FE E7 FF 10 27 00 E0 FF FF F3 3F FF F3 3F FC EF FF FD FF FF FE 07 00 00 00 00 00 00 00 00
 (1727438342.372671)  can0       583  [08]  00 00 80 00 10 40 40 40

The current candump parser only looks at the first number after the [ character. 