### PR TITLE
UDS scanner reply offset

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -155,6 +155,7 @@ HEADERS  += mainwindow.h \
     scriptingwindow.h \
     scriptcontainer.h \
     canfilter.h \
+    utils/HexSpinBox.h \
     utils/lfqueue.h \
     motorcontrollerconfigwindow.h \
     connections/canconnection.h \

--- a/re/udsscanwindow.cpp
+++ b/re/udsscanwindow.cpp
@@ -132,6 +132,7 @@ void UDSScanWindow::displayScanEntry(int idx)
     ui->spinStartID->setValue(currEditEntry->startID);
     ui->spinEndID->setValue(currEditEntry->endID);
     ui->spinReplyOffset->setValue(currEditEntry->idOffset);
+    ui->spinReplyOffset->setEnabled(!currEditEntry->bAdaptiveOffset);
     ui->cbAllowAdaptiveOffset->setChecked(currEditEntry->bAdaptiveOffset);
     ui->ckShowNoReply->setChecked(currEditEntry->bShowNoReplies);
     ui->cbBuses->setCurrentIndex(currEditEntry->busToScan);

--- a/ui/udsscanwindow.ui
+++ b/ui/udsscanwindow.ui
@@ -191,18 +191,21 @@
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="spinReplyOffset">
+        <widget class="HexSpinBox" name="spinReplyOffset">
          <property name="enabled">
           <bool>false</bool>
          </property>
          <property name="minimum">
-          <number>-128</number>
+          <number>-1024</number>
          </property>
          <property name="maximum">
-          <number>128</number>
+          <number>1024</number>
          </property>
          <property name="value">
           <number>8</number>
+         </property>
+         <property name="displayIntegerBase">
+          <number>16</number>
          </property>
         </widget>
        </item>
@@ -493,6 +496,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HexSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>utils/HexSpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>spinStartID</tabstop>
   <tabstop>spinEndID</tabstop>

--- a/utils/HexSpinBox.h
+++ b/utils/HexSpinBox.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QSpinBox>
+
+
+class HexSpinBox : public QSpinBox {
+
+public:
+    HexSpinBox(QWidget * parent = nullptr) :
+        QSpinBox(parent)
+    {
+        setDisplayIntegerBase(16);
+    }
+
+protected:
+    // this magic is needed to place minus sign BEFORE '0x' prefix
+    QString textFromValue(int value) const override
+    {
+        QString text = QString::number(qAbs(value), 16);
+        if (value < 0) return "-0x" + text;
+        else return "0x" + text;
+    }
+
+};


### PR DESCRIPTION
As was discussed in #945, UDS reply may have some significant offset.

Improved the range, and made a custom spinbox widget (standard one cannot display negative values in hex).