### PR TITLE
fix: Add support for boolean attribute values in DBC file saving

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -1426,6 +1426,9 @@ bool DBCFile::saveFile(QString fileName)
                     case QVariant::Type::String:
                         attrValOutput.append("\"" + val.value.toString() + "\";\n");
                         break;
+                    case QVariant::Type::Bool:
+                        attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
+                        break;
                     default:
                         attrValOutput.append(val.value.toString() + ";\n");
                         break;
@@ -1470,6 +1473,9 @@ bool DBCFile::saveFile(QString fileName)
                 {
                 case QVariant::Type::String:
                     attrValOutput.append("\"" + val.value.toString() + "\";\n");
+                    break;
+                case QVariant::Type::Bool:
+                    attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
                     break;
                 default:
                     attrValOutput.append(val.value.toString() + ";\n");
@@ -1548,6 +1554,9 @@ bool DBCFile::saveFile(QString fileName)
                     {
                     case QVariant::Type::String:
                         attrValOutput.append("\"" + val.value.toString() + "\";\n");
+                        break;
+                    case QVariant::Type::Bool:
+                        attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
                         break;
                     default:
                         attrValOutput.append(val.value.toString() + ";\n");


### PR DESCRIPTION
Fixed the boolean values saving by adding this type check on save, as discussed on #954 

