### PR TITLE
Fixed addmultiplexrange

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -463,9 +463,7 @@ DBC_SIGNAL* DBCFile::parseSignalLine(QString line, DBC_MESSAGE *msg)
     DBC_SIGNAL *sig;
 
     sig = new DBC_SIGNAL();
-
-    sig->multiplexLowValue = 0;
-    sig->multiplexHighValue = 0;
+    sig->addMultiplexRange(0, 0);
     sig->isMultiplexed = false;
     sig->isMultiplexor = false;
 


### PR DESCRIPTION
Fixed addmultiplexrange in DBC_SIGNAL
I found it after getting the following build error:

> dbc/dbchandler.cpp:467:10: error: ‘class DBC_SIGNAL’ has no member named ‘multiplexLowValue’
