### PR TITLE
CANFrameModel:  beginResetModel() nested call

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -189,10 +189,8 @@ void CANFrameModel::normalizeTiming()
 
 void CANFrameModel::setOverwriteMode(bool mode)
 {
-    beginResetModel();
     overwriteDups = mode;
     recalcOverwrite();
-    endResetModel();
 }
 
 void CANFrameModel::setClearMode(bool mode)


### PR DESCRIPTION
these calls are not needed, since actually all needed things performed in the `recalcOverwrite()`