### PR TITLE
Refactor and unit test for uds isotp handler -- branch qt6wip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,234 @@
+cmake_minimum_required(VERSION 3.21)
+project(SavvyCAN VERSION 1.0 LANGUAGES C CXX)
+
+set(QT_MIN_VERSION 6.4)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC_SEARCH_PATHS ${CMAKE_CURRENT_SOURCE_DIR}/ui)
+
+option(USE_DBUS "Enable DBus support" OFF)
+option(BUILD_TESTS "Build test target" OFF)
+option(USE_SANITIZER "Enable sanitizers for Debug builds" OFF)
+
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Gui PrintSupport SerialBus SerialPort Widgets Help Network OpenGL Qml)
+find_package(OpenGL REQUIRED)
+
+if(Qt6_VERSION VERSION_LESS ${QT_MIN_VERSION})
+    message(FATAL_ERROR "Qt version ${Qt6_VERSION} found, but ${QT_MIN_VERSION} or higher is required")
+endif()
+
+# Function for setting debug and sanitizer flags
+function(set_debug_sanitizer_options target_name)
+    if(CMAKE_BUILD_TYPE STREQUAL Debug)
+        target_compile_options(${target_name} PRIVATE -Wall -Wextra -g -O0)
+        if(USE_SANITIZER)
+            target_compile_options(${target_name} PRIVATE -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer)
+            target_link_options(${target_name} PRIVATE -fsanitize=address -fsanitize=undefined)
+        endif()
+    endif()
+endfunction()
+
+if(USE_DBUS AND UNIX AND NOT APPLE)
+    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS DBus)
+endif()
+
+qt_standard_project_setup()
+
+qt_add_executable(SavvyCAN WIN32 MACOSX_BUNDLE
+    bisectwindow.cpp bisectwindow.h
+    blfhandler.cpp blfhandler.h
+    bus_protocols/isotp_handler.cpp bus_protocols/isotp_handler.h
+    bus_protocols/isotp_message.h
+    bus_protocols/j1939_handler.cpp bus_protocols/j1939_handler.h
+    bus_protocols/uds_handler.cpp bus_protocols/uds_handler.h
+    can_structs.cpp can_structs.h
+    can_trigger_structs.h
+    canbridgewindow.cpp canbridgewindow.h
+    candatagrid.cpp candatagrid.h
+    canfilter.cpp canfilter.h
+    canframemodel.cpp canframemodel.h
+    config.h
+    connections/canbus.cpp connections/canbus.h
+    connections/canconconst.h
+    connections/canconfactory.cpp connections/canconfactory.h
+    connections/canconmanager.cpp connections/canconmanager.h
+    connections/canconnection.cpp connections/canconnection.h
+    connections/canconnectionmodel.cpp connections/canconnectionmodel.h
+    connections/canlogserver.cpp connections/canlogserver.h
+    connections/canserver.cpp connections/canserver.h
+    connections/connectionwindow.cpp connections/connectionwindow.h
+    connections/gvretserial.cpp connections/gvretserial.h
+    connections/lawicel_serial.cpp connections/lawicel_serial.h
+    connections/mqtt_bus.cpp connections/mqtt_bus.h
+    connections/newconnectiondialog.cpp connections/newconnectiondialog.h
+    connections/serialbusconnection.cpp connections/serialbusconnection.h
+    connections/socketcand.cpp connections/socketcand.h
+    dbc/dbc_classes.cpp dbc/dbc_classes.h
+    dbc/dbchandler.cpp dbc/dbchandler.h
+    dbc/dbcloadsavewindow.cpp dbc/dbcloadsavewindow.h
+    dbc/dbcmaineditor.cpp dbc/dbcmaineditor.h
+    dbc/dbcmessageeditor.cpp dbc/dbcmessageeditor.h
+    dbc/dbcnodeduplicateeditor.cpp dbc/dbcnodeduplicateeditor.h
+    dbc/dbcnodeeditor.cpp dbc/dbcnodeeditor.h
+    dbc/dbcnoderebaseeditor.cpp dbc/dbcnoderebaseeditor.h
+    dbc/dbcsignaleditor.cpp dbc/dbcsignaleditor.h
+    filterutility.cpp filterutility.h
+    firmwareuploaderwindow.cpp firmwareuploaderwindow.h
+    framefileio.cpp framefileio.h
+    frameplaybackobject.cpp frameplaybackobject.h
+    frameplaybackwindow.cpp frameplaybackwindow.h
+    framesenderobject.cpp framesenderobject.h
+    framesenderwindow.cpp framesenderwindow.h
+    helpwindow.cpp helpwindow.h
+    jsedit.cpp jsedit.h
+    main.cpp
+    mainsettingsdialog.cpp mainsettingsdialog.h
+    mainwindow.cpp mainwindow.h
+    motorcontrollerconfigwindow.cpp motorcontrollerconfigwindow.h
+    mqtt/qmqtt.h
+    mqtt/qmqtt_client.cpp mqtt/qmqtt_client.h mqtt/qmqtt_client_p.cpp mqtt/qmqtt_client_p.h
+    mqtt/qmqtt_frame.cpp mqtt/qmqtt_frame.h
+    mqtt/qmqtt_global.h
+    mqtt/qmqtt_message.cpp mqtt/qmqtt_message.h mqtt/qmqtt_message_p.h
+    mqtt/qmqtt_network.cpp mqtt/qmqtt_network_p.h
+    mqtt/qmqtt_networkinterface.h
+    mqtt/qmqtt_routedmessage.h
+    mqtt/qmqtt_router.cpp mqtt/qmqtt_router.h
+    mqtt/qmqtt_routesubscription.cpp mqtt/qmqtt_routesubscription.h
+    mqtt/qmqtt_socket.cpp mqtt/qmqtt_socket_p.h
+    mqtt/qmqtt_socketinterface.h
+    mqtt/qmqtt_ssl_socket.cpp mqtt/qmqtt_ssl_socket_p.h
+    mqtt/qmqtt_timer.cpp mqtt/qmqtt_timer_p.h
+    mqtt/qmqtt_timerinterface.h
+    mqtt/qmqtt_websocket.cpp mqtt/qmqtt_websocket_p.h
+    mqtt/qmqtt_websocketiodevice.cpp mqtt/qmqtt_websocketiodevice_p.h
+    pcaplite.cpp pcaplite.h
+    qcpaxistickerhex.cpp qcpaxistickerhex.h
+    qcustomplot.cpp qcustomplot.h
+    re/dbccomparatorwindow.cpp re/dbccomparatorwindow.h
+    re/discretestatewindow.cpp re/discretestatewindow.h
+    re/filecomparatorwindow.cpp re/filecomparatorwindow.h
+    re/flowviewwindow.cpp re/flowviewwindow.h
+    re/frameinfowindow.cpp re/frameinfowindow.h
+    re/fuzzingwindow.cpp re/fuzzingwindow.h
+    re/graphingwindow.cpp re/graphingwindow.h
+    re/isotp_interpreterwindow.cpp re/isotp_interpreterwindow.h
+    re/newgraphdialog.cpp re/newgraphdialog.h
+    re/rangestatewindow.cpp re/rangestatewindow.h
+    re/sniffer/SnifferDelegate.cpp re/sniffer/SnifferDelegate.h
+    re/sniffer/snifferitem.cpp re/sniffer/snifferitem.h
+    re/sniffer/sniffermodel.cpp re/sniffer/sniffermodel.h
+    re/sniffer/snifferwindow.cpp re/sniffer/snifferwindow.h
+    re/temporalgraphwindow.cpp re/temporalgraphwindow.h
+    re/udsscanwindow.cpp re/udsscanwindow.h
+    scriptcontainer.cpp scriptcontainer.h
+    scriptingwindow.cpp scriptingwindow.h
+    signalviewerwindow.cpp signalviewerwindow.h
+    simplecrypt.cpp simplecrypt.h
+    triggerdialog.cpp triggerdialog.h triggerdialog.ui
+    utility.cpp utility.h
+    utils/HexSpinBox.h
+    utils/lfqueue.h
+    images.qrc icons.qrc
+)
+
+if(APPLE)
+    set_target_properties(SavvyCAN PROPERTIES
+        MACOSX_BUNDLE_ICON_FILE SavvyIcon.icns
+        RESOURCE "icons/SavvyIcon.icns"
+    )
+endif()
+
+target_include_directories(SavvyCAN PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/mqtt
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils
+    ${CMAKE_CURRENT_SOURCE_DIR}/bus_protocols
+    ${CMAKE_CURRENT_SOURCE_DIR}/connections
+)
+
+target_compile_definitions(SavvyCAN PRIVATE
+    QCUSTOMPLOT_USE_OPENGL
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL Release)
+    target_compile_definitions(SavvyCAN PRIVATE QT_NO_DEBUG_OUTPUT)
+endif()
+
+set_debug_sanitizer_options(SavvyCAN)
+
+target_link_libraries(SavvyCAN PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::PrintSupport
+    Qt6::SerialBus
+    Qt6::SerialPort
+    Qt6::Widgets
+    Qt6::Help
+    Qt6::Network
+    Qt6::OpenGL
+    Qt6::Qml # for QJSEngine
+    OpenGL::GL
+)
+
+if(USE_DBUS AND UNIX AND NOT APPLE)
+    target_link_libraries(SavvyCAN PRIVATE Qt6::DBus)
+endif()
+
+if(WIN32)
+    set_target_properties(SavvyCAN PROPERTIES WIN32_EXECUTABLE TRUE)
+    target_sources(SavvyCAN PRIVATE icons/SavvyIcon.rc)
+endif()
+
+if(UNIX AND NOT APPLE)
+    if(NOT DEFINED PREFIX)
+        set(PREFIX "/usr/local")
+    endif()
+    install(TARGETS SavvyCAN RUNTIME DESTINATION ${PREFIX}/bin)
+    install(FILES SavvyCAN.desktop DESTINATION ${PREFIX}/share/applications)
+    install(DIRECTORY icons/hicolor DESTINATION ${PREFIX}/share/icons)
+    install(DIRECTORY examples DESTINATION ${PREFIX}/share/savvycan)
+    install(DIRECTORY help DESTINATION ${PREFIX}/share/savvycan)
+endif()
+
+install(TARGETS SavvyCAN
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+if(BUILD_TESTS)
+    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Test)
+    qt_add_executable(SavvyCAN_tests
+        test/main.cpp
+        test/tst_lfqueue.cpp test/tst_lfqueue.h
+        test/tst_cancon.cpp test/tst_cancon.h
+        connections/canconfactory.cpp connections/canconfactory.h
+        connections/canconnection.cpp connections/canconnection.h
+        connections/gvretserial.cpp connections/gvretserial.h
+        connections/socketcand.cpp connections/socketcand.h
+        connections/canconconst.h
+        connections/canbus.cpp connections/canbus.h
+        utils/lfqueue.h
+    )
+    target_include_directories(SavvyCAN_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/mqtt
+        ${CMAKE_CURRENT_SOURCE_DIR}/utils
+        ${CMAKE_CURRENT_SOURCE_DIR}/bus_protocols
+        ${CMAKE_CURRENT_SOURCE_DIR}/connections
+    )
+    target_link_libraries(SavvyCAN_tests PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::SerialBus
+        Qt6::Widgets
+        Qt6::Test
+    )
+    set_debug_sanitizer_options(SavvyCAN_tests)
+    install(TARGETS SavvyCAN_tests
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ qt_add_executable(SavvyCAN WIN32 MACOSX_BUNDLE
     bisectwindow.cpp bisectwindow.h
     blfhandler.cpp blfhandler.h
     bus_protocols/isotp_handler.cpp bus_protocols/isotp_handler.h
+    bus_protocols/handler_factory.cpp bus_protocols/handler_factory.h
     bus_protocols/isotp_message.h
     bus_protocols/j1939_handler.cpp bus_protocols/j1939_handler.h
     bus_protocols/uds_handler.cpp bus_protocols/uds_handler.h

--- a/bus_protocols/handler_factory.cpp
+++ b/bus_protocols/handler_factory.cpp
@@ -18,3 +18,18 @@ ISOTP_HANDLER* HandlerFactory::createISOTPHandler()
                     });
             });
 }
