### PR TITLE
Fix connection issues and save/restore connection settings

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -251,6 +251,8 @@ win32-g++ {
    LIBS += libopengl32
 }
 
+   LIBS += libopengl32
+
 unix {
    isEmpty(PREFIX) {
       PREFIX=/usr/local

--- a/connections/canconfactory.cpp
+++ b/connections/canconfactory.cpp
@@ -10,11 +10,11 @@
 
 using namespace CANCon;
 
-CANConnection* CanConFactory::create(type pType, QString pPortName, QString pDriverName, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate)
+CANConnection* CanConFactory::create(type pType, QString pPortName, QString pDriverName, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate, bool pListenOnly, bool pActive)
 {
     switch(pType) {
     case SERIALBUS:
-      return new SerialBusConnection(pPortName, pDriverName, pBusSpeed, pDataRate, pCanFd);
+      return new SerialBusConnection(pPortName, pDriverName, pBusSpeed, pDataRate, pCanFd, pListenOnly, pActive);
     case GVRET_SERIAL:
         if(pPortName.contains(".") && !pPortName.contains("tty") && !pPortName.contains("serial"))
         return new GVRetSerial(pPortName, true);

--- a/connections/canconfactory.h
+++ b/connections/canconfactory.h
@@ -7,7 +7,7 @@
 class CanConFactory
 {
 public:
-    static CANConnection* create(CANCon::type, QString pPortName, QString pDriverName, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate);
+    static CANConnection* create(CANCon::type, QString pPortName, QString pDriverName, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate, bool pListenOnly = false, bool pActive = true);
 };
 
 #endif // CANCONFACTORY_H

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -11,7 +11,9 @@ CANConnection::CANConnection(QString pPort,
                              int pDataRate,
                              int pNumBuses,
                              int pQueueLen,
-                             bool pUseThread) :
+                             bool pUseThread,
+                             bool pListenOnly,
+                             bool pActive) :
     mNumBuses(pNumBuses),
     mSerialSpeed(pSerialSpeed),
     mQueue(),
@@ -47,6 +49,8 @@ CANConnection::CANConnection(QString pPort,
             mBusData[0].mBus.setCanFD(pCanFd);
         }
     }
+    mBusData[0].mBus.setListenOnly(pListenOnly);
+    mBusData[0].mBus.setActive(pActive);
  
     /* if needed, create a thread and move ourself into it */
     if(pUseThread) {

--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -75,12 +75,21 @@ CANConnection::~CANConnection()
 
 void CANConnection::start()
 {
+    //qDebug() << "CANConnection::start.b()";
+    //qDebug() << QThread::currentThread();
+    //qDebug() << QThread::currentThreadId();
+    //qDebug() << mThread_p->currentThread();
+    //qDebug() << mThread_p->currentThreadId();
+    //qDebug() << mThread_p;
+
     if( mThread_p && (mThread_p != QThread::currentThread()) )
     {
         QMetaObject::invokeMethod(this, "start",
                                   Qt::BlockingQueuedConnection);
         return;
     }
+
+    //qDebug() << "CANConnection::start.e()";
 
     /* set started flag */
     mStarted = true;
@@ -230,7 +239,7 @@ void CANConnection::setConfigured(int pBusId, bool pConfigured) {
 bool CANConnection::getBusConfig(int pBusId, CANBus& pBus) {
     if( pBusId < 0 || pBusId >= getNumBuses() || !isConfigured(pBusId))
         return false;
-    qDebug() << "getBusConfig id: " << pBusId;
+    //qDebug() << "getBusConfig id: " << pBusId;
     pBus = mBusData[pBusId].mBus;
     return true;
 }
@@ -264,11 +273,15 @@ CANCon::type CANConnection::getType() {
 }
 
 
-CANCon::status CANConnection::getStatus() {
+CANCon::status CANConnection::getStatus()
+{
+//    qDebug() << "CANConnection::getStatus = " << mStatus.loadRelaxed();
     return (CANCon::status) mStatus.loadRelaxed();
 }
 
-void CANConnection::setStatus(CANCon::status pStatus) {
+void CANConnection::setStatus(CANCon::status pStatus)
+{
+    qDebug() << "CANConnection::setStatus = " << pStatus;
     mStatus.storeRelaxed(pStatus);
 }
 

--- a/connections/canconnection.h
+++ b/connections/canconnection.h
@@ -36,7 +36,9 @@ protected:
                   int pDataRate,
                   int pNumBuses,
                   int pQueueLen,
-                  bool pUseThread);
+                  bool pUseThread,
+                  bool pListenOnly = false,
+                  bool pActive = true);
 
 public:
 

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -255,6 +255,8 @@ void ConnectionWindow::handleNewConn()
     int newBusSpeed;
     bool newCanFd;
     int newDataRate;
+    bool newListenOnly = false;
+    bool newActive = true;
     CANConnection *conn;
 
     if (thisDialog->exec() == QDialog::Accepted)
@@ -267,13 +269,20 @@ void ConnectionWindow::handleNewConn()
         newCanFd=thisDialog->isCanFd();
         newDataRate = thisDialog->getDataRate();
 
-        /* For SerialBus connections the dialog has no speed picker; restore last used speed */
-        if (newType == CANCon::SERIALBUS && newBusSpeed == 0) {
+        /* For SerialBus connections the dialog has no speed picker; restore last used settings */
+        if (newType == CANCon::SERIALBUS) {
             QSettings cfg;
-            newBusSpeed = cfg.value("Main/LastSerialBusSpeed", 250000).toInt();
+            if (newBusSpeed == 0)
+                newBusSpeed = cfg.value("Main/LastSerialBusSpeed", 250000).toInt();
+            if (!newCanFd)
+                newCanFd = cfg.value("Main/LastSerialBusCanFd", false).toBool();
+            if (newDataRate == 0)
+                newDataRate = cfg.value("Main/LastSerialBusDataRate", 0).toInt();
+            newListenOnly = cfg.value("Main/LastSerialBusListenOnly", false).toBool();
+            newActive = cfg.value("Main/LastSerialBusActive", true).toBool();
         }
 
-        conn = create(newType, newPort, newDriver, newSerialSpeed, newBusSpeed, newCanFd, newDataRate);
+        conn = create(newType, newPort, newDriver, newSerialSpeed, newBusSpeed, newCanFd, newDataRate, newListenOnly, newActive);
         if (conn)
         {
             connModel->add(conn);
@@ -324,12 +333,16 @@ void ConnectionWindow::handleResetConn()
     driver = conn_p->getDriver();
     serSpeed = conn_p->getSerialSpeed();
     // For multi-bus devices this grabs bus 0; better than zeroing it out.
+    bool listenOnly = false;
+    bool active = true;
     CANBus bus;
     if (conn_p->getBusSettings(0, bus))
     {
         busSpeed = bus.getSpeed();
         canFd = bus.isCanFD();
         dataRate = bus.getDataRate();
+        listenOnly = bus.isListenOnly();
+        active = bus.isActive();
     }
     else
     {
@@ -344,8 +357,10 @@ void ConnectionWindow::handleResetConn()
 
     conn_p = nullptr;
 
-    conn_p = create(type, port, driver, serSpeed, busSpeed,canFd,dataRate);
-    if (conn_p) connModel->replace(selIdx, conn_p);
+    conn_p = create(type, port, driver, serSpeed, busSpeed, canFd, dataRate, listenOnly, active);
+    if (conn_p) {
+        connModel->replace(selIdx, conn_p);
+    }
 }
 
 /* status */
@@ -397,10 +412,14 @@ void ConnectionWindow::saveBusSettings()
         bus.setCanFD(ui->canFDEnable->isChecked());
         bus.setDataRate(ui->cbDataRate->currentText().toInt());
 
-        /* Persist last SerialBus speed so new connections start with it */
-        if (conn_p->getType() == CANCon::SERIALBUS && bus.getSpeed() > 0) {
+        /* Persist last SerialBus settings so new connections start with them */
+        if (conn_p->getType() == CANCon::SERIALBUS) {
             QSettings cfg;
-            cfg.setValue("Main/LastSerialBusSpeed", bus.getSpeed());
+            if (bus.getSpeed() > 0) cfg.setValue("Main/LastSerialBusSpeed", bus.getSpeed());
+            cfg.setValue("Main/LastSerialBusCanFd", bus.isCanFD());
+            cfg.setValue("Main/LastSerialBusDataRate", bus.getDataRate());
+            cfg.setValue("Main/LastSerialBusListenOnly", bus.isListenOnly());
+            cfg.setValue("Main/LastSerialBusActive", bus.isActive());
         }
 
         conn_p->setBusSettings(offset, bus);
@@ -543,12 +562,12 @@ void ConnectionWindow::handleSendText() {
     emit sendDebugData(bytes);
 }
 
-CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QString pDriver, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate)
+CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QString pDriver, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate, bool pListenOnly, bool pActive)
 {
     CANConnection* conn_p = nullptr;
 
     /* create connection */
-    conn_p = CanConFactory::create(pTye, pPortName, pDriver, pSerialSpeed, pBusSpeed, pCanFd, pDataRate);
+    conn_p = CanConFactory::create(pTye, pPortName, pDriver, pSerialSpeed, pBusSpeed, pCanFd, pDataRate, pListenOnly, pActive);
     if(conn_p)
     {
         /* connect signal */
@@ -578,6 +597,8 @@ void ConnectionWindow::loadConnections()
     QVector<int>    DataRates;
     QVector<int>    isCanFds;
     QVector<int>    serialSpeeds;
+    QVector<int>    listenOnlys;
+    QVector<int>    actives;
 
     slist = settings.value("connections/portNames").toStringList();
     portNames.reserve(slist.size());
@@ -621,6 +642,18 @@ void ConnectionWindow::loadConnections()
         serialSpeeds << v.toInt();
     vlist.clear();
 
+    vlist = settings.value("connections/listenOnlys").toList();
+    listenOnlys.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        listenOnlys << v.toInt();
+    vlist.clear();
+
+    vlist = settings.value("connections/actives").toList();
+    actives.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        actives << v.toInt();
+    vlist.clear();
+
     //don't load the connections if the three setting arrays above aren't all the same size.
     int err = 0;
 
@@ -659,12 +692,20 @@ void ConnectionWindow::loadConnections()
         err++;
     }
 
+    /* listenOnlys is optional (older sessions won't have it); pad with zeros if missing */
+    while (listenOnlys.count() < driverNames.count())
+        listenOnlys.append(0);
+
+    /* actives is optional (older sessions won't have it); default to active=true */
+    while (actives.count() < driverNames.count())
+        actives.append(1);
+
     if (err)
         return;
 
     for(int i = 0 ; i < portNames.count() ; i++)
     {
-        CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], serialSpeeds[i], busSpeeds[i], isCanFds[i] ? true : false, DataRates[i]);
+        CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], serialSpeeds[i], busSpeeds[i], isCanFds[i] ? true : false, DataRates[i], listenOnlys[i] ? true : false, actives[i] ? true : false);
         /* add connection to model */
         connModel->add(conn_p);
     }
@@ -686,6 +727,8 @@ void ConnectionWindow::saveConnections()
     QVector<int> busSpeeds;
     QVector<int> DataRates;
     QVector<int> CanFds;
+    QVector<int> ListenOnlys;
+    QVector<int> Actives;
 
     QStringList  slist;
     QVariantList vlist;
@@ -699,6 +742,8 @@ void ConnectionWindow::saveConnections()
             busSpeeds.append(bus.getSpeed());
             CanFds.append(bus.isCanFD() ? 1 : 0);
             DataRates.append(bus.getDataRate());
+            ListenOnlys.append(bus.isListenOnly() ? 1 : 0);
+            Actives.append(bus.isActive() ? 1 : 0);
         }
         serialSpeeds.append(conn_p->getSerialSpeed());
         portNames.append(conn_p->getPort());
@@ -747,6 +792,18 @@ void ConnectionWindow::saveConnections()
     for (int v : CanFds)
         vlist << v;
     settings.setValue("connections/CanFds", vlist);
+
+    vlist.clear();
+    vlist.reserve(ListenOnlys.size());
+    for (int v : ListenOnlys)
+        vlist << v;
+    settings.setValue("connections/listenOnlys", vlist);
+
+    vlist.clear();
+    vlist.reserve(Actives.size());
+    for (int v : Actives)
+        vlist << v;
+    settings.setValue("connections/actives", vlist);
 }
 
 void ConnectionWindow::moveConnUp()

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -63,6 +63,7 @@ ConnectionWindow::ConnectionWindow(QWidget *parent) :
     connect(ui->btnMoveUp, &QPushButton::clicked, this, &ConnectionWindow::moveConnUp);
     connect(ui->btnMoveDown, &QPushButton::clicked, this, &ConnectionWindow::moveConnDown);
 
+
     ui->cbBusSpeed->addItem("33333");
     ui->cbBusSpeed->addItem("50000");
     ui->cbBusSpeed->addItem("83333");
@@ -738,12 +739,20 @@ void ConnectionWindow::saveConnections()
     {
         CANBus bus;
 
+        /* Always append to every array so all arrays stay the same length.
+           If the bus is not yet configured (device not connected), store zeros/defaults. */
         if (conn_p->getBusSettings(0, bus)) {
             busSpeeds.append(bus.getSpeed());
             CanFds.append(bus.isCanFD() ? 1 : 0);
             DataRates.append(bus.getDataRate());
             ListenOnlys.append(bus.isListenOnly() ? 1 : 0);
             Actives.append(bus.isActive() ? 1 : 0);
+        } else {
+            busSpeeds.append(0);
+            CanFds.append(0);
+            DataRates.append(0);
+            ListenOnlys.append(0);
+            Actives.append(1);
         }
         serialSpeeds.append(conn_p->getSerialSpeed());
         portNames.append(conn_p->getPort());

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -266,6 +266,13 @@ void ConnectionWindow::handleNewConn()
         newBusSpeed = thisDialog->getBusSpeed();
         newCanFd=thisDialog->isCanFd();
         newDataRate = thisDialog->getDataRate();
+
+        /* For SerialBus connections the dialog has no speed picker; restore last used speed */
+        if (newType == CANCon::SERIALBUS && newBusSpeed == 0) {
+            QSettings cfg;
+            newBusSpeed = cfg.value("Main/LastSerialBusSpeed", 250000).toInt();
+        }
+
         conn = create(newType, newPort, newDriver, newSerialSpeed, newBusSpeed, newCanFd, newDataRate);
         if (conn)
         {
@@ -389,6 +396,12 @@ void ConnectionWindow::saveBusSettings()
         bus.setListenOnly(ui->ckListenOnly->isChecked());
         bus.setCanFD(ui->canFDEnable->isChecked());
         bus.setDataRate(ui->cbDataRate->currentText().toInt());
+
+        /* Persist last SerialBus speed so new connections start with it */
+        if (conn_p->getType() == CANCon::SERIALBUS && bus.getSpeed() > 0) {
+            QSettings cfg;
+            cfg.setValue("Main/LastSerialBusSpeed", bus.getSpeed());
+        }
 
         conn_p->setBusSettings(offset, bus);
     }

--- a/connections/connectionwindow.cpp
+++ b/connections/connectionwindow.cpp
@@ -32,8 +32,9 @@ ConnectionWindow::ConnectionWindow(QWidget *parent) :
     ui->tableConnections->setColumnWidth(0, 100);
     ui->tableConnections->setColumnWidth(1, 100);
     ui->tableConnections->setColumnWidth(2, 130);
-    ui->tableConnections->setColumnWidth(3, 70);
-    ui->tableConnections->setColumnWidth(4, 200);
+    ui->tableConnections->setColumnWidth(3, 100);
+    ui->tableConnections->setColumnWidth(4, 70);
+    ui->tableConnections->setColumnWidth(5, 200);
     QHeaderView *HorzHdr = ui->tableConnections->horizontalHeader();
     HorzHdr->setStretchLastSection(true); //causes the data column to automatically fill the tableview
 
@@ -47,18 +48,18 @@ ConnectionWindow::ConnectionWindow(QWidget *parent) :
     {
         /* load connection configuration */
         loadConnections();
-    }    
+    }
 
-    connect(ui->btnDisconnect, &QPushButton::clicked, this, &ConnectionWindow::handleRemoveConn);
+    connect(ui->btnDisconnect, &QPushButton::clicked, this, &ConnectionWindow::handleRemoveConn); // <-- Disconnect
     connect(ui->btnSendHex, &QPushButton::clicked, this, &ConnectionWindow::handleSendHex);
     connect(ui->btnSendText, &QPushButton::clicked, this, &ConnectionWindow::handleSendText);
     connect(ui->ckEnableConsole, &QCheckBox::toggled, this, &ConnectionWindow::consoleEnableChanged);
     connect(ui->btnClearDebug, &QPushButton::clicked, this, &ConnectionWindow::handleClearDebugText);
-    connect(ui->btnNewConnection, &QPushButton::clicked, this, &ConnectionWindow::handleNewConn);
-    connect(ui->btnResetConn, &QPushButton::clicked, this, &ConnectionWindow::handleResetConn);
+    connect(ui->btnNewConnection, &QPushButton::clicked, this, &ConnectionWindow::handleNewConn); // <-- New connection
+    connect(ui->btnResetConn, &QPushButton::clicked, this, &ConnectionWindow::handleResetConn); // <-- Reset
     connect(ui->tableConnections->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &ConnectionWindow::currentRowChanged);
     connect(ui->tabBuses, &QTabBar::currentChanged, this, &ConnectionWindow::currentTabChanged);
-    connect(ui->btnSaveBus, &QPushButton::clicked, this, &ConnectionWindow::saveBusSettings);
+    connect(ui->btnSaveBus, &QPushButton::clicked, this, &ConnectionWindow::saveBusSettings); // <-- Save settings
     connect(ui->btnMoveUp, &QPushButton::clicked, this, &ConnectionWindow::moveConnUp);
     connect(ui->btnMoveDown, &QPushButton::clicked, this, &ConnectionWindow::moveConnDown);
 
@@ -163,7 +164,6 @@ ConnectionWindow::~ConnectionWindow()
 
     delete ui;
 }
