### PR TITLE
Modify the Note to point users to QT6 buildable source more easily.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to download it separately.
 
 This project requires 5.14.0 or higher because of a dependency on QtSerialBus and other new additions to Qt.
 
-NOTE: As the code in this master branch sits, it does compile with QT6. Support for QT6 is approximately "beta" quality. Most all functions should work, please send issues if found.
+NOTE: There is a work-in-progress branch QT6WIP that can compile with QT6 (Tested with Qt 6.9 on 2026-03-11). Support for QT6 is approximately "beta" quality. Most all functions should work, please send issues if found.
 
 It appears that the current binary build for MacOS requires at least MacOS 10.15
 


### PR DESCRIPTION
I was struggling a bit to compile SavvyCAN under QT6. As the NOTE was explaining, I should have been ok compiling the master branch. It did not work. Only after looking through the Issues, I found out about the QT6WIP branch, that worked for me. Hopefully this NOTE will help newcomers get to working program more easily.