### PR TITLE
Use 'resize' to specify QByteArray buffer size in Qt6.

### DIFF
--- a/connections/lawicel_serial.cpp
+++ b/connections/lawicel_serial.cpp
@@ -180,6 +180,10 @@ bool LAWICELSerial::piSendFrame(const CANFrame& frame)
             buildStr = QString::asprintf("t%03X%u", ID, static_cast<unsigned int>(frame.payload().length()));
         }
     }
+
+    int neededSize = buildStr.length() + (frame.payload().length() * 2) + 1;  // +1 for CR
+    buffer.resize(neededSize);
+
     foreach (QChar chr, buildStr)
     {
         buffer[idx] = chr.toLatin1();


### PR DESCRIPTION
Use 'resize' to specify QByteArray buffer size in Qt6 to avoid
```bash
ASSERT: "n <= d.size - pos" in file /opt/homebrew/include/QtCore/qbytearray.h, line 571
```
when sending frame with 'slcan' devices.
buffer.append() or buffer.resize()
https://github.com/collin80/SavvyCAN/issues/922#issuecomment-2856881576