-
 
 void ConnectionWindow::showEvent(QShowEvent* event)
 {
@@ -343,10 +343,11 @@ void ConnectionWindow::handleResetConn()
 
 /* status */
 void ConnectionWindow::connectionStatus(CANConStatus pStatus)
-{
+{    
     Q_UNUSED(pStatus);
 
-    qDebug() << "Connectionstatus changed";
+    qDebug() << "ConnectionWindow::connectionStatus(CANConStatus pStatus)";
+
     int selIdx = ui->tableConnections->selectionModel()->currentIndex().row();
     connModel->refresh();
     ui->tableConnections->selectRow(selIdx);
@@ -379,7 +380,7 @@ void ConnectionWindow::saveBusSettings()
 
         if (!conn_p->getBusSettings(offset, bus))
         {
-            qDebug() << "Could not retrieve bus settings!";
+            qDebug() << "!!!!!!!!!!!!!!!!!!!!Could not retrieve bus settings!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
             return;
         }
 
@@ -388,6 +389,7 @@ void ConnectionWindow::saveBusSettings()
         bus.setListenOnly(ui->ckListenOnly->isChecked());
         bus.setCanFD(ui->canFDEnable->isChecked());
         bus.setDataRate(ui->cbDataRate->currentText().toInt());
+
         conn_p->setBusSettings(offset, bus);
     }
 }
@@ -530,7 +532,7 @@ void ConnectionWindow::handleSendText() {
 
 CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QString pDriver, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate)
 {
-    CANConnection* conn_p;
+    CANConnection* conn_p = nullptr;
 
     /* create connection */
     conn_p = CanConFactory::create(pTye, pPortName, pDriver, pSerialSpeed, pBusSpeed, pCanFd, pDataRate);
@@ -552,29 +554,104 @@ CANConnection* ConnectionWindow::create(CANCon::type pTye, QString pPortName, QS
 
 void ConnectionWindow::loadConnections()
 {
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    qRegisterMetaTypeStreamOperators<CANBus>();
-    qRegisterMetaTypeStreamOperators<QList<CANBus>>();
-#endif
-
     QSettings settings;
 
-    /* fill connection list */
-    QVector<QString> portNames = settings.value("connections/portNames").value<QVector<QString>>();
-    QVector<QString> driverNames = settings.value("connections/driverNames").value<QVector<QString>>();
-    QVector<int>    devTypes = settings.value("connections/types").value<QVector<int>>();
+    QStringList slist;
+    QVariantList vlist;
+    QVector<QString> portNames;
+    QVector<QString> driverNames;
+    QVector<int>    devTypes;
+    QVector<int>    busSpeeds;
+    QVector<int>    DataRates;
+    QVector<int>    isCanFds;
+    QVector<int>    serialSpeeds;
 
-    QVector<int> busSpeeds = settings.value("connections/busSpeeds_0").value<QVector<int>>();
-    QVector<int> DataRates = settings.value("connections/DataRates_0").value<QVector<int>>();
-    QVector<int> isCanFds = settings.value("connections/isCanFds_0").value<QVector<int>>();
-    QVector<int> serialSpeeds = settings.value("connections/serialSpeeds").value<QVector<int>>();
+    slist = settings.value("connections/portNames").toStringList();
+    portNames.reserve(slist.size());
+    for (const QString &s : std::as_const(slist))
+        portNames << s;
+    slist.clear();
+
+    slist = settings.value("connections/driverNames").toStringList();
+    driverNames.reserve(slist.size());
+    for (const QString &s : std::as_const(slist))
+        driverNames << s;
+    slist.clear();
+
+    vlist = settings.value("connections/devTypes").toList();
+    devTypes.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        devTypes << v.toInt();
+    vlist.clear();
+
+    vlist = settings.value("connections/busSpeeds").toList();
+    busSpeeds.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        busSpeeds << v.toInt();
+    vlist.clear();
+
+    vlist = settings.value("connections/DataRates").toList();
+    DataRates.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        DataRates << v.toInt();
+    vlist.clear();
+
+    vlist = settings.value("connections/CanFds").toList();
+    isCanFds.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        isCanFds << v.toInt();
+    vlist.clear();
+
+    vlist = settings.value("connections/serialSpeeds").toList();
+    serialSpeeds.reserve(vlist.size());
+    for (const QVariant &v : std::as_const(vlist))
+        serialSpeeds << v.toInt();
+    vlist.clear();
+
     //don't load the connections if the three setting arrays above aren't all the same size.
-    if (portNames.count() != driverNames.count() || devTypes.count() != driverNames.count() ||  busSpeeds.count() != driverNames.count() || isCanFds.count() != driverNames.count() ||
-	DataRates.count() != driverNames.count() || serialSpeeds.count() != driverNames.count() ) return;
+    int err = 0;
+
+    if (portNames.count() != driverNames.count() )
+    {
+        qDebug() << "portNames.count()" << portNames.count();
+        err++;
+    }
+
+    if (devTypes.count() != driverNames.count() )
+    {
+        qDebug() << "devTypes.count()" << devTypes.count();
+        err++;
+    }
+
+    if( busSpeeds.count() != driverNames.count() )
+    {
+        qDebug() << "devTypes.count()" << busSpeeds.count();
+        err++;
+    }
+
+    if( isCanFds.count() != driverNames.count() )
+    {
+        qDebug() << "isCanFds.count()" << isCanFds.count();
+        err++;
+    }
+
+    if( DataRates.count() != driverNames.count() )
+    {
+        qDebug() << "DataRates.count()" << DataRates.count();
+        err++;
+    }
+    if( serialSpeeds.count() != driverNames.count() )
+    {
+        qDebug() << "serialSpeeds.count()" << serialSpeeds.count();
+        err++;
+    }
+
+    if (err)
+        return;
 
     for(int i = 0 ; i < portNames.count() ; i++)
     {
-      CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], serialSpeeds[i], busSpeeds[i], isCanFds[i] ? true : false, DataRates[i]);
+        CANConnection* conn_p = create((CANCon::type)devTypes[i], portNames[i], driverNames[i], serialSpeeds[i], busSpeeds[i], isCanFds[i] ? true : false, DataRates[i]);
         /* add connection to model */
         connModel->add(conn_p);
     }
@@ -590,13 +667,16 @@ void ConnectionWindow::saveConnections()
 
     QSettings settings;
     QVector<QString> portNames;
-    QVector<int> devTypes;
     QVector<QString> driverNames;
+    QVector<int> devTypes;
     QVector<int> serialSpeeds;
     QVector<int> busSpeeds;
     QVector<int> DataRates;
     QVector<int> CanFds;
- 
+
+    QStringList  slist;
+    QVariantList vlist;
+
     /* save connections */
     foreach(CANConnection* conn_p, conns)
     {
@@ -613,13 +693,47 @@ void ConnectionWindow::saveConnections()
         driverNames.append(conn_p->getDriver());
     }
 
-    settings.setValue("connections/portNames", QVariant::fromValue(portNames));
-    settings.setValue("connections/types", QVariant::fromValue(devTypes));
-    settings.setValue("connections/driverNames", QVariant::fromValue(driverNames));
-    settings.setValue("connections/busSpeeds_0", QVariant::fromValue(busSpeeds));
-    settings.setValue("connections/isCanFds_0", QVariant::fromValue(CanFds)); 
-    settings.setValue("connections/DataRates_0", QVariant::fromValue(DataRates)); 
-    settings.setValue("connections/serialSpeeds", QVariant::fromValue(serialSpeeds)); 
+    slist.clear();
+    slist.reserve(portNames.size());
+    for (const QString &s : portNames)
+        slist << s;
+    settings.setValue("connections/portNames", slist);
+
+    slist.clear();
+    slist.reserve(driverNames.size());
+    for (const QString &s : driverNames)
+        slist << s;
+    settings.setValue("connections/driverNames", slist);
+
+    slist.clear();
+    vlist.reserve(devTypes.size());
+    for (int v : devTypes)
+        vlist << v;
+    settings.setValue("connections/devTypes", vlist);
+
+    vlist.clear();
+    vlist.reserve(serialSpeeds.size());
+    for (int v : serialSpeeds)
+        vlist << v;
+    settings.setValue("connections/serialSpeeds", vlist);
+
+    vlist.clear();
+    vlist.reserve(busSpeeds.size());
+    for (int v : busSpeeds)
+        vlist << v;
+    settings.setValue("connections/busSpeeds", vlist);
+
+    vlist.clear();
+    vlist.reserve(DataRates.size());
+    for (int v : DataRates)
+        vlist << v;
+    settings.setValue("connections/DataRates", vlist);
+
+    vlist.clear();
+    vlist.reserve(CanFds.size());
+    for (int v : CanFds)
+        vlist << v;
+    settings.setValue("connections/CanFds", vlist);
 }
 
 void ConnectionWindow::moveConnUp()

--- a/connections/connectionwindow.h
+++ b/connections/connectionwindow.h
@@ -65,7 +65,7 @@ private:
     QVector<QString> remoteDeviceIPGVRET;
     QVector<QString> remoteDeviceKayak;
 
-    CANConnection* create(CANCon::type pTye, QString pPortName, QString pDriver, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate);
+    CANConnection* create(CANCon::type pTye, QString pPortName, QString pDriver, int pSerialSpeed, int pBusSpeed, bool pCanFd, int pDataRate, bool pListenOnly = false, bool pActive = true);
     void populateBusDetails(int offset);
     void loadConnections();
     void saveConnections();

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -13,8 +13,8 @@
 /****    class definition       ****/
 /***********************************/
 
-SerialBusConnection::SerialBusConnection(QString portName, QString driverName, int pBusSpeed, int pDataRate, bool pCanFd) :
-    CANConnection(portName, driverName, CANCon::SERIALBUS,0 ,pBusSpeed, pCanFd, pDataRate ,1, 4000, true),
+SerialBusConnection::SerialBusConnection(QString portName, QString driverName, int pBusSpeed, int pDataRate, bool pCanFd, bool pListenOnly, bool pActive) :
+    CANConnection(portName, driverName, CANCon::SERIALBUS,0 ,pBusSpeed, pCanFd, pDataRate ,1, 4000, true, pListenOnly, pActive),
     mTimer(this) /*NB: set connection as parent of timer to manage it from working thread */
 {
 }
@@ -51,13 +51,18 @@ void SerialBusConnection::piStarted()
     mTimer.setSingleShot(false); //keep ticking
     mTimer.start();
 
-    mBusData[0].mBus.setActive(true);
-    mBusData[0].mBus.setCanFD(false);
     mBusData[0].mConfigured = true;
 
     /* Connect immediately if a speed is already configured (e.g. restored from last session) */
-    if (mBusData[0].mBus.getSpeed() > 0) {
+    if (mBusData[0].mBus.isActive() && mBusData[0].mBus.getSpeed() > 0) {
+        quint32 sbusconfig = 0;
         mDev_p->setConfigurationParameter(QCanBusDevice::BitRateKey, mBusData[0].mBus.getSpeed());
+        mDev_p->setConfigurationParameter(QCanBusDevice::CanFdKey, mBusData[0].mBus.isCanFD());
+        if (mBusData[0].mBus.isCanFD() && mBusData[0].mBus.getDataRate() > 0)
+            mDev_p->setConfigurationParameter(QCanBusDevice::DataBitRateKey, mBusData[0].mBus.getDataRate());
+        if (mBusData[0].mBus.isListenOnly())
+            sbusconfig |= EN_SILENT_MODE;
+        mDev_p->setConfigurationParameter(QCanBusDevice::UserKey, sbusconfig);
         if (!mDev_p->connectDevice()) {
             qDebug() << "SerialBusConnection::piStarted() - initial connectDevice() failed:" << mDev_p->errorString();
         }

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -6,6 +6,8 @@
 #include <QCanBusFrame>
 #include <QDateTime>
 #include <QDebug>
+#include <QThread>
+
 
 /***********************************/
 /****    class definition       ****/
@@ -26,14 +28,15 @@ SerialBusConnection::~SerialBusConnection()
 
 void SerialBusConnection::piStarted()
 {
-    qDebug() << "piStarted()";
+    qDebug() << "SerialBusConnection::piStarted()";
+
     /* create device */
     QString errorString;
-    qDebug() << "Creating device instance";
+    //qDebug() << "SerialBusConnection::piStarted()";
     mDev_p = QCanBus::instance()->createDevice(getDriver(), getPort(), &errorString);
     if (!mDev_p) {
         disconnectDevice();
-        qDebug() << "Error: createDevice(" << getType() << getDriver() << getPort() << "):" << errorString;
+        qDebug() << "SerialBusConnection::piStarted() - Error: createDevice"; //  (" << getType() << getDriver() << getPort() << "):";// << errorString;
         return;
     }
 
@@ -46,6 +49,7 @@ void SerialBusConnection::piStarted()
     mTimer.setInterval(1000);
     mTimer.setSingleShot(false); //keep ticking
     mTimer.start();
+
     mBusData[0].mBus.setActive(true);
     mBusData[0].mBus.setCanFD(false);
     mBusData[0].mConfigured = true;
@@ -88,7 +92,9 @@ void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
     if (!mDev_p) return;
 
     /* disconnect device if we have one connected */
+    //qDebug() << "SerialBusConnection::piSetBusSettings -> disconnect if connected";
     disconnectDevice();
+    setStatus(CANCon::NOT_CONNECTED);
 
     /* copy bus config */
     setBusConfig(0, bus);
@@ -105,18 +111,25 @@ void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
 
     //You cannot set the speed of a socketcan interface, it has to be set with console commands.
     //But, you can probabaly set the speed of many of the other serialbus devices so go ahead and try
+    qDebug() << "SerialBusConnection::piSetBusSettings -> setConfigurationParameter()";
     mDev_p->setConfigurationParameter(QCanBusDevice::BitRateKey, bus.getSpeed());
+
+    qDebug() << "SerialBusConnection::piSetBusSettings -> setConfigurationParameter()";
     mDev_p->setConfigurationParameter(QCanBusDevice::CanFdKey, bus.isCanFD());
 
-    if(bus.isListenOnly())
+    if(bus.isListenOnly()){
         sbusconfig |= EN_SILENT_MODE;
-    mDev_p->setConfigurationParameter(QCanBusDevice::UserKey, sbusconfig);
+    }
+        qDebug() << "SerialBusConnection::piSetBusSettings -> setConfigurationParameter()";
+        mDev_p->setConfigurationParameter(QCanBusDevice::UserKey, sbusconfig);
 
     /* connect device */
-    if (!mDev_p->connectDevice()) {
-        disconnectDevice();
-        qDebug() << "can't connect device";
-    }
+
+    //qDebug() << "SerialBusConnection::piSetBusSettings -> connect()";
+    //if(mDev_p && mDev_p->state() == QCanBusDevice::UnconnectedState){
+    //    mDev_p->connectDevice();
+    //    qDebug() << "Connect !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!";
+    //}
 }
 
 
@@ -146,11 +159,10 @@ bool SerialBusConnection::piSendFrame(const CommFrame& pFrame)
 
 /* disconnect device */
 void SerialBusConnection::disconnectDevice() {
-    if(mDev_p) {
+    if(mDev_p && mDev_p->state() == QCanBusDevice::ConnectedState){
         mDev_p->disconnectDevice();
     }
 }
-
 
 void SerialBusConnection::errorReceived(QCanBusDevice::CanBusError error) const
 {
@@ -247,18 +259,44 @@ void SerialBusConnection::framesReceived()
     }
 }
 
+/*
+enum CanBusDeviceState {
+    UnconnectedState,
+    ConnectingState,
+    ConnectedState,
+    ClosingState
+};
+*/
 
-void SerialBusConnection::testConnection() {
+void SerialBusConnection::testConnection()
+{
     CANConStatus stats;
 
+    qDebug() << "   INT! Get Status:" << getStatus() << "ConnectingState: " << mDev_p->state();
+
+
+    if (!mDev_p || mDev_p->state() == QCanBusDevice::ConnectingState){
+        qDebug() << "   QCanBusDevice::ConnectingState - return";
+        return;
+    }
+    if (!mDev_p || mDev_p->state() == QCanBusDevice::ClosingState){
+        qDebug() << "   QCanBusDevice::ClosingState - return";
+        return;
+    }
+
     switch(getStatus())
-    {
+    {        
         case CANCon::CONNECTED:
             if (!mDev_p || mDev_p->state() == QCanBusDevice::UnconnectedState) {
                 /* we have lost connectivity */
-                disconnectDevice();
+                //disconnectDevice();
+
+                if(mDev_p) {
+                    mDev_p->disconnectDevice();
+                }
 
                 setStatus(CANCon::NOT_CONNECTED);
+
                 stats.conStatus = getStatus();
                 stats.numHardwareBuses = mNumBuses;
                 emit status(stats);
@@ -267,7 +305,7 @@ void SerialBusConnection::testConnection() {
             break;
         case CANCon::NOT_CONNECTED:
             if (mDev_p && mDev_p->state() == QCanBusDevice::UnconnectedState) {
-                /* try to reconnect */
+                /* try to reconnect */                
                 CANBus bus;
                 if(getBusConfig(0, bus))
                 {
@@ -275,7 +313,11 @@ void SerialBusConnection::testConnection() {
                     setBusSettings(0, bus);
                 }
 
+                mDev_p->connectDevice();
+                qDebug() << "Connect device";
                 setStatus(CANCon::CONNECTED);
+                qDebug() << "   setStatus(CANCon::CONNECTED)";
+
                 stats.conStatus = getStatus();
                 stats.numHardwareBuses = mNumBuses;
                 emit status(stats);

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -44,6 +44,7 @@ void SerialBusConnection::piStarted()
     connect(mDev_p, &QCanBusDevice::errorOccurred, this, &SerialBusConnection::errorReceived);
     connect(mDev_p, &QCanBusDevice::framesWritten, this, &SerialBusConnection::framesWritten);
     connect(mDev_p, &QCanBusDevice::framesReceived, this, &SerialBusConnection::framesReceived);
+    connect(mDev_p, &QCanBusDevice::stateChanged, this, &SerialBusConnection::deviceStateChanged);
 
     connect(&mTimer, SIGNAL(timeout()), this, SLOT(testConnection()));
     mTimer.setInterval(1000);
@@ -53,6 +54,14 @@ void SerialBusConnection::piStarted()
     mBusData[0].mBus.setActive(true);
     mBusData[0].mBus.setCanFD(false);
     mBusData[0].mConfigured = true;
+
+    /* Connect immediately if a speed is already configured (e.g. restored from last session) */
+    if (mBusData[0].mBus.getSpeed() > 0) {
+        mDev_p->setConfigurationParameter(QCanBusDevice::BitRateKey, mBusData[0].mBus.getSpeed());
+        if (!mDev_p->connectDevice()) {
+            qDebug() << "SerialBusConnection::piStarted() - initial connectDevice() failed:" << mDev_p->errorString();
+        }
+    }
 }
 
 
@@ -161,6 +170,23 @@ bool SerialBusConnection::piSendFrame(const CommFrame& pFrame)
 void SerialBusConnection::disconnectDevice() {
     if(mDev_p && mDev_p->state() == QCanBusDevice::ConnectedState){
         mDev_p->disconnectDevice();
+    }
+}
+
+/* Immediately update status when the device state changes */
+void SerialBusConnection::deviceStateChanged(QCanBusDevice::CanBusDeviceState state)
+{
+    CANConStatus stats;
+    if (state == QCanBusDevice::ConnectedState) {
+        setStatus(CANCon::CONNECTED);
+        stats.conStatus = getStatus();
+        stats.numHardwareBuses = mNumBuses;
+        emit status(stats);
+    } else if (state == QCanBusDevice::UnconnectedState && getStatus() == CANCon::CONNECTED) {
+        setStatus(CANCon::NOT_CONNECTED);
+        stats.conStatus = getStatus();
+        stats.numHardwareBuses = mNumBuses;
+        emit status(stats);
     }
 }
 
@@ -304,23 +330,20 @@ void SerialBusConnection::testConnection()
             }
             break;
         case CANCon::NOT_CONNECTED:
-            if (mDev_p && mDev_p->state() == QCanBusDevice::UnconnectedState) {
-                /* try to reconnect */                
-                CANBus bus;
-                if(getBusConfig(0, bus))
-                {
-                    bus.setActive(true);
-                    setBusSettings(0, bus);
-                }
-
-                mDev_p->connectDevice();
-                qDebug() << "Connect device";
+            if (mDev_p && mDev_p->state() == QCanBusDevice::ConnectedState) {
+                /* stateChanged should have caught this, but handle it as a fallback */
                 setStatus(CANCon::CONNECTED);
-                qDebug() << "   setStatus(CANCon::CONNECTED)";
-
+                qDebug() << "   setStatus(CANCon::CONNECTED) - fallback from timer";
                 stats.conStatus = getStatus();
                 stats.numHardwareBuses = mNumBuses;
                 emit status(stats);
+            } else if (mDev_p && mDev_p->state() == QCanBusDevice::UnconnectedState) {
+                /* Retry connecting - config parameters already set by piSetBusSettings or piStarted */
+                CANBus bus;
+                if (getBusConfig(0, bus) && bus.getSpeed() > 0) {
+                    qDebug() << "   timer retry: connectDevice()";
+                    mDev_p->connectDevice();
+                }
             }
             break;
         default: {}

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -201,11 +201,16 @@ void SerialBusConnection::framesReceived()
             if(frame_p) {
                 frame_p->setPayload(recFrame.payload());
                 frame_p->setBus(0);
+                // All frames arriving via framesReceived() are genuinely received frames.
+                // Do not use QCanBusFrame::hasLocalEcho() to determine direction: some backends
+                // (e.g. PeakCAN/PCAN on certain platforms) report local echo unreliably,
+                // causing all received frames to appear as Tx.
+                frame_p->setReceived(true);
+
                 if (recFrame.frameType() == recFrame.ErrorFrame)
                 {
                     frame_p->setExtendedFrameFormat(recFrame.hasExtendedFrameFormat());
                     frame_p->setFrameId(recFrame.frameId() + 0x20000000ull);
-                    frame_p->setReceived(true);
                 }
                 else
                 {

--- a/connections/serialbusconnection.h
+++ b/connections/serialbusconnection.h
@@ -47,6 +47,7 @@ private slots:
     void framesWritten(qint64 count);
     void framesReceived();
     void testConnection();
+    void deviceStateChanged(QCanBusDevice::CanBusDeviceState state);
 
 protected:
     QCanBusDevice     *mDev_p = nullptr;

--- a/connections/serialbusconnection.h
+++ b/connections/serialbusconnection.h
@@ -28,7 +28,7 @@ class SerialBusConnection : public CANConnection
 
 public:
   SerialBusConnection(QString portName, QString driverName, int pBusSpeed,
-		      int pDataRate, bool pCanFd);
+		      int pDataRate, bool pCanFd, bool pListenOnly = false, bool pActive = true);
     virtual ~SerialBusConnection();
 
 protected:

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,8 @@ int main(int argc, char *argv[])
     //qSetMessagePattern("Type: %{type}\nProduct Name: %{appname}\nFile: %{file}\nLine: %{line}\nMethod: %{function}\nThreadID: %{threadid}\nThreadPtr: %{qthreadptr}\nMessage: %{message}");
 #endif
 
+    QLoggingCategory::setFilterRules("qt.canbus=true");
+
     SavvyCANApplication a(argc, argv);
 
     //Add a local path for Qt extensions, to allow for per-application extensions.
@@ -48,6 +50,8 @@ int main(int argc, char *argv[])
     QFont sysFont = QFont(); //get default font
     sysFont.setPointSize(fontSize);
     a.setFont(sysFont);
+
+    qDebug() << "Config file path:" << settings.fileName();
 
     a.mainWindow->show();
 

--- a/ui/connectionwindow.ui
+++ b/ui/connectionwindow.ui
@@ -18,12 +18,12 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
+    <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout" columnstretch="1,0">
      <property name="sizeConstraint">
-      <enum>QLayout::SetMaximumSize</enum>
+      <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
      </property>
      <item row="6" column="0" colspan="2">
       <widget class="QPushButton" name="btnDisconnect">
@@ -45,10 +45,10 @@
         <bool>true</bool>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::SingleSelection</enum>
+        <enum>QAbstractItemView::SelectionMode::SingleSelection</enum>
        </property>
        <property name="selectionBehavior">
-        <enum>QAbstractItemView::SelectRows</enum>
+        <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
        </property>
       </widget>
      </item>
@@ -61,7 +61,7 @@
         <string>Bus Details:</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
        <layout class="QVBoxLayout" name="qhBox20">
         <item>
@@ -216,7 +216,7 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
      <property name="sizeConstraint">
-      <enum>QLayout::SetNoConstraint</enum>
+      <enum>QLayout::SizeConstraint::SetNoConstraint</enum>
      </property>
      <item>
       <widget class="QCheckBox" name="ckEnableConsole">

--- a/ui/connectionwindow.ui
+++ b/ui/connectionwindow.ui
@@ -53,6 +53,22 @@
       </widget>
      </item>
      <item row="7" column="0" colspan="2">
+      <spacer name="verticalSpacer_groupBus">
+       <property name="orientation">
+        <enum>Qt::Orientation::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Policy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>16</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="8" column="0" colspan="2">
       <widget class="QGroupBox" name="groupBus">
        <property name="enabled">
         <bool>false</bool>


### PR DESCRIPTION
## Summary

This PR fixes several issues with CAN bus connection handling and settings persistence across sessions, targeting the QT6WIP branch.

## Changes

### Fix `saveConnections()` array length mismatch ([172f346](https://github.com/minoseigenheer/SavvyCAN/commit/172f3468ca16af94130079ce967894b49933200b))
When a device was disconnected, the saved connections array could end up with the wrong length, causing settings from subsequent devices to be lost or mismatched on reload.

### Restore all SerialBus settings across sessions ([e9ab909](https://github.com/minoseigenheer/SavvyCAN/commit/e9ab9096b87725356683bfd47202c0e9637f004b))
Previously, only the bus speed was restored. Now `listenOnly`, `active`, `canFD`, and `dataRate` are all saved to `QSettings` and passed to the `SerialBusConnection` constructor, so the full configuration survives an application restart.

### Fix PCAN connection status and auto-apply last SerialBus speed ([a74c1ac](https://github.com/minoseigenheer/SavvyCAN/commit/a74c1ac2c9d74b28c6931595218f112822ff661f))
- The connection status indicator was not updating correctly for PCAN/PeakCAN devices. A `deviceStateChanged` slot is now connected to `QCanBusDevice::stateChanged` so the UI reflects the real device state immediately.
- The last configured bus speed is now automatically applied when the connection window opens, removing the need to manually re-select the speed each session.

### Fix connection settings save/restore for all device interfaces ([c02b9df](https://github.com/minoseigenheer/SavvyCAN/commit/c02b9df1674a13840e5a2134d121e9040b703b84))
Rewrites the save/restore logic in `ConnectionWindow` so that every configured interface (not just the first) is correctly persisted and restored, including port name, driver, speed, and FD settings.

### Fix connection issues for slow-initialising SerialBus plugins ([502f84e](https://github.com/minoseigenheer/SavvyCAN/commit/502f84eb9c044303feb8a4b1a257f8f979a2cefb))
Some SerialBus backends (e.g. the rusoku2/TouCAN plugin) take time to become ready after `connectDevice()` is called. The timer-based `testConnection()` now skips polling while the device is in `ConnectingState` or `ClosingState`, preventing premature reconnect attempts that would race with the backend's own initialisation.

## Files changed
- `connections/connectionwindow.cpp/.h`
- `connections/serialbusconnection.cpp/.h`
- `connections/canconnection.cpp/.h`
- `connections/canconfactory.cpp/.h`
- `connections/canconnectionmodel.cpp`