+
+UDS_HANDLER* HandlerFactory::createUDSHandler() {
+        ISOTP_HANDLER *isoHandler = HandlerFactory::createISOTPHandler();
+    return new UDS_HANDLER(isoHandler,
+            /* getNoOfBusesCallback */ [](void){  return CANConManager::getInstance()->getNumBuses(); },
+            /* pendingConn */ [isoHandler](UDS_HANDLER* handler) -> QMetaObject::Connection {
+            return QObject::connect(
+                    isoHandler,
+                    &ISOTP_HANDLER::newISOMessage,
+                    handler,
+                    [handler](ISOTP_MESSAGE msg){
+                    handler->gotISOTPFrame(msg);
+                    });
+            });
+}

--- a/bus_protocols/handler_factory.cpp
+++ b/bus_protocols/handler_factory.cpp
@@ -1,0 +1,20 @@
+#include "handler_factory.h"
+#include "isotp_handler.h"
+#include "connections/canconmanager.h"
+#include "mainwindow.h"
+
+ISOTP_HANDLER* HandlerFactory::createISOTPHandler()
+{
+    return new ISOTP_HANDLER(*MainWindow::getReference()->getCANFrameModel()->getListReference(),
+            /* canSendCallback */ [](const CANFrame& pFrame){ CANConManager::getInstance()->sendFrame(pFrame); },
+            /* getNoOfBusesCallback */ [](void){  return CANConManager::getInstance()->getNumBuses(); },
+            /* pendingConn */ [](ISOTP_HANDLER* handler) -> QMetaObject::Connection {
+            return QObject::connect(
+                    CANConManager::getInstance(),
+                    &CANConManager::framesReceived,
+                    handler,
+                    [handler](void*, const QVector<CANFrame>& frames){
+                    handler->rapidFrames(frames);
+                    });
+            });
+}

--- a/bus_protocols/handler_factory.h
+++ b/bus_protocols/handler_factory.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class ISOTP_HANDLER;
+
+class HandlerFactory
+{
+public:
+
+    // Factory methods
+    static ISOTP_HANDLER* createISOTPHandler();
+};

--- a/bus_protocols/handler_factory.h
+++ b/bus_protocols/handler_factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 class ISOTP_HANDLER;
+class UDS_HANDLER;
 
 class HandlerFactory
 {
@@ -8,4 +9,5 @@ public:
 
     // Factory methods
     static ISOTP_HANDLER* createISOTPHandler();
+    static UDS_HANDLER* createUDSHandler();
 };

--- a/bus_protocols/isotp_handler.cpp
+++ b/bus_protocols/isotp_handler.cpp
@@ -7,7 +7,7 @@
 ISOTP_HANDLER::ISOTP_HANDLER(const QVector<CANFrame> &modelFrames,
                              CanSendCallback sendCb,
                              GetNoOfBusesCallback getBusesCb,
-                             PendingConnection pendingConn )
+                             PendingConnection<ISOTP_HANDLER> pendingConn )
     : modelFrames(modelFrames),
       canSendCallback(sendCb),
       getNoOfBusesCallback(getBusesCb),

--- a/bus_protocols/isotp_handler.h
+++ b/bus_protocols/isotp_handler.h
@@ -2,21 +2,29 @@
 
 #include <Qt>
 #include <QObject>
-#include <QDebug>
 #include <QTimer>
+#include <QHash>
 #include "can_structs.h"
-#include "mainwindow.h"
-#include "canframemodel.h"
 #include "isotp_message.h"
 #include "canfilter.h"
+
 
 class ISOTP_HANDLER : public QObject
 {
     Q_OBJECT
 
+    using CanSendCallback = std::function<void(const CANFrame& pFrame)>;
+    using GetNoOfBusesCallback = std::function<int(void)>;
+    using PendingConnection = std::function<QMetaObject::Connection(ISOTP_HANDLER*)>; // lambda to call connect() in setReception()
+
 public:
-    ISOTP_HANDLER();
+    ISOTP_HANDLER(const QVector<CANFrame> &modelFrames,
+                  CanSendCallback sendCb,
+                  GetNoOfBusesCallback getBusesCb,
+                  PendingConnection pendingConn
+                );
     ~ISOTP_HANDLER();
+
     void setExtendedAddressing(bool mode);
     void setReception(bool mode); //set whether to accept and forward frames or not
     void setEmitPartials(bool mode);
@@ -30,7 +38,7 @@ public:
 
 public slots:
     void updatedFrames(int);
-    void rapidFrames(const CANConnection* conn, const QVector<CANFrame>& pFrames);
+    void rapidFrames(const QVector<CANFrame>& pFrames);
     void frameTimerTick();
 
 signals:
@@ -40,7 +48,7 @@ private:
     QHash<uint32_t, ISOTP_MESSAGE> messageBuffer;
     QList<CANFrame> sendingFrames;
     QList<CANFilter> filters;
-    const QVector<CANFrame> *modelFrames;
+    const QVector<CANFrame> &modelFrames;
     bool useExtendedAddressing;
     bool isReceiving;
     bool waitingForFlow;
@@ -55,4 +63,10 @@ private:
 
     void processFrame(const CANFrame &frame);
     void checkNeedFlush(uint64_t ID);
+
+    CanSendCallback canSendCallback;
+    GetNoOfBusesCallback getNoOfBusesCallback;
+
+    PendingConnection pendingConnection;
+    QMetaObject::Connection connection;
 };

--- a/bus_protocols/isotp_handler.h
+++ b/bus_protocols/isotp_handler.h
@@ -63,10 +63,20 @@ private:
 
     void processFrame(const CANFrame &frame);
     void checkNeedFlush(uint64_t ID);
+    void updateIsoTpCanFrameInfo();
 
     CanSendCallback canSendCallback;
     GetNoOfBusesCallback getNoOfBusesCallback;
 
     PendingConnection pendingConnection;
     QMetaObject::Connection connection;
+
+    // Info about ISO-TP frame formats
+    struct FrameInfo {
+        int cfAndSfPciOffset;
+        int sfFrameLen;
+        int ffPciOffset;
+        int ffFrameLen;
+        int cfFrameLen;
+    } frameInfo;
 };

--- a/bus_protocols/isotp_handler.h
+++ b/bus_protocols/isotp_handler.h
@@ -14,14 +14,16 @@ class ISOTP_HANDLER : public QObject
     Q_OBJECT
 
     using CanSendCallback = std::function<void(const CANFrame& pFrame)>;
-    using GetNoOfBusesCallback = std::function<int(void)>;
-    using PendingConnection = std::function<QMetaObject::Connection(ISOTP_HANDLER*)>; // lambda to call connect() in setReception()
 
 public:
+    using GetNoOfBusesCallback = std::function<int(void)>;
+    template <typename handler>
+    using PendingConnection = std::function<QMetaObject::Connection(handler*)>; // lambda to call connect() in setReception()
+
     ISOTP_HANDLER(const QVector<CANFrame> &modelFrames,
                   CanSendCallback sendCb,
                   GetNoOfBusesCallback getBusesCb,
-                  PendingConnection pendingConn
+                  PendingConnection<ISOTP_HANDLER> pendingConn
                 );
     ~ISOTP_HANDLER();
 
@@ -68,7 +70,7 @@ private:
     CanSendCallback canSendCallback;
     GetNoOfBusesCallback getNoOfBusesCallback;
 
-    PendingConnection pendingConnection;
+    PendingConnection<ISOTP_HANDLER> pendingConnection;
     QMetaObject::Connection connection;
 
     // Info about ISO-TP frame formats

--- a/bus_protocols/uds_handler.cpp
+++ b/bus_protocols/uds_handler.cpp
@@ -1,9 +1,8 @@
 #include "uds_handler.h"
 #include "connections/canconmanager.h"
 #include "isotp_handler.h"
-#include "handler_factory.h"
-#include "mainwindow.h"
 #include <QDebug>
