### PR TITLE
refactor: Remove logged and version from asc file detection

### DIFF
--- a/framefileio.cpp
+++ b/framefileio.cpp
@@ -1661,16 +1661,6 @@ bool FrameFileIO::isCanalyzerASC(QString filename)
             line = inFile->readLine();
             if (!line.startsWith("base")) isMatch = false;
         }
-        if (!inFile->atEnd() && isMatch)
-        {
-            line = inFile->readLine();
-            if (!line.contains("logged")) isMatch = false;
-        }
-        if (!inFile->atEnd() && isMatch)
-        {
-            line = inFile->readLine();
-            if (!line.contains("version")) isMatch = false;
-        }
     }
     catch (...)
     {


### PR DESCRIPTION
Possible solution to issue #847
Some `asc` files seem not to have the "logged" and "version" keywords.
As an example, Kvazer Memorator exported logs have the following format:
```
date Fri Dec 19 05:10:18 pm 2025
base hex timestamps absolute
// CAN channel: 1 2
Begin Triggerblock
// ;    time  can ident           attr dlc data ...  
      0.311250987 Log Trigger Event (type=0x2, active=0x01, pre-trigger=0, post-trigger=0)
      0.311250987 1  C0           Rx   d   8 38 FF 00 00 01 01 00 00 
...
```
