### PR TITLE
DBC filter labeling attribute wrong name

### DIFF
--- a/dbc/dbcloadsavewindow.cpp
+++ b/dbc/dbcloadsavewindow.cpp
@@ -362,7 +362,7 @@ void DBCLoadSaveWindow::cellChanged(int row, int col)
                 attr.enumVals.clear();
                 attr.lower = 0;
                 attr.upper = 0;
-                attr.name = "labelfilters";
+                attr.name = "filterlabeling";
                 attr.valType = ATTR_INT;
                 file->dbc_attributes.append(attr);
                 file->messageHandler->setFilterLabeling(labelFilters);


### PR DESCRIPTION
Wrong name for 'filterlabeling' attribute leads to junk in some cases:

```
BA_DEF_ BO_ "GenMsgBackgroundColor" STRING ;
BA_DEF_ BO_ "GenMsgForegroundColor" STRING ;
BA_DEF_ BO_ "labelfilters" INT 0 0;
BA_DEF_ BO_ "labelfilters" INT 0 0;
BA_DEF_ BO_ "labelfilters" INT 0 0;
BA_DEF_DEF_ "GenMsgBackgroundColor" "#ffffff";
BA_DEF_DEF_ "GenMsgForegroundColor" "#000000";
BA_DEF_DEF_ "labelfilters" 1;
BA_DEF_DEF_ "labelfilters" 0;
BA_DEF_DEF_ "labelfilters" 1;
```

can be reproduced on master branch as well.