### PR TITLE
Corrected extended CAN ID read for IDs < 0x800

### DIFF
--- a/connections/canconfactory.cpp
+++ b/connections/canconfactory.cpp
@@ -14,7 +14,7 @@ CANConnection* CanConFactory::create(type pType, QString pPortName, QString pDri
 {
     switch(pType) {
     case SERIALBUS:
-        return new SerialBusConnection(pPortName, pDriverName);
+      return new SerialBusConnection(pPortName, pDriverName, pBusSpeed, pDataRate, pCanFd);
     case GVRET_SERIAL:
         if(pPortName.contains(".") && !pPortName.contains("tty") && !pPortName.contains("serial"))
         return new GVRetSerial(pPortName, true);

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -41,8 +41,13 @@ CANConnection::CANConnection(QString pPort,
 
     if (pBusSpeed > 0) mBusData[0].mBus.setSpeed(pBusSpeed);
     mBusData[0].mBus.setCanFD(pCanFd);
-    if (pDataRate > 0) mBusData[0].mBus.setDataRate(pDataRate);
-
+    if (pDataRate > 0) {
+      mBusData[0].mBus.setDataRate(pDataRate);
+      if (pCanFd) {
+	mBusData[0].mBus.setCanFD(pCanFd);
+      }
+    }
+ 
     /* if needed, create a thread and move ourself into it */
     if(pUseThread) {
         mThread_p = new QThread();
@@ -208,6 +213,10 @@ bool CANConnection::sendFrames(const QList<CANFrame>& pFrames)
 
 int CANConnection::getNumBuses() const{
     return mNumBuses;
+}
+
+int CANConnection::getSerialSpeed() const{
+  return mSerialSpeed;
 }
 
 

--- a/connections/canconnection.h
+++ b/connections/canconnection.h
@@ -53,6 +53,12 @@ public:
     int getNumBuses() const;
 
     /**
+     * @brief getserialSpeed
+     * @return returns the serial speed of the device
+     */
+    int getSerialSpeed() const;
+
+    /**
      * @brief getPort
      * @return returns the port name of the device
      */

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -551,13 +551,17 @@ void ConnectionWindow::loadConnections()
     QVector<QString> driverNames = settings.value("connections/driverNames").value<QVector<QString>>();
     QVector<int>    devTypes = settings.value("connections/types").value<QVector<int>>();
 
+    QVector<int> busSpeeds = settings.value("connections/busSpeeds_0").value<QVector<int>>();
+    QVector<int> DataRates = settings.value("connections/DataRates_0").value<QVector<int>>();
+    QVector<int> isCanFds = settings.value("connections/isCanFds_0").value<QVector<int>>();
+    QVector<int> serialSpeeds = settings.value("connections/serialSpeeds").value<QVector<int>>();
     //don't load the connections if the three setting arrays above aren't all the same size.
-    if (portNames.count() != driverNames.count() || devTypes.count() != driverNames.count()) return;
+    if (portNames.count() != driverNames.count() || devTypes.count() != driverNames.count() ||  busSpeeds.count() != driverNames.count() || isCanFds.count() != driverNames.count() ||
+	DataRates.count() != driverNames.count() || serialSpeeds.count() != driverNames.count() ) return;
 
     for(int i = 0 ; i < portNames.count() ; i++)
     {
-        //TODO: add serial speed and bus speed to this properly.
-        CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], 0, 0, false, 0);
+      CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], serialSpeeds[i], busSpeeds[i], isCanFds[i] ? true : false, DataRates[i]);
         /* add connection to model */
         connModel->add(conn_p);
     }
@@ -577,10 +581,19 @@ void ConnectionWindow::saveConnections()
     QVector<QString> driverNames;
     QVector<int> serialSpeeds;
     QVector<int> busSpeeds;
-
+    QVector<int> DataRates;
+    QVector<int> CanFds;
+ 
     /* save connections */
     foreach(CANConnection* conn_p, conns)
-    {
+      { CANBus bus;
+
+        if (conn_p->getBusSettings(0, bus)) {
+          busSpeeds.append(bus.getSpeed());
+	  CanFds.append(bus.isCanFD() ? 1 : 0);
+	  DataRates.append(bus.getDataRate());
+        }
+	serialSpeeds.append(conn_p->getSerialSpeed());
         portNames.append(conn_p->getPort());
         devTypes.append(conn_p->getType());
         driverNames.append(conn_p->getDriver());
@@ -589,6 +602,10 @@ void ConnectionWindow::saveConnections()
     settings.setValue("connections/portNames", QVariant::fromValue(portNames));
     settings.setValue("connections/types", QVariant::fromValue(devTypes));
     settings.setValue("connections/driverNames", QVariant::fromValue(driverNames));
+    settings.setValue("connections/busSpeeds_0", QVariant::fromValue(busSpeeds));
+    settings.setValue("connections/isCanFds_0", QVariant::fromValue(CanFds)); 
+    settings.setValue("connections/DataRates_0", QVariant::fromValue(DataRates)); 
+    settings.setValue("connections/serialSpeeds", QVariant::fromValue(serialSpeeds)); 
 }
 
 void ConnectionWindow::moveConnUp()

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -11,8 +11,8 @@
 /****    class definition       ****/
 /***********************************/
 
-SerialBusConnection::SerialBusConnection(QString portName, QString driverName) :
-    CANConnection(portName, driverName, CANCon::SERIALBUS,0 ,0, false, 0 ,1, 4000, true),
+SerialBusConnection::SerialBusConnection(QString portName, QString driverName, int pBusSpeed, int pDataRate, bool pCanFd) :
+    CANConnection(portName, driverName, CANCon::SERIALBUS,0 ,pBusSpeed, pCanFd, pDataRate ,1, 4000, true),
     mTimer(this) /*NB: set connection as parent of timer to manage it from working thread */
 {
 }

--- a/connections/serialbusconnection.h
+++ b/connections/serialbusconnection.h
@@ -27,7 +27,8 @@ class SerialBusConnection : public CANConnection
     Q_OBJECT
 
 public:
-    SerialBusConnection(QString portName, QString driverName);
+  SerialBusConnection(QString portName, QString driverName, int pBusSpeed,
+		      int pDataRate, bool pCanFd);
     virtual ~SerialBusConnection();
 
 protected:

--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -1454,7 +1454,8 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         QByteArray bytes(numBytes, 0);
                         thisFrame.isReceived = true;
                         thisFrame.bus = 0;
-                        if (thisFrame.frameId() > 0x10000000)
+                        if ((thisFrame.frameId() > 0x10000000) ||
+			    (tokens[3].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1506,7 +1507,8 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = tokens[2].toInt();
-                        if (thisFrame.frameId() > 0x10000000)
+                        if ((thisFrame.frameId() > 0x10000000) ||
+			    (tokens[4].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1548,7 +1550,8 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = 0;
-                        if (thisFrame.frameId() > 0x10000000)
+                        if ((thisFrame.frameId() > 0x10000000) ||
+			    (tokens[3].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1600,7 +1603,8 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = tokens[3].toInt();
-                        if (thisFrame.frameId() > 0x10000000)
+                        if ((thisFrame.frameId() > 0x10000000) ||
+			    (tokens[4].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }


### PR DESCRIPTION
I found a bug that analyzed and saved CAN frames that are extended frames in real but with ids in the standard id range as shorted standard frames only.
This has been corrected here for all available PCAN file reads.
