### PR TITLE
Main table display format change: remove 'useHex', add 'useAsciiDec' to view data in decimal format

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -75,7 +75,7 @@ CANFrameModel::CANFrameModel(QObject *parent)
     interpretFrames = false;
     overwriteDups = false;
     filtersPersistDuringClear = false;
-    useHexMode = true;
+    useAsciiDec = true;
     timeStyle = TS_MICROS;
     timeOffset = 0;
     needFilterRefresh = false;
@@ -90,13 +90,13 @@ void CANFrameModel::setBytesPerLine(int bpl)
     bytesPerLine = bpl;
 }
 
-void CANFrameModel::setHexMode(bool mode)
+void CANFrameModel::setUseAsciiDec(bool mode)
 {
-    if (useHexMode != mode)
+    if (useAsciiDec != mode)
     {
         this->beginResetModel();
-        useHexMode = mode;
-        Utility::decimalMode = !useHexMode;
+        useAsciiDec = mode;
+        Utility::decimalMode = useAsciiDec;
         this->endResetModel();
     }
 }
@@ -476,20 +476,27 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
             if (ts.type() == QVariant::LongLong) return QString::number(ts.toLongLong()); //never scientific notion, all digits shown
             if (ts.type() == QVariant::DateTime) return ts.toDateTime().toString(timeFormat); //custom set format for dates and times
             return Utility::formatTimestamp(thisFrame.timeStamp().microSeconds());
+
         case Column::FrameId:
             return Utility::formatCANID(thisFrame.frameId(), thisFrame.hasExtendedFrameFormat());
+
         case Column::Extended:
             return QString::number(thisFrame.hasExtendedFrameFormat());
+
         case Column::Remote:
             if (!overwriteDups) return QString::number(thisFrame.frameType() == QCanBusFrame::RemoteRequestFrame);
             return QString::number(thisFrame.frameCount);
+
         case Column::Direction:
             if (thisFrame.isReceived) return QString(tr("Rx"));
             return QString(tr("Tx"));
+
         case Column::Bus:
             return QString::number(thisFrame.bus);
+
         case Column::Length:
             return QString::number(dataLen);
+
         case Column::ASCII:
             if (thisFrame.frameId() >= 0x7FFFFFF0ull)
             {
@@ -497,37 +504,57 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
                 tempString.append(QString::number(thisFrame.frameId() & 0x7));
                 return tempString;
             }
+
             if (thisFrame.frameType() == QCanBusFrame::DataFrame) {
                 if (dataLen < 0) dataLen = 0;
-                //if (dLen > 8) dLen = 8;
-                for (int i = 0; i < dataLen; i++)
+                
+                if (useAsciiDec)
                 {
-                    char byt = thisFrame.payload()[i];
-                    //0x20 through 0x7E are printable characters. Outside of that range they aren't. So use dots instead
-                    if (byt < 0x20) byt = 0x2E; //dot character
-                    if (byt > 0x7E) byt = 0x2E;
-                    tempString.append(QString::fromUtf8(&byt, 1));
-                    if (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) tempString.append("\n");
+                    for (int i = 0; i < dataLen; i++)
+                    {
+                        tempString.append(QString::number(data[i], 10).rightJustified(3, ' '));
+
+                        (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) ? 
+                            tempString.append("\n") : tempString.append(" ");
+                    }
+                } else {
+                    // classic ascii mode, non-printable characters are dots, and bytesPerLine determines when to wrap to a new line
+                    for (int i = 0; i < dataLen; i++)
+                    {
+                        char byt = thisFrame.payload()[i];
+                        //0x20 through 0x7E are printable characters. Outside of that range they aren't. So use dots instead
+                        if (byt < 0x20) byt = 0x2E; //dot character
+                        if (byt > 0x7E) byt = 0x2E;
+                        tempString.append(QString::fromUtf8(&byt, 1));
+                        if (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) tempString.append("\n");
+                    }
                 }
             }
+
             if (thisFrame.frameType() == QCanBusFrame::ErrorFrame)
             {
                  tempString = "ERROR";
             }
             return tempString;
+
         case Column::Data:
+
             if (dataLen < 0) dataLen = 0;
-            //if (useHexMode) tempString.append("0x ");
+
             if (thisFrame.frameType() == QCanBusFrame::RemoteRequestFrame) {
                 return tempString;
             }
-            for (int i = 0; i < dataLen; i++)
-            {
-                if (useHexMode) tempString.append( QString::number(data[i], 16).toUpper().rightJustified(2, '0'));
-                else tempString.append(QString::number(data[i], 10));
-                if (!((i+1) % bytesPerLine) && (i != (dataLen - 1))) tempString.append("\n");
-                else tempString.append(" ");
+
+            for (int i = 0; i < dataLen; i++) {
+
+                tempString.append( QString::number(data[i], 16).toUpper().rightJustified(2, '0'));
+
+                if (!((i+1) % bytesPerLine) && (i != (dataLen - 1)))
+                    tempString.append("\n");
+                else
+                    tempString.append(" ");
             }
+
             if (thisFrame.frameType() == thisFrame.ErrorFrame)
             {
                 if (thisFrame.error() & thisFrame.TransmissionTimeoutError) tempString.append("\nTX Timeout");
@@ -577,8 +604,9 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
                 }
             }
             return tempString;
