### PR TITLE
Correct length in host IP and port extraction

### DIFF
--- a/connections/socketcand.cpp
+++ b/connections/socketcand.cpp
@@ -20,7 +20,7 @@ SocketCANd::SocketCANd(QString portName) :
 
     sendDebug("SocketCANd()");
     hostCanIDs = portName.left(portName.indexOf("@")).split(',');
-    QString hostIPandPort = portName.mid(portName.indexOf("can://")+6, portName.length() - portName.indexOf("can://") - 6); //6 is lenght of 'can://'
+    QString hostIPandPort = portName.mid(portName.indexOf("can://")+6, portName.length() - portName.indexOf("can://") - 7); //7 is lenght of 'can://'
     hostIP = QHostAddress(hostIPandPort.left(hostIPandPort.indexOf(":")));
     hostPort = (hostIPandPort.right(hostIPandPort.length() - hostIPandPort.lastIndexOf(":") -1)).toInt();
     mNumBuses = hostCanIDs.length();


### PR DESCRIPTION
The latest build for The QT6WIP didnt connect to a socketcand server, from the console output i noticed that the port it tried to connect was :0 instead of the actual port. I compared the differences between the main and qt6 branches and noticed this difference in the ip and port extraction part, changing it and building for a couple hours fixed the issue. I also build it myself with the original value and that did not work, im confident this is the proper fix for this issue.