### PR TITLE
Fix connection reset parameters and CAN‑FD toggle

### DIFF
--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -315,10 +315,21 @@ void ConnectionWindow::handleResetConn()
     type = conn_p->getType();
     port = conn_p->getPort();
     driver = conn_p->getDriver();
-    serSpeed = 0; //TODO: implement these
-    busSpeed = 0;
-    dataRate = 0;
-    canFd = false;
+    serSpeed = conn_p->getSerialSpeed();
+    // For multi-bus devices this grabs bus 0; better than zeroing it out.
+    CANBus bus;
+    if (conn_p->getBusSettings(0, bus))
+    {
+        busSpeed = bus.getSpeed();
+        canFd = bus.isCanFD();
+        dataRate = bus.getDataRate();
+    }
+    else
+    {
+        busSpeed = 0;
+        dataRate = 0;
+        canFd = false;
+    }
 
 
     /* stop and delete connection */

--- a/connections/newconnectiondialog.cpp
+++ b/connections/newconnectiondialog.cpp
@@ -435,7 +435,7 @@ bool NewConnectionDialog::isCanFd()
  {
      if (getConnectionType() == CANCon::LAWICEL)
      {
-         return ui->cbCanFd;
+         return ui->cbCanFd->isChecked();
      }
      else return 0;
  }


### PR DESCRIPTION
- preserve serial speed, bus speed, CAN‑FD flag, and data rate when resetting a connection so recreated devices reconnect with the same settings
- return the actual checked state of the CAN‑FD checkbox (was always true due to pointer conversion)