-        default:
-            return tempString;
+
+            default:
+                return tempString;
         }
     }
 
@@ -612,7 +640,7 @@ QVariant CANFrameModel::headerData(int section, Qt::Orientation orientation,
         case Column::Length:
             return QString(tr("Len"));
         case Column::ASCII:
-            return QString(tr("ASCII"));
+            return QString(useAsciiDec ? tr("Decimal") : tr("ASCII"));
         case Column::Data:
             return QString(tr("Data"));
         default:

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -46,7 +46,7 @@ public:
     void setInterpretMode(bool);
     bool getInterpretMode();
     void setOverwriteMode(bool);
-    void setHexMode(bool);
+    void setUseAsciiDec(bool);
     void setClearMode(bool mode);
     void setTimeStyle(TimeStyle newStyle);
     void setIgnoreDBCColors(bool mode);
@@ -93,7 +93,7 @@ private:
     bool filtersPersistDuringClear;
     QString timeFormat;
     TimeStyle timeStyle;
-    bool useHexMode;
+    bool useAsciiDec;
     bool needFilterRefresh;
     bool ignoreDBCColors;
     int64_t timeOffset;
@@ -105,4 +105,3 @@ private:
 
 
 #endif // CANFRAMEMODEL_H
-

--- a/mainsettingsdialog.cpp
+++ b/mainsettingsdialog.cpp
@@ -26,7 +26,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
 
     //update the GUI with all the settings we have stored giving things
     //defaults if nothing was stored (if this is the first time)
-    ui->cbDisplayHex->setChecked(settings.value("Main/UseHex", true).toBool());
+    ui->cbDisplayAsciiDec->setChecked(settings.value("Main/UseAsciiDec", true).toBool());
     ui->cbFlowAutoRef->setChecked(settings.value("FlowView/AutoRef", false).toBool());
     ui->cbHexGraphFlow->setChecked(settings.value("FlowView/GraphHex", false).toBool());
     ui->cbFlowUseTimestamp->setChecked(settings.value("FlowView/UseTimestamp", true).toBool());
@@ -47,8 +47,8 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
 
     ui->cbLoadConnections->setChecked(settings.value("Main/SaveRestoreConnections", false).toBool());
 
-    ui->spinFontSize->setValue(settings.value("Main/FontSize", ui->cbDisplayHex->font().pointSize()).toUInt());
-    ui->cbFontFixedWidth->setChecked(settings.value("Main/FontFixedWidth", false).toBool());
+    ui->spinFontSize->setValue(settings.value("Main/FontSize", ui->spinFontSize->font().pointSize()).toUInt());
+    ui->cbFontFixedWidth->setChecked(settings.value("Main/FontFixedWidth", true).toBool());
 
     bool secondsMode = settings.value("Main/TimeSeconds", false).toBool();
     bool clockMode = settings.value("Main/TimeClock", false).toBool();
@@ -108,7 +108,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     ui->spinBytesPerLine->setValue(settings.value("Main/BytesPerLine", 8).toInt());
 
     //just for simplicity they all call the same function and that function updates all settings at once
-    connect(ui->cbDisplayHex, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
+    connect(ui->cbDisplayAsciiDec, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbFlowAutoRef, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbFlowUseTimestamp, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->cbInfoAutoExpand, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
@@ -177,7 +177,7 @@ void MainSettingsDialog::updateSettings()
 {
     QSettings settings;
 
-    settings.setValue("Main/UseHex", ui->cbDisplayHex->isChecked());
+    settings.setValue("Main/UseAsciiDec", ui->cbDisplayAsciiDec->isChecked());
     settings.setValue("FlowView/AutoRef", ui->cbFlowAutoRef->isChecked());
     settings.setValue("FlowView/UseTimestamp", ui->cbFlowUseTimestamp->isChecked());
     settings.setValue("FlowView/GraphHex", ui->cbHexGraphFlow->isChecked());

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -35,8 +35,7 @@ MainWindow::MainWindow(QWidget *parent) :
     qRegisterMetaTypeStreamOperators<QVector<int>>();
 #endif
 
-    useHex = true;
-
+    UseAsciiDec = false;
     selfRef = this;
 
     this->setWindowTitle("Savvy CAN V" + QString::number(VERSION) + " [Built " + QString(__DATE__) +"]");
@@ -389,7 +388,7 @@ void MainWindow::readSettings()
         ui->canFramesView->setColumnWidth(5, settings.value("Main/BusColumn", 40).toUInt()); //bus
         ui->canFramesView->setColumnWidth(6, settings.value("Main/LengthColumn", 40).toUInt()); //length
         ui->canFramesView->setColumnWidth(7, settings.value("Main/AsciiColumn", 50).toUInt()); //ascii
-        //ui->canFramesView->setColumnWidth(8, settings.value("Main/DataColumn", 225).toUInt()); //data
+        ui->canFramesView->setColumnWidth(8, settings.value("Main/DataColumn", 225).toUInt()); //data
     }
     if (settings.value("Main/AutoScroll", false).toBool())
     {
@@ -411,9 +410,10 @@ void MainWindow::readSettings()
 void MainWindow::readUpdateableSettings()
 {
     QSettings settings;
-    useHex = settings.value("Main/UseHex", true).toBool();
-    model->setHexMode(useHex);
-    Utility::decimalMode = !useHex;
+
+    UseAsciiDec = settings.value("Main/UseAsciiDec", true).toBool();
+    model->setUseAsciiDec(UseAsciiDec);
+    Utility::decimalMode = UseAsciiDec;
 
     bool tempBool;
     TimeStyle ts = TS_MICROS;
@@ -450,6 +450,7 @@ void MainWindow::writeSettings()
     {
         settings.setValue("Main/WindowSize", size());
         settings.setValue("Main/WindowPos", pos());
+        settings.setValue("Main/UseAsciiDec", UseAsciiDec);
         settings.setValue("Main/TimeColumn", ui->canFramesView->columnWidth(0));
         settings.setValue("Main/IDColumn", ui->canFramesView->columnWidth(1));
         settings.setValue("Main/ExtColumn", ui->canFramesView->columnWidth(2));
@@ -457,8 +458,8 @@ void MainWindow::writeSettings()
         settings.setValue("Main/DirColumn", ui->canFramesView->columnWidth(4));
         settings.setValue("Main/BusColumn", ui->canFramesView->columnWidth(5));
         settings.setValue("Main/LengthColumn", ui->canFramesView->columnWidth(6));
-        settings.setValue("Main/AsciiColumn", ui->canFramesView->columnWidth(7));
-        //settings.setValue("Main/DataColumn", ui->canFramesView->columnWidth(8));
+        settings.setValue("Main/AsciiColumn", ui->canFramesView->columnWidth(7)); //ascii
+        settings.setValue("Main/DataColumn", ui->canFramesView->columnWidth(8)); //data
     }
 }
 
@@ -1083,6 +1084,8 @@ void MainWindow::handleLoadFile()
     QMessageBox::StandardButton confirmDialog;
 
     bool loadResult = FrameFileIO::loadFrameFile(filename, &tempFrames);
+
+    qInfo() << "Load result: " << loadResult << " Frames loaded: " << tempFrames.count();
 
     if (!loadResult)
     {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -159,7 +159,7 @@ private:
     int framesPerSec;
     int rxFrames;
     bool inhibitFilterUpdate;
-    bool useHex;
+    bool UseAsciiDec;
     bool allowCapture;
     bool ignoreDBCColors;
     bool CSVAbsTime;

--- a/ui/mainsettingsdialog.ui
+++ b/ui/mainsettingsdialog.ui
@@ -77,9 +77,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="cbDisplayHex">
+         <widget class="QCheckBox" name="cbDisplayAsciiDec">
           <property name="text">
-           <string>Display values as hexadecimal</string>
+           <string>ASCII column: display as decimal</string>
           </property>
          </widget>
         </item>
@@ -486,7 +486,7 @@
   <tabstop>cbMainAutoScroll</tabstop>
   <tabstop>cbRestorePositions</tabstop>
   <tabstop>cbLoadConnections</tabstop>
-  <tabstop>cbDisplayHex</tabstop>
+  <tabstop>cbDisplayAsciiDec</tabstop>
   <tabstop>cbValidate</tabstop>
   <tabstop>cbUseFiltered</tabstop>
   <tabstop>cbUseOpenGL</tabstop>

--- a/utility.h
+++ b/utility.h
@@ -138,7 +138,7 @@ public:
 
     static QString formatCANID(uint64_t id, bool extended)
     {
-        if (decimalMode) return QString::number(id, 10);
+        //if (decimalMode) return QString::number(id, 10);
 
         if (extended)
         {


### PR DESCRIPTION
Leaving the Data column in hex format, to see the decimal conversion of bytes I decided to use the Ascii column.
It's important to have the hex view stable and user can decide to view the ascii converion in text mode or decimal mode.

Decimal data format use padding to preserve high readability.

Update the settings window:

<img width="301" height="159" alt="image" src="https://github.com/user-attachments/assets/38c1d331-727c-4ff4-8c35-668576bcd05e" />


In Ascii mode (the existing):

<img width="929" height="86" alt="image" src="https://github.com/user-attachments/assets/87f6702e-c758-4b0b-9309-2c0d315c7ef6" />

In new decimal format enabled:

<img width="938" height="144" alt="image" src="https://github.com/user-attachments/assets/287f5e05-89aa-4677-9d3f-23a71ead5faa" />