+#include "utility.h"
 
 static QVector<CODE_STRUCT> UDS_DIAG_CTRL_SUB = {
     {1,"DFLT_SESS", "Default session"},
@@ -170,12 +169,15 @@ UDS_MESSAGE::UDS_MESSAGE()
     isErrorReply = false;
 }
 
-UDS_HANDLER::UDS_HANDLER()
+UDS_HANDLER::UDS_HANDLER(ISOTP_HANDLER *isotp_handler,
+                         ISOTP_HANDLER::GetNoOfBusesCallback getBusesCb,
+                         ISOTP_HANDLER::PendingConnection<UDS_HANDLER> pendingConn)
+    : isoHandler(isotp_handler),
+      getNoOfBusesCallback(getBusesCb),
+      pendingConnection(pendingConn)
 {
     isReceiving = false;
     useExtendedAddressing = false;
-    modelFrames = MainWindow::getReference()->getCANFrameModel()->getListReference();
-    isoHandler = HandlerFactory::createISOTPHandler();
 }
 
 UDS_HANDLER::~UDS_HANDLER()
@@ -183,7 +185,7 @@ UDS_HANDLER::~UDS_HANDLER()
     delete isoHandler;
 }
 
-UDS_MESSAGE UDS_HANDLER::tryISOtoUDS(ISOTP_MESSAGE msg, bool *result)
+UDS_MESSAGE UDS_HANDLER::tryISOtoUDS(const ISOTP_MESSAGE& msg, bool *result)
 {
     const unsigned char *data = reinterpret_cast<const unsigned char *>(msg.payload().constData());
     int dataLen = msg.payload().length();
@@ -236,7 +238,7 @@ UDS_MESSAGE UDS_HANDLER::tryISOtoUDS(ISOTP_MESSAGE msg, bool *result)
     return udsMsg;
 }
 
-void UDS_HANDLER::gotISOTPFrame(ISOTP_MESSAGE msg)
+void UDS_HANDLER::gotISOTPFrame(const ISOTP_MESSAGE &msg)
 {
     qDebug() << "UDS handler got ISOTP frame";
     UDS_MESSAGE udsMsg;
@@ -255,18 +257,19 @@ void UDS_HANDLER::setFlowCtrl(bool state)
 void UDS_HANDLER::setReception(bool mode)
 {
     if (isReceiving == mode) return;
-
     isReceiving = mode;
 
     if (isReceiving)
     {
-        connect(isoHandler, SIGNAL(newISOMessage(ISOTP_MESSAGE)), this, SLOT(gotISOTPFrame(ISOTP_MESSAGE)));
+        if (pendingConnection)
+            connection = pendingConnection(this);
         isoHandler->setReception(true); //must enable ISOTP reception too.
         qDebug() << "Enabling reception of ISO-TP frames in UDS handler";
     }
     else
     {
-        disconnect(isoHandler, SIGNAL(newISOMessage(ISOTP_MESSAGE)), this, SLOT(gotISOTPFrame(ISOTP_MESSAGE)));
+        if (connection)
+            QObject::disconnect(connection);
         isoHandler->setReception(false);
         qDebug() << "Disabling reception of ISOTP frames in UDS handler";
     }
@@ -276,7 +279,7 @@ void UDS_HANDLER::sendUDSFrame(const UDS_MESSAGE &msg)
 {
     QByteArray data;
     if (msg.bus < 0) return;
-    if (msg.bus >= CANConManager::getInstance()->getNumBuses()) return;
+    if (msg.bus >= getNoOfBusesCallback()) return;
     if (msg.service > 0xFF) return;
 
     data.append(msg.service);

--- a/bus_protocols/uds_handler.cpp
+++ b/bus_protocols/uds_handler.cpp
@@ -1,6 +1,8 @@
 #include "uds_handler.h"
 #include "connections/canconmanager.h"
 #include "isotp_handler.h"
+#include "handler_factory.h"
+#include "mainwindow.h"
 #include <QDebug>
 
 static QVector<CODE_STRUCT> UDS_DIAG_CTRL_SUB = {
@@ -173,7 +175,7 @@ UDS_HANDLER::UDS_HANDLER()
     isReceiving = false;
     useExtendedAddressing = false;
     modelFrames = MainWindow::getReference()->getCANFrameModel()->getListReference();
-    isoHandler = new ISOTP_HANDLER();
+    isoHandler = HandlerFactory::createISOTPHandler();
 }
 
 UDS_HANDLER::~UDS_HANDLER()

--- a/bus_protocols/uds_handler.h
+++ b/bus_protocols/uds_handler.h
@@ -6,8 +6,8 @@
 #include <QDebug>
 #include "can_structs.h"
 #include "isotp_message.h"
+#include "isotp_handler.h"
 
-class ISOTP_HANDLER;
 
 namespace UDS_SERVICES
 {
@@ -86,10 +86,11 @@ class UDS_HANDLER : public QObject
     Q_OBJECT
 
 public:
-    UDS_HANDLER();
+    UDS_HANDLER(ISOTP_HANDLER *isotp_handler,
+                ISOTP_HANDLER::GetNoOfBusesCallback getBusesCb,
+                ISOTP_HANDLER::PendingConnection<UDS_HANDLER> pendingConn);
     ~UDS_HANDLER();
     void setExtendedAddressing(bool mode);
-    static UDS_HANDLER* getInstance();
     void setReception(bool mode); //set whether to accept and forward frames or not
     void sendUDSFrame(const UDS_MESSAGE &msg);
     void setProcessAllIDs(bool state);
@@ -105,23 +106,27 @@ public:
     QString getShortDesc(QVector<CODE_STRUCT> &codeVector, int code);
     QString getLongDesc(QVector<CODE_STRUCT> &codeVector, int code);
     QString getDetailedMessageAnalysis(const UDS_MESSAGE &msg);
-    UDS_MESSAGE tryISOtoUDS(ISOTP_MESSAGE msg, bool *result);
+    UDS_MESSAGE tryISOtoUDS(const ISOTP_MESSAGE& msg, bool *result);
 
 public slots:
-    void gotISOTPFrame(ISOTP_MESSAGE msg);
+    void gotISOTPFrame(const ISOTP_MESSAGE &msg);
 
 signals:
     void newUDSMessage(UDS_MESSAGE msg);
 
 private:
     QList<ISOTP_MESSAGE> messageBuffer;
-    const QVector<CANFrame> *modelFrames;
     bool isReceiving;
     bool useExtendedAddressing;
 
     void processFrame(const CANFrame &frame);
 
     ISOTP_HANDLER *isoHandler;
+
+    ISOTP_HANDLER::GetNoOfBusesCallback getNoOfBusesCallback;
+
+    ISOTP_HANDLER::PendingConnection<UDS_HANDLER> pendingConnection;
+    QMetaObject::Connection connection;
 };
 
 

--- a/candatagrid.cpp
+++ b/candatagrid.cpp
@@ -532,6 +532,7 @@ void CANDataGrid::paintCommonEnding()
     //and we don't need these anymore after we're done drawing
     delete painter;
     delete smallMetric;
+    delete largeMetric;
 }
 
 //given a grid cell we return which bit position that is within the CAN frame.

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -1405,7 +1405,7 @@ bool DBCFile::saveFile(QString fileName)
                     case QMetaType::QString:
                         attrValOutput.append("\"" + val.value.toString() + "\";\n");
                         break;
-                    case QVariant::Type::Bool:
+                    case QMetaType::Bool:
                         attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
                         break;
                     default:
@@ -1455,7 +1455,7 @@ bool DBCFile::saveFile(QString fileName)
                 case QMetaType::QString:
                     attrValOutput.append("\"" + val.value.toString() + "\";\n");
                     break;
-                case QVariant::Type::Bool:
+                case QMetaType::Bool:
                     attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
                     break;
                 default:
@@ -1538,7 +1538,7 @@ bool DBCFile::saveFile(QString fileName)
                     case QMetaType::QString:
                         attrValOutput.append("\"" + val.value.toString() + "\";\n");
                         break;
-                    case QVariant::Type::Bool:
+                    case QMetaType::Bool:
                         attrValOutput.append(QString::number(val.value.toBool() ? 1 : 0) + ";\n");
                         break;
                     default:

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -266,11 +266,31 @@ DBCFile::DBCFile(const DBCFile& cpy) : QObject()
     fileName = cpy.fileName;
     filePath = cpy.filePath;
     assocBuses = cpy.assocBuses;
-    dbc_nodes.clear();
-    dbc_nodes.append(cpy.dbc_nodes);
+
+    clearAndDelete(dbc_nodes);
+
+    for (DBC_NODE* srcNode : cpy.dbc_nodes) {
+        if (srcNode) {
+            dbc_nodes.append(new DBC_NODE(*srcNode)); // deep copy not just pointers
+        }
+    }
+
     dbc_attributes.clear();
     dbc_attributes.append(cpy.dbc_attributes);
     isDirty = cpy.isDirty;
+}
+
+void DBCFile::clearAndDelete(QList<DBC_NODE *>& list)
+{
+    if (!list.empty()) {
+        qDeleteAll(list);
+        list.clear();
+    }
+}
+
+DBCFile::~DBCFile()
+{
+    clearAndDelete(dbc_nodes);
 }
 
 DBCFile& DBCFile::operator=(const DBCFile& cpy)

--- a/dbc/dbchandler.h
+++ b/dbc/dbchandler.h
@@ -66,6 +66,7 @@ class DBCFile: public QObject
 public:
     DBCFile();
     DBCFile(const DBCFile& cpy);
+    ~DBCFile();
     DBCFile& operator=(const DBCFile& cpy);
     DBC_NODE *findNodeByName(QString name);
     DBC_NODE *findNodeByNameAndComment(QString fullname);
@@ -104,6 +105,7 @@ private:
     bool parseSignalValueTypeLine(QString line);
     bool parseAttributeLine(QString line);
     bool parseDefaultAttrLine(QString line);
+    void clearAndDelete(QList<DBC_NODE *>& list);
 };
 
 class DBCHandler: public QObject

