### PR TITLE
UDSScanWindow fix dark theme

### DIFF
--- a/re/udsscanwindow.cpp
+++ b/re/udsscanwindow.cpp
@@ -118,8 +118,9 @@ bool UDSScanWindow::eventFilter(QObject *obj, QEvent *event)
 
 void UDSScanWindow::setControlState(QWidget & widget, bool valid)
 {
-    QPalette pal = widget.palette();
-    pal.setColor(QPalette::ColorRole::Base , valid ? Qt::white : Qt::red);
+    QPalette pal = QApplication::palette(&widget);    // default palette for widget's class
+    if (!valid)
+        pal.setColor(QPalette::ColorRole::Base, Qt::red);
     widget.setPalette(pal);
 }
 


### PR DESCRIPTION
If application uses default dark theme in Windows (win10 / win11), default is a white text on a dark gray.

That means that setting white background ('Base' in Qt terms) was not the best idea - I cannot read white text on a white background ;-)