### PR TITLE
Fix reading PCAN-View frames with empty data field

### DIFF
--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -1454,8 +1454,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         QByteArray bytes(numBytes, 0);
                         thisFrame.isReceived = true;
                         thisFrame.bus = 0;
-                        if ((thisFrame.frameId() > 0x10000000) ||
-			    (tokens[3].length() >= 8))
+                        if ((thisFrame.frameId() > 0x10000000) || (tokens[3].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1464,7 +1463,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                             thisFrame.setExtendedFrameFormat(false);
                         }
 
-                        if (tokens[5] == "R")
+                        if (tokens.value(5) == "R") // might be empty!
                         {
                             thisFrame.setFrameType(QCanBusFrame::RemoteRequestFrame);
                         }
@@ -1507,8 +1506,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = tokens[2].toInt();
-                        if ((thisFrame.frameId() > 0x10000000) ||
-			    (tokens[4].length() >= 8))
+                        if ((thisFrame.frameId() > 0x10000000) || (tokens[4].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1516,7 +1514,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         {
                             thisFrame.setExtendedFrameFormat(false);
                         }
-                        if (tokens[7] == "R")
+                        if (tokens.value(7) == "R")
                         {
                             thisFrame.setFrameType(QCanBusFrame::RemoteRequestFrame);
                         }
@@ -1550,8 +1548,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = 0;
-                        if ((thisFrame.frameId() > 0x10000000) ||
-			    (tokens[3].length() >= 8))
+                        if ((thisFrame.frameId() > 0x10000000) || (tokens[3].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1559,7 +1556,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         {
                             thisFrame.setExtendedFrameFormat(false);
                         }
-                        if (tokens[6] == "R")
+                        if (tokens.value(6) == "R")
                         {
                             thisFrame.setFrameType(QCanBusFrame::RemoteRequestFrame);
                         }
@@ -1603,8 +1600,7 @@ bool FrameFileIO::loadPCANFile(QString filename, QVector<CANFrame>* frames)
                         //qDebug() << thisFrame.payload().length();
                         thisFrame.isReceived = true;
                         thisFrame.bus = tokens[3].toInt();
-                        if ((thisFrame.frameId() > 0x10000000) ||
-			    (tokens[4].length() >= 8))
+                        if ((thisFrame.frameId() > 0x10000000) || (tokens[4].length() >= 8))
                         {
                             thisFrame.setExtendedFrameFormat(true);
                         }
@@ -1646,10 +1642,7 @@ bool FrameFileIO::isCanalyzerASC(QString filename)
 {
     QFile *inFile = new QFile(filename);
     QByteArray line;
-    //int lineCounter = 0;
-    //bool inHeader = true;
     bool isMatch = true;
-    QList<QByteArray> tokens;
 
     if (!inFile->open(QIODevice::ReadOnly | QIODevice::Text))
     {
@@ -2576,7 +2569,6 @@ bool FrameFileIO::loadLogFile(QString filename, QVector<CANFrame>* frames)
     QFile *inFile = new QFile(filename);
     CANFrame thisFrame;
     QByteArray line;
-    uint64_t timeStamp = Utility::GetTimeMS();
     int lineCounter = 0;
     bool foundErrors = false;
 
@@ -2604,7 +2596,7 @@ bool FrameFileIO::loadLogFile(QString filename, QVector<CANFrame>* frames)
             if (tokens.length() >= 6)
             {
                 QList<QByteArray> timeToks = tokens[0].split(':');
-                timeStamp = (timeToks[0].toUInt() * (1000ul * 1000ul * 60ul * 60ul)) + (timeToks[1].toUInt() * (1000ul * 1000ul * 60ul))
+                uint64_t timeStamp = (timeToks[0].toUInt() * (1000ul * 1000ul * 60ul * 60ul)) + (timeToks[1].toUInt() * (1000ul * 1000ul * 60ul))
                       + (timeToks[2].toUInt() * (1000ul * 1000ul)) + (timeToks[3].toUInt() * 100ul);
                 thisFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, timeStamp));
                 if (tokens[1].at(0) == 'R') thisFrame.isReceived = true;


### PR DESCRIPTION
I found an issue with PCAN-View logs.

GMLAN (can bus in the GM vehicles) contains a lot of frames without data, that cannot be read back from PCAN log

A real world sample:

30 - empty frame
31 - standard one
```
;$FILEVERSION=1.1
...
    30)      3769.9  Rx     0FFFE0C0  0  
    31)      3773.1  Rx     10002040  4  09 01 35 72 
```

There are a few codestyle fixes as well. It was hard for me with so many lines underlined with yellow, sorry for that ;-)