--- a/mqtt/qmqtt.qbs
+++ b/mqtt/qmqtt.qbs
@@ -8,7 +8,7 @@ Product {
     property bool webSocketSupport: false
     property string libraryType: "dynamiclibrary"
     targetName: "qmqtt"
-    version: "1.0.0"
+    version: "1.0.3"
 
     cpp.defines: [
         "QT_BUILD_QMQTT_LIB",

--- a/mqtt/qmqtt_client.cpp
+++ b/mqtt/qmqtt_client.cpp
@@ -79,7 +79,7 @@ QMQTT::Client::Client(const QString& url,
 {
     Q_D(Client);
 #ifndef QT_NO_SSL
-    d->init(url, origin, version, NULL, ignoreSelfSigned);
+    d->init(url, origin, version, nullptr, ignoreSelfSigned);
 #else
     Q_UNUSED(ignoreSelfSigned)
     d->init(url, origin, version);

--- a/mqtt/qmqtt_client.h
+++ b/mqtt/qmqtt_client.h
@@ -51,7 +51,14 @@
 QT_FORWARD_DECLARE_CLASS(QSslError)
 #endif // QT_NO_SSL
 
+#ifndef Q_ENUM_NS
+#define Q_ENUM_NS(x)
+#endif // Q_ENUM_NS
+
 namespace QMQTT {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+Q_MQTT_EXPORT Q_NAMESPACE
+#endif
 
 static const quint8 LIBRARY_VERSION_MAJOR = 0;
 static const quint8 LIBRARY_VERSION_MINOR = 3;
@@ -63,6 +70,7 @@ enum MQTTVersion
     V3_1_0 = 3,
     V3_1_1 = 4
 };
+Q_ENUM_NS(MQTTVersion)
 
 enum ConnectionState
 {
@@ -71,6 +79,7 @@ enum ConnectionState
     STATE_CONNECTED,
     STATE_DISCONNECTED
 };
+Q_ENUM_NS(ConnectionState)
 
 enum ClientError
 {
@@ -105,6 +114,7 @@ enum ClientError
     MqttNotAuthorizedError,
     MqttNoPingResponse
 };
+Q_ENUM_NS(ClientError)
 
 class ClientPrivate;
 class Message;
@@ -137,14 +147,14 @@ class Q_MQTT_EXPORT Client : public QObject
 public:
     Client(const QHostAddress& host = QHostAddress::LocalHost,
            const quint16 port = 1883,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 
 #ifndef QT_NO_SSL
     Client(const QString& hostName,
            const quint16 port,
            const QSslConfiguration& config,
            const bool ignoreSelfSigned=false,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 #endif // QT_NO_SSL
 
     // This function is provided for backward compatibility with older versions of QMQTT.
@@ -155,7 +165,7 @@ public:
            const quint16 port,
            const bool ssl,
            const bool ignoreSelfSigned,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 
 #ifdef QT_WEBSOCKETS_LIB
     // Create a connection over websockets
@@ -163,7 +173,7 @@ public:
            const QString& origin,
            QWebSocketProtocol::Version version,
            bool ignoreSelfSigned = false,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 
 #ifndef QT_NO_SSL
     Client(const QString& url,
@@ -171,7 +181,7 @@ public:
            QWebSocketProtocol::Version version,
            const QSslConfiguration& config,
            const bool ignoreSelfSigned = false,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 #endif // QT_NO_SSL
 #endif // QT_WEBSOCKETS_LIB
 
@@ -179,7 +189,7 @@ public:
     Client(NetworkInterface* network,
            const QHostAddress& host = QHostAddress::LocalHost,
            const quint16 port = 1883,
-           QObject* parent = NULL);
+           QObject* parent = nullptr);
 
     virtual ~Client();
 
@@ -206,7 +216,7 @@ public:
     void setSslConfiguration(const QSslConfiguration& config);
 #endif // QT_NO_SSL
 
-public slots:
+public Q_SLOTS:
     void setHost(const QHostAddress& host);
     void setHostName(const QString& hostName);
     void setPort(const quint16 port);
@@ -236,7 +246,7 @@ public slots:
     void ignoreSslErrors(const QList<QSslError>& errors);
 #endif // QT_NO_SSL
 
-signals:
+Q_SIGNALS:
     void connected();
     void disconnected();
     void error(const QMQTT::ClientError error);
@@ -250,7 +260,7 @@ signals:
     void sslErrors(const QList<QSslError>& errors);
 #endif // QT_NO_SSL
 
-protected slots:
+protected Q_SLOTS:
     void onNetworkConnected();
     void onNetworkDisconnected();
     void onNetworkReceived(const QMQTT::Frame& frame);

--- a/mqtt/qmqtt_client_p.cpp
+++ b/mqtt/qmqtt_client_p.cpp
@@ -73,7 +73,7 @@ void QMQTT::ClientPrivate::init(const QHostAddress& host, const quint16 port, Ne
     Q_Q(Client);
     _host = host;
     _port = port;
-    if(network == NULL)
+    if(network == nullptr)
     {
         init(new Network(q));
     }
@@ -335,7 +335,12 @@ void QMQTT::ClientPrivate::stopKeepAlive()
 
 quint16 QMQTT::ClientPrivate::nextmid()
 {
-    return _gmid++;
+    const quint16 result = _gmid;
+    _gmid++;
+    if (_gmid == 0)
+      _gmid++;
+
+    return result;
 }
 
 quint16 QMQTT::ClientPrivate::publish(const Message& message)
@@ -376,6 +381,7 @@ void QMQTT::ClientPrivate::onNetworkDisconnected()
     stopKeepAlive();
     _midToTopic.clear();
     _midToMessage.clear();
+    _connectionState = ConnectionState::STATE_DISCONNECTED;
     emit q->disconnected();
 }
 
@@ -539,7 +545,7 @@ void QMQTT::ClientPrivate::setAutoReconnectInterval(const int autoReconnectInter
 
 bool QMQTT::ClientPrivate::isConnectedToHost() const
 {
-    return _network->isConnectedToHost();
+    return _connectionState == ConnectionState::STATE_CONNECTED;
 }
 
 QMQTT::ConnectionState QMQTT::ClientPrivate::connectionState() const

--- a/mqtt/qmqtt_client_p.h
+++ b/mqtt/qmqtt_client_p.h
@@ -60,7 +60,7 @@ public:
     ClientPrivate(Client* qq_ptr);
     ~ClientPrivate();
 
-    void init(const QHostAddress& host, const quint16 port, NetworkInterface* network = NULL);
+    void init(const QHostAddress& host, const quint16 port, NetworkInterface* network = nullptr);
 #ifndef QT_NO_SSL
     void init(const QString& hostName, const quint16 port, const QSslConfiguration& config,
               const bool ignoreSelfSigned=false);

--- a/mqtt/qmqtt_global.h
+++ b/mqtt/qmqtt_global.h
@@ -35,7 +35,7 @@
 #include <QtGlobal>
 
 //#ifndef QT_STATIC
-//#  if defined(QT_BUILD_QMQTT_LIB)
+//#if !defined(QT_STATIC) && !defined(MQTT_PROJECT_INCLUDE_SRC)
 //#    define Q_MQTT_EXPORT Q_DECL_EXPORT
 //#  else
 //#    define Q_MQTT_EXPORT Q_DECL_IMPORT

--- a/mqtt/qmqtt_network.cpp
+++ b/mqtt/qmqtt_network.cpp
@@ -239,8 +239,13 @@ void QMQTT::Network::onSocketReadReady()
         case Length:
             _length |= (byte & 0x7F) << _shift;
             _shift += 7;
-            if ((byte & 0x80) != 0)
+            if ((byte & 0x80) != 0) {
+                if (_shift > 21) { // only up to 4 bytes (3*7 shifts)
+                    _readState = Header;
+                    emit error(QAbstractSocket::SocketError::UnknownSocketError);
+                }
                 break;
+            }
             if (_length == 0) {
                 _readState = Header;
                 Frame frame(_header, _data);

--- a/mqtt/qmqtt_network_p.h
+++ b/mqtt/qmqtt_network_p.h
@@ -59,23 +59,23 @@ class Network : public NetworkInterface
     Q_OBJECT
 
 public:
-    Network(QObject* parent = NULL);
+    Network(QObject* parent = nullptr);
 #ifndef QT_NO_SSL
-    Network(const QSslConfiguration& config, QObject* parent = NULL);
+    Network(const QSslConfiguration& config, QObject* parent = nullptr);
 #endif // QT_NO_SSL
 #ifdef QT_WEBSOCKETS_LIB
 #ifndef QT_NO_SSL
     Network(const QString& origin,
             QWebSocketProtocol::Version version,
             const QSslConfiguration* sslConfig,
-            QObject* parent = NULL);
+            QObject* parent = nullptr);
 #endif // QT_NO_SSL
     Network(const QString& origin,
             QWebSocketProtocol::Version version,
-            QObject* parent = NULL);
+            QObject* parent = nullptr);
 #endif // QT_WEBSOCKETS_LIB
     Network(SocketInterface* socketInterface, TimerInterface* timerInterface,
-            QObject* parent = NULL);
+            QObject* parent = nullptr);
     ~Network();
 
     void sendFrame(const Frame &frame);
@@ -91,7 +91,7 @@ public:
     void setSslConfiguration(const QSslConfiguration& config);
 #endif // QT_NO_SSL
 
-public slots:
+public Q_SLOTS:
     void connectToHost(const QHostAddress& host, const quint16 port);
     void connectToHost(const QString& hostName, const quint16 port);
     void disconnectFromHost();
@@ -99,7 +99,7 @@ public slots:
     void ignoreSslErrors();
 #endif // QT_NO_SSL
 
-protected slots:
+protected Q_SLOTS:
     void onSocketError(QAbstractSocket::SocketError socketError);
 
 protected:
@@ -125,7 +125,7 @@ protected:
     int _shift;
     QByteArray _data;
 
-protected slots:
+protected Q_SLOTS:
     void onSocketReadReady();
     void onDisconnected();
     void connectToHost();

--- a/mqtt/qmqtt_networkinterface.h
+++ b/mqtt/qmqtt_networkinterface.h
@@ -53,7 +53,7 @@ class Q_MQTT_EXPORT NetworkInterface : public QObject
 {
     Q_OBJECT
 public:
-    explicit NetworkInterface(QObject* parent = NULL) : QObject(parent) {}
+    explicit NetworkInterface(QObject* parent = nullptr) : QObject(parent) {}
     virtual ~NetworkInterface() {}
 
     virtual void sendFrame(const Frame& frame) = 0;
@@ -69,7 +69,7 @@ public:
     virtual void setSslConfiguration(const QSslConfiguration& config) = 0;
 #endif // QT_NO_SSL
 
-public slots:
+public Q_SLOTS:
     virtual void connectToHost(const QHostAddress& host, const quint16 port) = 0;
     virtual void connectToHost(const QString& hostName, const quint16 port) = 0;
     virtual void disconnectFromHost() = 0;
@@ -77,7 +77,7 @@ public slots:
     virtual void ignoreSslErrors() = 0;
 #endif // QT_NO_SSL
 
-signals:
+Q_SIGNALS:
     void connected();
     void disconnected();
     void received(const QMQTT::Frame& frame);

--- a/mqtt/qmqtt_router.h
+++ b/mqtt/qmqtt_router.h
@@ -46,7 +46,7 @@ class Q_MQTT_EXPORT Router : public QObject
 {
     Q_OBJECT
 public:
-    explicit Router(Client *parent = 0);
+    explicit Router(Client *parent = nullptr);
 
     RouteSubscription *subscribe(const QString &route);
     Client *client() const;

--- a/mqtt/qmqtt_routesubscription.h
+++ b/mqtt/qmqtt_routesubscription.h
@@ -56,16 +56,16 @@ public:
 
     QString route() const;
 
-signals:
+Q_SIGNALS:
     void received(const RoutedMessage &message);
 
-private slots:
+private Q_SLOTS:
     void routeMessage(const Message &message);
 
 private:
     friend class Router;
 
-    explicit RouteSubscription(Router *parent = 0);
+    explicit RouteSubscription(Router *parent = nullptr);
     void setRoute(const QString &route);
 
     QPointer<Client> _client;

--- a/mqtt/qmqtt_socket.cpp
+++ b/mqtt/qmqtt_socket.cpp
@@ -41,9 +41,13 @@ QMQTT::Socket::Socket(QObject* parent)
     connect(_socket.data(), &QTcpSocket::connected,    this, &SocketInterface::connected);
     connect(_socket.data(), &QTcpSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
-            SIGNAL(error(QTcpSocket::error)),
-            this,
-            SLOT(errorHandler(SocketInterface::error)));
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred),
+#else
+            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),
+#endif
+             this,
+             static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
 }
 
 QMQTT::Socket::~Socket()

--- a/mqtt/qmqtt_socket_p.h
+++ b/mqtt/qmqtt_socket_p.h
@@ -50,7 +50,7 @@ class Socket : public SocketInterface
 {
     Q_OBJECT
 public:
-    explicit Socket(QObject* parent = NULL);
+    explicit Socket(QObject* parent = nullptr);
     virtual	~Socket();
 
     virtual QIODevice *ioDevice();

--- a/mqtt/qmqtt_socketinterface.h
+++ b/mqtt/qmqtt_socketinterface.h
@@ -54,7 +54,7 @@ class Q_MQTT_EXPORT SocketInterface : public QObject
 {
     Q_OBJECT
 public:
-    explicit SocketInterface(QObject* parent = NULL) : QObject(parent) {}
+    explicit SocketInterface(QObject* parent = nullptr) : QObject(parent) {}
     virtual ~SocketInterface() {}
 
     virtual QIODevice* ioDevice() = 0;
@@ -70,7 +70,7 @@ public:
     virtual void setSslConfiguration(const QSslConfiguration& config) { Q_UNUSED(config); }
 #endif // QT_NO_SSL
 
-signals:
+Q_SIGNALS:
     void connected();
     void disconnected();
     void error(QAbstractSocket::SocketError socketError);

--- a/mqtt/qmqtt_ssl_socket.cpp
+++ b/mqtt/qmqtt_ssl_socket.cpp
@@ -46,9 +46,13 @@ QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
     connect(_socket.data(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
     connect(_socket.data(), &QSslSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
-            SIGNAL(error(QSslSocket::error)),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::errorOccurred),
+#else
+            static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::error),
+#endif
             this,
-            SLOT(errorHandler(SocketInterface::error)));
+            static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
     connect(_socket.data(),
             static_cast<void (QSslSocket::*)(const QList<QSslError>&)>(&QSslSocket::sslErrors),
             this,

--- a/mqtt/qmqtt_ssl_socket_p.h
+++ b/mqtt/qmqtt_ssl_socket_p.h
@@ -54,7 +54,7 @@ class SslSocket : public SocketInterface
 {
     Q_OBJECT
 public:
-    explicit SslSocket(const QSslConfiguration& config, QObject* parent = NULL);
+    explicit SslSocket(const QSslConfiguration& config, QObject* parent = nullptr);
     virtual ~SslSocket();
 
     virtual QIODevice *ioDevice();

--- a/mqtt/qmqtt_timer_p.h
+++ b/mqtt/qmqtt_timer_p.h
@@ -43,7 +43,7 @@ class Timer : public TimerInterface
 {
     Q_OBJECT
 public:
-    explicit Timer(QObject *parent = 0);
+    explicit Timer(QObject *parent = nullptr);
     virtual ~Timer();
 
     bool isSingleShot() const;

--- a/mqtt/qmqtt_timerinterface.h
+++ b/mqtt/qmqtt_timerinterface.h
@@ -42,7 +42,7 @@ class Q_MQTT_EXPORT TimerInterface : public QObject
 {
     Q_OBJECT
 public:
-    explicit TimerInterface(QObject* parent = NULL) : QObject(parent) {}
+    explicit TimerInterface(QObject* parent = nullptr) : QObject(parent) {}
     virtual ~TimerInterface() {}
 
     virtual bool isSingleShot() const = 0;
@@ -52,7 +52,7 @@ public:
     virtual void start() = 0;
     virtual void stop() = 0;
 
-signals:
+Q_SIGNALS:
     void timeout();
 };
 

--- a/mqtt/qmqtt_websocket.cpp
+++ b/mqtt/qmqtt_websocket.cpp
@@ -16,7 +16,7 @@ QMQTT::WebSocket::WebSocket(const QString& origin,
     , _ioDevice(new WebSocketIODevice(_socket, this))
 {
     initialize();
-    if (sslConfig != NULL)
+    if (sslConfig != nullptr)
         _socket->setSslConfiguration(*sslConfig);
     connect(_socket, &QWebSocket::sslErrors, this, &WebSocket::sslErrors);
 }

--- a/mqtt/qmqtt_websocket_p.h
+++ b/mqtt/qmqtt_websocket_p.h
@@ -62,12 +62,12 @@ public:
     WebSocket(const QString& origin,
               QWebSocketProtocol::Version version,
               const QSslConfiguration* sslConfig,
-              QObject* parent = NULL);
+              QObject* parent = nullptr);
 #endif // QT_NO_SSL
 
     WebSocket(const QString& origin,
               QWebSocketProtocol::Version version,
-              QObject* parent = NULL);
+              QObject* parent = nullptr);
 
     virtual ~WebSocket();
 

--- a/mqtt/qmqtt_websocketiodevice_p.h
+++ b/mqtt/qmqtt_websocketiodevice_p.h
@@ -37,12 +37,9 @@
 
 #include <QByteArray>
 #include <QIODevice>
-#include <QList>
-#include <QAbstractSocket>
 
 QT_FORWARD_DECLARE_CLASS(QWebSocket)
 QT_FORWARD_DECLARE_CLASS(QNetworkRequest)
-QT_FORWARD_DECLARE_CLASS(QSslError)
 
 namespace QMQTT
 {
@@ -51,27 +48,18 @@ class WebSocketIODevice : public QIODevice
 {
     Q_OBJECT
 public:
-    explicit WebSocketIODevice(QWebSocket *socket, QObject *parent = NULL);
+    explicit WebSocketIODevice(QWebSocket *socket, QObject *parent = nullptr);
 
     bool connectToHost(const QNetworkRequest &request);
 
     virtual qint64 bytesAvailable() const;
-
-signals:
-    void connected();
-
-    void disconnected();
-
-    void error(QAbstractSocket::SocketError error);
-
-    void sslErrors(const QList<QSslError> &errors);
 
 protected:
     virtual qint64 readData(char *data, qint64 maxSize);
 
     virtual qint64 writeData(const char *data, qint64 maxSize);
 
-private slots:
+private Q_SLOTS:
     void binaryMessageReceived(const QByteArray &frame);
 
 private:

--- a/re/isotp_interpreterwindow.cpp
+++ b/re/isotp_interpreterwindow.cpp
@@ -3,6 +3,9 @@
 #include "mainwindow.h"
 #include "helpwindow.h"
 #include "filterutility.h"
+#include "bus_protocols/handler_factory.h"
+#include "bus_protocols/isotp_handler.h"
+#include "bus_protocols/uds_handler.h"
 
 ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     QDialog(parent),
@@ -12,7 +15,7 @@ ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames
     setWindowFlags(Qt::Window);
     modelFrames = frames;
 
-    decoder = new ISOTP_HANDLER;
+    decoder = HandlerFactory::createISOTPHandler();
     udsDecoder = new UDS_HANDLER;
 
     decoder->setReception(true);

--- a/re/isotp_interpreterwindow.cpp
+++ b/re/isotp_interpreterwindow.cpp
@@ -16,7 +16,7 @@ ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(const QVector<CANFrame> *frames
     modelFrames = frames;
 
     decoder = HandlerFactory::createISOTPHandler();
-    udsDecoder = new UDS_HANDLER;
+    udsDecoder = HandlerFactory::createUDSHandler();
 
     decoder->setReception(true);
     decoder->setProcessAll(true);

--- a/re/isotp_interpreterwindow.h
+++ b/re/isotp_interpreterwindow.h
@@ -2,10 +2,14 @@
 #define ISOTP_INTERPRETERWINDOW_H
 
 #include <QDialog>
-#include "bus_protocols/isotp_handler.h"
+#include <QListWidgetItem>
+#include "can_structs.h"
+
 
 class ISOTP_MESSAGE;
+class UDS_MESSAGE;
 class ISOTP_HANDLER;
+class UDS_HANDLER;
 
 namespace Ui {
 class ISOTP_InterpreterWindow;

--- a/re/udsscanwindow.cpp
+++ b/re/udsscanwindow.cpp
@@ -2,6 +2,7 @@
 #include "ui_udsscanwindow.h"
 #include "mainwindow.h"
 #include "connections/canconmanager.h"
+#include "bus_protocols/handler_factory.h"
 #include "bus_protocols/uds_handler.h"
 #include "utility.h"
 #include "helpwindow.h"
@@ -37,7 +38,7 @@ UDSScanWindow::UDSScanWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     waitTimer = new QTimer;
     waitTimer->setInterval(100);
 
-    udsHandler = new UDS_HANDLER;
+    udsHandler = HandlerFactory::createUDSHandler();
     inhibitUpdates = false;
 
     for (int i = 0; i < 13; i++) ui->cbScanType->addItem(SCANTYPE_NAMES[i]);

--- a/scriptcontainer.cpp
+++ b/scriptcontainer.cpp
@@ -1,8 +1,12 @@
 #include <QJSValueIterator>
 #include <QDebug>
+#include <QTableWidget>
 
 #include "scriptcontainer.h"
 #include "connections/canconmanager.h"
+#include "bus_protocols/isotp_handler.h"
+#include "bus_protocols/handler_factory.h"
+#include "scriptingwindow.h"
 
 ScriptContainer::ScriptContainer()
 {
@@ -281,8 +285,8 @@ void CANScriptHelper::gotTargettedFrame(const CANFrame &frame)
 ISOTPScriptHelper::ISOTPScriptHelper(QJSEngine *engine)
 {
     scriptEngine = engine;
-    handler = new ISOTP_HANDLER;
-    connect(handler, SIGNAL(newISOMessage(ISOTP_MESSAGE)), this, SLOT(newISOMessage(ISOTP_MESSAGE)));
+    handler = HandlerFactory::createISOTPHandler();
+    connect(handler, &ISOTP_HANDLER::newISOMessage, this, &ISOTPScriptHelper::newISOMessage);
     handler->setReception(true);
     handler->setFlowCtrl(true);
 }

--- a/scriptcontainer.cpp
+++ b/scriptcontainer.cpp
@@ -5,6 +5,7 @@
 #include "scriptcontainer.h"
 #include "connections/canconmanager.h"
 #include "bus_protocols/isotp_handler.h"
+#include "bus_protocols/uds_handler.h"
 #include "bus_protocols/handler_factory.h"
 #include "scriptingwindow.h"
 
@@ -366,7 +367,7 @@ void ISOTPScriptHelper::newISOMessage(ISOTP_MESSAGE msg)
 UDSScriptHelper::UDSScriptHelper(QJSEngine *engine)
 {
     scriptEngine = engine;
-    handler = new UDS_HANDLER;
+    handler = HandlerFactory::createUDSHandler();
     connect(handler, SIGNAL(newUDSMessage(UDS_MESSAGE)), this, SLOT(newUDSMessage(UDS_MESSAGE)));
     handler->setReception(true);
     handler->setFlowCtrl(true); //uds potentially requires flow control so turn it on

--- a/scriptcontainer.h
+++ b/scriptcontainer.h
@@ -14,6 +14,7 @@
 class ScriptingWindow;
 class QTableWidget;
 class ISOTP_HANDLER;
+class UDS_HANDLER;
 
 class CANScriptHelper: public QObject
 {

--- a/scriptcontainer.h
+++ b/scriptcontainer.h
@@ -3,7 +3,6 @@
 
 #include "can_structs.h"
 #include "canfilter.h"
-#include "bus_protocols/isotp_handler.h"
 #include "bus_protocols/isotp_message.h"
 #include "bus_protocols/uds_handler.h"
 
@@ -13,6 +12,8 @@
 #include <qlistwidget.h>
 
 class ScriptingWindow;
+class QTableWidget;
+class ISOTP_HANDLER;
 
 class CANScriptHelper: public QObject
 {

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -4,12 +4,14 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QSettings>
+#include <QMessageBox>
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
 #include <QtCore/QRandomGenerator>
 #endif
 
 #include "connections/canconmanager.h"
 #include "helpwindow.h"
+#include "utility.h"
 
 ScriptingWindow::ScriptingWindow(const QVector<CANFrame> *frames, QWidget *parent) :
     QDialog(parent),

--- a/ui/discretestatewindow.ui
+++ b/ui/discretestatewindow.ui
@@ -169,7 +169,6 @@
           <font>
            <family>Nirmala UI</family>
            <pointsize>26</pointsize>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>

--- a/ui/scriptingwindow.ui
+++ b/ui/scriptingwindow.ui
@@ -20,7 +20,6 @@
       <widget class="QLabel" name="label_4">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -39,7 +38,6 @@
       <widget class="QLabel" name="label">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -87,7 +85,6 @@
       <widget class="QLabel" name="label_2">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -142,7 +139,6 @@
       <widget class="QLabel" name="label_3">
        <property name="font">
         <font>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.21)
+project(SavvyCAN_unit_tests LANGUAGES CXX)
+
+set(QT_MIN_VERSION 6.4)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Find Qt6
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Test SerialBus)
+
+# Directories where SavvyCAN headers live
+set(SAVVYCAN_INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bus_protocols
+    ${CMAKE_CURRENT_SOURCE_DIR}/../connections
+    ${CMAKE_CURRENT_SOURCE_DIR}/../utils
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+###### iso-tp handler test ######
+set(TEST_SOURCES_ISOTP_HANDLER
+    test_isotp_handler.cpp
+    ../bus_protocols/isotp_handler.cpp  # the class under test
+    ../canfilter.cpp
+)
+
+add_executable(TestIsoTpHandler ${TEST_SOURCES_ISOTP_HANDLER})
+
+target_include_directories(TestIsoTpHandler PRIVATE ${SAVVYCAN_INCLUDE_DIRS})
+
+target_link_libraries(TestIsoTpHandler
+    Qt6::Core
+    Qt6::Test
+    Qt6::SerialBus
+)
+
+# Enable ctest integration
+enable_testing()
+add_test(NAME TestIsoTpHandler COMMAND TestIsoTpHandler)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # Find Qt6
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Test SerialBus)
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS Core Test SerialBus Widgets)
 
 # Directories where SavvyCAN headers live
 set(SAVVYCAN_INCLUDE_DIRS
@@ -39,6 +39,29 @@ target_link_libraries(TestIsoTpHandler
     Qt6::SerialBus
 )
 
+###### uds handler test ######
+set(TEST_SOURCES_UDS_HANDLER
+    test_uds_handler.cpp
+    ../bus_protocols/uds_handler.cpp  # the class under test
+    ../bus_protocols/isotp_handler.cpp
+
+    ../canfilter.cpp
+    ../utility.cpp
+)
+
+add_executable(TestUdsHandler ${TEST_SOURCES_UDS_HANDLER})
+
+target_include_directories(TestUdsHandler PRIVATE ${SAVVYCAN_INCLUDE_DIRS})
+
+target_link_libraries(TestUdsHandler
+    Qt6::Core
+    Qt6::Test
+    Qt6::SerialBus
+    Qt6::Widgets
+)
+
+
 # Enable ctest integration
 enable_testing()
 add_test(NAME TestIsoTpHandler COMMAND TestIsoTpHandler)
+add_test(NAME TestUdsHandler COMMAND TestUdsHandler)

--- a/unit_tests/test_isotp_handler.cpp
+++ b/unit_tests/test_isotp_handler.cpp
@@ -1,0 +1,313 @@
+#include <QtTest/QtTest>
+#include "isotp_handler.h"
+
+class TestIsoTpHandler : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+
+    void testSingleFrame();
+    void testFirstAndConsecutiveFramesNoCf();
+    void testFirstAndConsecutiveFramesWithCf();
+    void testFlowControlFrame();
+    void testExtendedAddressing();
+    void testFirstAndConsecutiveFramesAndExtedingAddressingNoCf();
+    void testFirstAndConsecutiveFramesAndExtedingAddressingWithCf();
+signals:
+    void framesReceived(void*, const QVector<CANFrame>& frames);
+private:
+    void sendCanFramesToHandler(void*, const QVector<CANFrame>& frames);
+    void helperFirstAndConsecutiveFrames(bool sendCF);
+    void helperFirstAndConsecutiveFramesAndExtedingAddressing(bool sendCF);
+    std::vector<ISOTP_MESSAGE> capturedIsoTpMessages;
+    std::vector<CANFrame> sentFrames;
+    QVector<CANFrame> dummyFrames;
+    std::unique_ptr<ISOTP_HANDLER> isotp_handler;
+};
+
+void TestIsoTpHandler::sendCanFramesToHandler(void*, const QVector<CANFrame>& frames)
+{
+    emit framesReceived(nullptr, frames);
+}
+
+void TestIsoTpHandler::init()
+{
+    capturedIsoTpMessages.clear();
+    sentFrames.clear();
+    dummyFrames.clear();
+
+    // Create pendingConnection to later send can frames into the handler
+    auto pendingConn = [this](ISOTP_HANDLER* handler) -> QMetaObject::Connection {
+        return QObject::connect(
+            this,
+            &TestIsoTpHandler::framesReceived,
+            handler,
+            [handler](void*, const QVector<CANFrame>& frames){
+                handler->rapidFrames(frames);
+            }
+        );
+    };
+
+    // Construct ISOTP_HANDLER with proper callbacks
+    isotp_handler = std::make_unique<ISOTP_HANDLER>(
+        dummyFrames,
+        [this](const CANFrame& frame) { sentFrames.push_back(frame); },
+        []() -> int { return 1; }, // getNoOfBuses callback
+        pendingConn
+    );
+
+    // capture the sent isotp messages
+    QObject::connect(isotp_handler.get(), &ISOTP_HANDLER::newISOMessage,
+            this, [this](const ISOTP_MESSAGE& msg) {
+            capturedIsoTpMessages.push_back(msg);
+            });
+
+    // Process all message IDs, not just filtered ones
+    isotp_handler->setProcessAll(true);
+    // enable pendingConn
+    isotp_handler->setReception(true);
+}
+
+void TestIsoTpHandler::cleanup()
+{
+    isotp_handler.reset();
+    capturedIsoTpMessages.clear();
+    sentFrames.clear();
+}
+
+// --- Test Single Frame (SF) ---
+void TestIsoTpHandler::testSingleFrame()
+{
+    CANFrame frame;
+    frame.bus = 0;
+    frame.setFrameId(0x123);
+    frame.setExtendedFrameFormat(false);
+
+    QByteArray data(8, 0);
+    data[0] = 0x02; // SF, length = 2
+    data[1] = 0xDE;
+    data[2] = 0xAD;
+    frame.setPayload(data);
+
+    sendCanFramesToHandler(nullptr, {frame});
+
+    QCOMPARE(capturedIsoTpMessages.size(), 1u);
+    QCOMPARE(capturedIsoTpMessages[0].frameId(), 0x123u);
+    QCOMPARE(capturedIsoTpMessages[0].payload(), QByteArray::fromHex("dead"));
+}
+
+void TestIsoTpHandler::testFirstAndConsecutiveFramesWithCf()
+{
+    helperFirstAndConsecutiveFrames(true);
+}
+
+void TestIsoTpHandler::testFirstAndConsecutiveFramesNoCf()
+{
+    helperFirstAndConsecutiveFrames(false);
+}
+
+void TestIsoTpHandler::helperFirstAndConsecutiveFrames(bool sendCF)
+{
+    int senderId = 0x451;
+    int receiverId = 0x456;
+    if (sendCF)
+    {
+        isotp_handler->setFlowCtrl(sendCF);
+        // send SF Message to set private members lastSenderID and lastSenderBus
+        // that are needed for later FC frame
+        isotp_handler->sendISOTPFrame(/* bus */ 0, senderId, QByteArray::fromHex("AFFEBABE"));
+    }
+
+    // FF – total length = 8 bytes
+    CANFrame ff;
+    ff.bus = 0;
+    ff.setFrameId(receiverId);
+    ff.setExtendedFrameFormat(false);
+    QByteArray ffData(8, 0);
+    ffData[0] = 0x10; // FF type
+    ffData[1] = 0x08; // total length = 8
+    ffData[2] = 0xCA;
+    ffData[3] = 0xFE;
+    ffData[4] = 0xBA;
+    ffData[5] = 0xBE;
+    ffData[6] = 0xAF;
+    ffData[7] = 0xFE;
+    ff.setPayload(ffData);
+
+    sendCanFramesToHandler(nullptr, {ff});
+
+    if (sendCF)
+    {
+        auto &msg = sentFrames[0];
+        QCOMPARE(msg.payload(), QByteArray::fromHex("04AFFEBABEAAAAAA"));
+        QCOMPARE(msg.frameId(), senderId);
+        // FC - did we sent it?
+        QCOMPARE(sentFrames.size(), 2u);
+        QByteArray fcData(8, 0);
+        fcData[0] = 0x30; // Flow Control: Continue
+        fcData[1] = 0x00; // Block size
+        fcData[2] = 0x03; // STmin
+        QCOMPARE(sentFrames[1].payload(), fcData);
+    }
+
+    // CF – remaining 2 bytes
+    CANFrame cf;
+    cf.bus = 0;
+    cf.setFrameId(receiverId);
+    cf.setExtendedFrameFormat(false);
+    QByteArray cfData(8, 0);
+    cfData[0] = 0x21; // sequence 1
+    cfData[1] = 0xEF;
+    cfData[2] = 0xAC;
+    cfData[3] = 0x00;
+    cfData[4] = 0x00;
+    cfData[5] = 0x00;
+    cfData[6] = 0x00;
+    cfData[7] = 0x00;
+    cf.setPayload(cfData);
+
+    sendCanFramesToHandler(nullptr, {cf});
+
+    QCOMPARE(capturedIsoTpMessages.size(), 1u);
+    QCOMPARE(capturedIsoTpMessages[0].frameId(), 0x456u);
+    auto &msg = capturedIsoTpMessages[0];
+    QCOMPARE(msg.reportedLength, /* expectedLength */ 8);
+    QCOMPARE(msg.payload(), QByteArray::fromHex("CAFEBABEAFFEEFAC"));
+}
+
+void TestIsoTpHandler::testFirstAndConsecutiveFramesAndExtedingAddressingNoCf()
+{
+    helperFirstAndConsecutiveFramesAndExtedingAddressing(false);
+}
+
+void TestIsoTpHandler::testFirstAndConsecutiveFramesAndExtedingAddressingWithCf()
+{
+    helperFirstAndConsecutiveFramesAndExtedingAddressing(true);
+}
+
+void TestIsoTpHandler::helperFirstAndConsecutiveFramesAndExtedingAddressing(bool sendCF)
+{
+    int senderId = 0x451;
+    int receiverId = 0x456;
+    uint8_t targetAddress = 0xfb; // TA (extended addressing)
+
+    isotp_handler->setExtendedAddressing(true);
+
+    if (sendCF)
+    {
+        isotp_handler->setFlowCtrl(sendCF);
+        // send SF Message to set private members lastSenderID and lastSenderBus
+        // that are needed for later FC frame
+        isotp_handler->sendISOTPFrame(/* bus */ 0, senderId, QByteArray::fromHex("AFFEBABE"));
+    }
+
+    // FF – total length = 8 bytes
+    CANFrame ff;
+    ff.bus = 0;
+    ff.setFrameId(receiverId);
+    ff.setExtendedFrameFormat(false);
+    QByteArray ffData(8, 0);
+    ffData[0] = targetAddress;
+    ffData[1] = 0x10; // FF type
+    ffData[2] = 0x08; // total length = 8
+    ffData[3] = 0xCA;
+    ffData[4] = 0xFE;
+    ffData[5] = 0xBA;
+    ffData[6] = 0xBE;
+    ffData[7] = 0xAF;
+    ff.setPayload(ffData);
+
+    sendCanFramesToHandler(nullptr, {ff});
+
+    if (sendCF)
+    {
+        auto &msg = sentFrames[0];
+        QCOMPARE(msg.payload(), QByteArray::fromHex("04AFFEBABEAAAAAA"));
+        QCOMPARE(msg.frameId(), senderId);
+        // FC - did we sent it?
+        QCOMPARE(sentFrames.size(), 2u);
+        QByteArray fcData(8, 0);
+        fcData[0] = 0x30; // Flow Control: Continue
+        fcData[1] = 0x00; // Block size
+        fcData[2] = 0x03; // STmin
+        QCOMPARE(sentFrames[1].payload(), fcData);
+    }
+
+    // CF – remaining 2 bytes
+    CANFrame cf;
+    cf.bus = 0;
+    cf.setFrameId(receiverId);
+    cf.setExtendedFrameFormat(false);
+    QByteArray cfData(8, 0);
+    cfData[0] = targetAddress;
+    cfData[1] = 0x21; // sequence 1
+    cfData[2] = 0xFE;
+    cfData[3] = 0xEF;
+    cfData[4] = 0xAC;
+    cfData[5] = 0x00;
+    cfData[6] = 0x00;
+    cfData[7] = 0x00;
+    cf.setPayload(cfData);
+
+    sendCanFramesToHandler(nullptr, {cf});
+
+    QCOMPARE(capturedIsoTpMessages.size(), 1u);
+    QCOMPARE(capturedIsoTpMessages[0].frameId() >> 8 ,  receiverId); // the CAN id
+    QCOMPARE(capturedIsoTpMessages[0].frameId() & 0xFF,  targetAddress); // the TA
+    auto &msg = capturedIsoTpMessages[0];
+    QCOMPARE(msg.reportedLength, /* expectedLength */ 8);
+    QCOMPARE(msg.payload(), QByteArray::fromHex("CAFEBABEAFFEEFAC"));
+}
+
+// --- Test Flow Control Frame (FC) ---
+void TestIsoTpHandler::testFlowControlFrame()
+{
+    CANFrame fc;
+    fc.bus = 0;
+    fc.setFrameId(0x321);
+    fc.setExtendedFrameFormat(false);
+    QByteArray fcData(8, 0);
+    fcData[0] = 0x30; // Flow Control: Continue To Send
+    fcData[1] = 0x00; // block size
+    fcData[2] = 0x05; // separation time
+    fc.setPayload(fcData);
+
+    sendCanFramesToHandler(nullptr, {fc});
+
+    // FC frame should not generate ISO messages
+    QVERIFY(capturedIsoTpMessages.empty());
+    QVERIFY(sentFrames.empty());
+}
+
+// --- Extended Addressing Test ---
+void TestIsoTpHandler::testExtendedAddressing()
+{
+    isotp_handler->setExtendedAddressing(true);
+    int receiverId = 0x200;
+
+    CANFrame frame;
+    frame.bus = 0;
+    frame.setFrameId(receiverId);
+    frame.setExtendedFrameFormat(false);
+    QByteArray data(8, 0);
+
+    uint8_t targetAddress = 0xfb; // TA (extended addressing)
+    data[0] = targetAddress;
+    data[1] = 0x02; // SF, length=2
+    data[2] = 0xAA;
+    data[3] = 0xBB;
+    frame.setPayload(data);
+
+    sendCanFramesToHandler(nullptr, {frame});
+
+    QCOMPARE(capturedIsoTpMessages.size(), 1u);
+    QCOMPARE(capturedIsoTpMessages[0].frameId() >> 8 ,  receiverId); // the CAN id
+    QCOMPARE(capturedIsoTpMessages[0].frameId() & 0xFF,  targetAddress); // the TA
+    QCOMPARE(capturedIsoTpMessages[0].payload(), QByteArray::fromHex("AABB")); // payload
+}
+
+QTEST_MAIN(TestIsoTpHandler)
+#include "test_isotp_handler.moc"

--- a/unit_tests/test_uds_handler.cpp
+++ b/unit_tests/test_uds_handler.cpp
@@ -1,0 +1,183 @@
+#include <QtTest/QtTest>
+#include "isotp_handler.h"
+#include "uds_handler.h"
+
+class TestUdsHandler : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void cleanup();
+    void testReadDataByIdentifier();
+    void testMultiFrameResponse();
+    void testNegativeResponse();
+signals:
+    void framesReceived(void*, const QVector<CANFrame>& frames);
+    void forwardedISOTPMessage(const ISOTP_MESSAGE& msg);
+private:
+    void sendCanFramesToHandler(void*, const QVector<CANFrame>& frames);
+    void sendIsoTpFramesToHandler(const ISOTP_MESSAGE& msg);
+    ISOTP_HANDLER* initAndGetIsoTpHandler();
+    std::vector<ISOTP_MESSAGE> capturedIsoTpMessages;
+    std::vector<UDS_MESSAGE> capturedUDSMessages;
+    std::vector<CANFrame> sentFrames;
+    QVector<CANFrame> dummyFrames;
+    UDS_HANDLER* uds_handler;
+};
+
+void TestUdsHandler::sendCanFramesToHandler(void*, const QVector<CANFrame>& frames)
+{
+    emit framesReceived(nullptr, frames);
+}
+
+void TestUdsHandler::sendIsoTpFramesToHandler(const ISOTP_MESSAGE& msg)
+{
+    emit forwardedISOTPMessage(msg);
+}
+
+ISOTP_HANDLER* TestUdsHandler::initAndGetIsoTpHandler()
+{
+    capturedIsoTpMessages.clear();
+
+    ISOTP_HANDLER* isotp_handler;
+    // Create pendingConnection to later send can frames into the handler
+    auto pendingConn = [this](ISOTP_HANDLER* handler) -> QMetaObject::Connection {
+        return QObject::connect(
+            this,
+            &TestUdsHandler::framesReceived,
+            handler,
+            [handler](void*, const QVector<CANFrame>& frames){
+                handler->rapidFrames(frames);
+            }
+        );
+    };
+
+    // Construct ISOTP_HANDLER with proper callbacks
+    isotp_handler = new ISOTP_HANDLER(
+        dummyFrames,
+        [this](const CANFrame& frame) { sentFrames.push_back(frame); },
+        []() -> int { return 1; }, // getNoOfBuses callback
+        pendingConn
+    );
+
+    // capture the sent isotp messages
+    QObject::connect(isotp_handler, &ISOTP_HANDLER::newISOMessage,
+            this, [this](const ISOTP_MESSAGE& msg) {
+            emit forwardedISOTPMessage(msg);
+            capturedIsoTpMessages.push_back(msg);
+            });
+
+    return isotp_handler;
+}
+
+void TestUdsHandler::init()
+{
+    capturedUDSMessages.clear();
+    sentFrames.clear();
+    dummyFrames.clear();
+
+
+    ///////////////// UDS handler setup //////////////
+    // Create UDS_HANDLER with proper callbacks
+    auto udsPendingConn = [this](UDS_HANDLER *handler) -> QMetaObject::Connection
+    {
+        return QObject::connect(
+            this,
+            &TestUdsHandler::forwardedISOTPMessage,
+            handler,
+            [handler](const ISOTP_MESSAGE& msg)
+            {
+                handler->gotISOTPFrame(msg);
+            });
+    };
+
+    uds_handler = new UDS_HANDLER(
+        initAndGetIsoTpHandler(),
+        []() -> int { return 1; }, // getNoOfBuses callback
+        udsPendingConn
+    );
+
+    uds_handler->setProcessAllIDs(true);
+    uds_handler->setReception(true);
+
+    // capture the sent uds messages
+    QObject::connect(uds_handler, &UDS_HANDLER::newUDSMessage,
+            this, [this](UDS_MESSAGE msg) {
+            capturedUDSMessages.push_back(msg);
+            });
+}
+
+void TestUdsHandler::cleanup()
+{
+    delete uds_handler;
+    capturedIsoTpMessages.clear();
+    capturedUDSMessages.clear();
+    sentFrames.clear();
+}
+
+void TestUdsHandler::testReadDataByIdentifier()
+{
+    ISOTP_MESSAGE msg;
+
+    msg.setFrameType(QCanBusFrame::FrameType::DataFrame);
+    msg.setExtendedFrameFormat(false);
+    msg.setFrameId(0x7E0);
+    msg.reportedLength = 3;
+    msg.setPayload(QByteArray::fromHex("22F190")); // ReadDataByIdentifier, DID=F190
+
+    // Feed the ISO-TP message via QT signal -> slot
+    sendIsoTpFramesToHandler(msg);
+
+    QCOMPARE(capturedUDSMessages.size(), 1u);
+
+    const UDS_MESSAGE& uds = capturedUDSMessages[0];
+    qDebug() << uds_handler->getDetailedMessageAnalysis(uds);
+    QCOMPARE(uds.service, 0x22);
+    QCOMPARE(uds.payload(), QByteArray::fromHex("F190"));
+}
+
+void TestUdsHandler::testMultiFrameResponse()
+{
+    // Prepare a multi-frame ISO-TP message: positive response 0x62, DID F190, VIN starts with "WVW1234"
+    ISOTP_MESSAGE msg;
+    msg.setFrameId(0x7E8);
+    msg.reportedLength = 20;
+    msg.setPayload(QByteArray::fromHex("62F1905756575731323334")); // 0x62 = positive response, F190 = DID
+
+    // Feed the ISO-TP message via QT signal -> slot
+    sendIsoTpFramesToHandler(msg);
+
+    // Verify that one UDS message was captured
+    QCOMPARE(capturedUDSMessages.size(), 1u);
+
+    const UDS_MESSAGE& uds = capturedUDSMessages[0];
+    qDebug() << uds_handler->getDetailedMessageAnalysis(uds);
+    QCOMPARE(uds.service, 0x62);                         // service byte
+    QVERIFY(uds.payload().startsWith(QByteArray::fromHex("F190"))); // DID should be first bytes
+    QVERIFY(uds.payload().contains("WVW"));             // VIN prefix check
+}
+
+void TestUdsHandler::testNegativeResponse()
+{
+    // ISO-TP negative response: service 0x7F, original service 0x22, NRC = 0x13
+    ISOTP_MESSAGE msg;
+    msg.setFrameType(QCanBusFrame::FrameType::DataFrame);
+    msg.setExtendedFrameFormat(false);
+    msg.setFrameId(0x7E8);
+    msg.reportedLength = 3;
+    msg.setPayload(QByteArray::fromHex("7F2213")); // 0x7F = NACK, 0x22 = service, 0x13 = NRC
+
+    // Feed the ISO-TP message via QT signal -> slot
+    sendIsoTpFramesToHandler(msg);
+
+    QCOMPARE(capturedUDSMessages.size(), 1u);
+
+    const UDS_MESSAGE& uds = capturedUDSMessages[0];
+    QCOMPARE(uds.service, 0x22);      // original requested service
+    QVERIFY(uds.isErrorReply);        // should be flagged as negative response
+    QCOMPARE(uds.subFunc, 0x13);      // NRC
+    QCOMPARE(uds.payload(), QByteArray()); // payload should be empty after removing 2 bytes
+}
+QTEST_MAIN(TestUdsHandler)
+#include "test_uds_handler.moc"


### PR DESCRIPTION
I've added some unit tests for uds and isotp. I had to refactor those classes and use cmake to compile the tests the (CMakeLists.txt for building the test is independent)

I created them in the subfolder unit_tests/

you can build the tests there after configuring a cmake build dir like that
```

mkdir unit_tests/build
cd unit_tests/build
cmake ..
make TestUdsHandler
make TestIsoTpHandler 
# or use just make to build both at once
```

Below are the commit messages that are relevant for this PR as it is based on my previous PR https://github.com/collin80/SavvyCAN/pull/980

**-> the tests for uds handler are incomplete as there might be a bug:**
commit 058163ecefdde52c8f430f4cdd5e7cbdef9c8cb4

    unit test for UDS_HANDLER
    
    The tests are partially working as there is some confusion and likely
    a bug in UDS_HANDLER::tryISOtoUDS:
    
    udsMsg.payload().remove(0, 1);
    
    - this statement does not change the payload so the SID stays in the payload.
    - There are other occurrences of the same pattern
    
    and In UDS_HANDLER::getDetailedMessageAnalysis eg. in
    'case UDS_SERVICES::READ_BY_ID:' the first byte is skipped, as it was not
    removed beforehand in tryISOtoUDS()
    is that intentional?
    some of my tests fail

commit d60637246c7cf38a1ed60646a3b2006709f47011
    refactor UDS_HANDLER to make it easier for unit tests
    - avoid tight coupling inside the class with callbacks
    - add handler_factory class for UDS_HANDLER
    - add some forward definitions and move some headers includes
    - have modelFrames removed as it is not used at all

commit b0e494268805f6990f4d1234627790b55dfe78d3
    simplify processFrame with precalculated ISO-TP frameinfo

commit 42ea9b0ec780a8cdb67199acd2983141aebc19c5
    unit test for ISOTP_HANDLER
    some isotp tests:
    - testSingleFrame
    - testFirstAndConsecutiveFramesNoCf
    - testFirstAndConsecutiveFramesWithCf
    - testFlowControlFrame
    - testExtendedAddressing
    - testFirstAndConsecutiveFramesAndExtedingAddressingNoCf
    - testFirstAndConsecutiveFramesAndExtedingAddressingWithCf

commit cc8c646b7cbf06647555c81b904f35a03974c955
    refactor ISOTP_HANDLER to make it easier for unit tests
    - avoid tight coupling inside the class with callbacks
    - add handler_factory class for ISOTP_HANDLER
    - add some forward definitions and move some headers includes
    - have modelFrames as reference instead of a pointer
