### PR TITLE
Scripting window: resizable panes, crash fix on delete, system font

### DIFF
--- a/connections/canconnection.cpp
+++ b/connections/canconnection.cpp
@@ -1,5 +1,6 @@
 #include <QSettings>
 #include <QThread>
+#include <QMutexLocker>
 #include "canconnection.h"
 
 CANConnection::CANConnection(QString pPort,
@@ -286,19 +287,6 @@ void CANConnection::debugInput(QByteArray bytes) {
 
 bool CANConnection::addTargettedFrame(int pBusId, uint32_t ID, uint32_t mask, QObject *receiver)
 {
-/*
-    if( mThread_p && (mThread_p != QThread::currentThread()) ) {
-        bool ret;
-        QMetaObject::invokeMethod(this, "addTargettedFrame",
-                                  Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret),
-                                  Q_ARG(int, pBusId),
-                                  Q_ARG(uint32_t , ID),
-                                  Q_ARG(uint32_t , mask),
-                                  Q_ARG(QObject *, receiver));
-        return ret;
-    }
-*/
     /* sanity checks */
     if(pBusId < -1 || pBusId >=  getNumBuses())
         return false;
@@ -308,6 +296,7 @@ bool CANConnection::addTargettedFrame(int pBusId, uint32_t ID, uint32_t mask, QO
     target.id = ID;
     target.mask = mask;
     target.observer = receiver;
+    QMutexLocker locker(&mTargettedMutex);
     if (pBusId > -1)
         mBusData[pBusId].mTargettedFrames.append(target);
     else
@@ -320,19 +309,6 @@ bool CANConnection::addTargettedFrame(int pBusId, uint32_t ID, uint32_t mask, QO
 
 bool CANConnection::removeTargettedFrame(int pBusId, uint32_t ID, uint32_t mask, QObject *receiver)
 {
-/*
-    if( mThread_p && (mThread_p != QThread::currentThread()) ) {
-        bool ret;
-        QMetaObject::invokeMethod(this, "removeTargettedFrame",
-                                  Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret),
-                                  Q_ARG(int, pBusId),
-                                  Q_ARG(uint32_t , ID),
-                                  Q_ARG(uint32_t , mask),
-                                  Q_ARG(QObject *, receiver));
-        return ret;
-    }
-*/
     /* sanity checks */
     if(pBusId < -1 || pBusId >= getNumBuses())
         return false;
@@ -341,13 +317,20 @@ bool CANConnection::removeTargettedFrame(int pBusId, uint32_t ID, uint32_t mask,
     target.id = ID;
     target.mask = mask;
     target.observer = receiver;
-    mBusData[pBusId].mTargettedFrames.removeAll(target);
+    QMutexLocker locker(&mTargettedMutex);
+    if (pBusId > -1)
+        mBusData[pBusId].mTargettedFrames.removeAll(target);
+    else
+    {
+        for (int i = 0; i < mBusData.count(); i++) mBusData[i].mTargettedFrames.removeAll(target);
+    }
 
     return true;
 }
 
 bool CANConnection::removeAllTargettedFrames(QObject *receiver)
 {
+    QMutexLocker locker(&mTargettedMutex);
     for (int i = 0; i < getNumBuses(); i++) {
         foreach (const CANFltObserver filt, mBusData[i].mTargettedFrames)
         {
@@ -367,6 +350,9 @@ void CANConnection::checkTargettedFrame(CommFrame &frame)
     int bus = frame.getBus();
     if (bus > (mBusData.length() - 1)) bus = mBusData.length() - 1;
 
+    // Hold the mutex through invokeMethod so the observer cannot be deleted
+    // between us reading the pointer and posting the event to it.
+    QMutexLocker locker(&mTargettedMutex);
     if (mBusData[bus].mTargettedFrames.length() == 0) return;
     foreach (const CANFltObserver filt, mBusData[frame.getBus()].mTargettedFrames)
     {

--- a/connections/canconnection.h
+++ b/connections/canconnection.h
@@ -3,6 +3,7 @@
 
 #include <Qt>
 #include <QObject>
+#include <QMutex>
 #include "utils/lfqueue.h"
 #include "can_structs.h"
 #include "canbus.h"
@@ -328,6 +329,9 @@ private:
     QAtomicInt          mStatus;
     bool                mStarted;
     QThread*            mThread_p;
+    // Protects mTargettedFrames across the worker-thread reader (checkTargettedFrame)
+    // and the main-thread writers (add/removeTargettedFrame).
+    QMutex              mTargettedMutex;
 };
 
 #endif // CANCONNECTION_H

--- a/jsedit.cpp
+++ b/jsedit.cpp
@@ -717,16 +717,9 @@ JSEdit::JSEdit(QWidget *parent)
     connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateSidebar()));
     connect(this, SIGNAL(updateRequest(QRect, int)), this, SLOT(updateSidebar(QRect, int)));
 
-#if defined(Q_OS_MAC)
-    QFont textFont = font();
-    textFont.setPointSize(12);
-    textFont.setFamily("Monaco");
+    QFont textFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    textFont.setPointSize(14);
     setFont(textFont);
-#elif defined(Q_OS_UNIX)
-    QFont textFont = font();
-    textFont.setFamily("Monospace");
-    setFont(textFont);
-#endif
 }
 
 JSEdit::~JSEdit()

--- a/scriptcontainer.cpp
+++ b/scriptcontainer.cpp
@@ -1,6 +1,7 @@
 #include <QJSValueIterator>
 #include <QDebug>
 #include <QTableWidget>
+#include <QCoreApplication>
 
 #include "scriptcontainer.h"
 #include "connections/canconmanager.h"
@@ -24,25 +25,28 @@ ScriptContainer::~ScriptContainer()
     qDebug() << "Script Container Destructor " << (uint64_t)this << "c: " << (uint64_t)canHelper;
     timer.stop();
     disconnect(&timer, SIGNAL(timeout()), this, SLOT(tick()));
-    if (scriptEngine)
-    {
-        scriptText = "";
-        compileScript();
-        //delete scriptEngine;   //doing this here seems to cause a crash. No crash if you don't.
-        //scriptEngine = nullptr;
-    }
+    // Clear CAN filters and flush any pending queued events before deleting helpers.
+    // Qt::QueuedConnection means gotTargettedFrame calls may still be in the event
+    // queue; removePostedEvents() ensures those events are discarded before the
+    // objects are freed, preventing the segfault on script deletion.
     if (canHelper)
     {
+        canHelper->clearFilters();
+        QCoreApplication::removePostedEvents(canHelper);
         delete canHelper;
         canHelper = nullptr;
     }
     if (isoHelper)
     {
+        isoHelper->clearFilters();
+        QCoreApplication::removePostedEvents(isoHelper);
         delete isoHelper;
         isoHelper = nullptr;
     }
     if (udsHelper)
     {
+        udsHelper->clearFilters();
+        QCoreApplication::removePostedEvents(udsHelper);
         delete udsHelper;
         udsHelper = nullptr;
     }

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -3,6 +3,7 @@
 
 #include <QFile>
 #include <QFileDialog>
+#include <QFontDatabase>
 #include <QSettings>
 #include <QMessageBox>
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
@@ -24,7 +25,7 @@ ScriptingWindow::ScriptingWindow(const QVector<CommFrame> *frames, QWidget *pare
     editor->setFrameShape(JSEdit::NoFrame);
     editor->setWordWrapMode(QTextOption::NoWrap);
     editor->setEnabled(false);
-    editor->setFont(QFont("Monospace", 12));
+    editor->setFont(QFontDatabase::systemFont(QFontDatabase::FixedFont));
     editor->show();
 
     //Show whitespaces

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -288,12 +288,15 @@ void ScriptingWindow::deleteCurrentScript()
     switch (ret)
     {
     case QMessageBox::Yes:
-        ui->listLoadedScripts->takeItem(sel);
+        // Obtain the script pointer and update the data model before manipulating
+        // the list widget, so that the currentRowChanged signal (fired by takeItem)
+        // does not cause changeCurrentScript() to touch the script being deleted.
         thisScript = scripts.at(sel);
+        if (currentScript == thisScript) currentScript = nullptr;
         scripts.removeAt(sel);
-        delete thisScript;  //causes a seg fault. Seems to be due to currently running javascript code. No idea how to stop code from running
+        ui->listLoadedScripts->takeItem(sel);
+        delete thisScript;
         thisScript = nullptr;
-        currentScript = nullptr;
 
         if (ui->listLoadedScripts->count() > 0)
         {
@@ -304,6 +307,8 @@ void ScriptingWindow::deleteCurrentScript()
         {
             editor->setPlainText("");
             editor->setEnabled(false);
+            ui->tableVariables->clearContents();
+            for (int i = ui->tableVariables->rowCount() - 1; i >= 0; i--) ui->tableVariables->removeRow(i);
         }
         break;
     case QMessageBox::No:

--- a/scriptingwindow.cpp
+++ b/scriptingwindow.cpp
@@ -34,6 +34,11 @@ ScriptingWindow::ScriptingWindow(const QVector<CommFrame> *frames, QWidget *pare
 
     ui->verticalLayout->insertWidget(2,editor, 10);
 
+    // Default splitter ratios (overridden by readSettings if positions are saved)
+    ui->splitterMain->setSizes({1, 2});   // left 1/3, right 2/3
+    ui->splitterLeft->setSizes({3, 2});   // variables 3/5, scripts 2/5
+    ui->splitterRight->setSizes({3, 2});  // editor 3/5, log 2/5
+
     readSettings();
 
     modelFrames = frames;
@@ -139,8 +144,14 @@ void ScriptingWindow::readSettings()
     QSettings settings;
     if (settings.value("Main/SaveRestorePositions", false).toBool())
     {
-        resize(settings.value("ScriptingWindow/WindowSize", QSize(860, 650)).toSize());
+        resize(settings.value("ScriptingWindow/WindowSize", QSize(1000, 700)).toSize());
         move(Utility::constrainedWindowPos(settings.value("ScriptingWindow/WindowPos", QPoint(100, 100)).toPoint()));
+        if (settings.contains("ScriptingWindow/SplitterMain"))
+            ui->splitterMain->restoreState(settings.value("ScriptingWindow/SplitterMain").toByteArray());
+        if (settings.contains("ScriptingWindow/SplitterLeft"))
+            ui->splitterLeft->restoreState(settings.value("ScriptingWindow/SplitterLeft").toByteArray());
+        if (settings.contains("ScriptingWindow/SplitterRight"))
+            ui->splitterRight->restoreState(settings.value("ScriptingWindow/SplitterRight").toByteArray());
     }
 }
 
@@ -152,6 +163,9 @@ void ScriptingWindow::writeSettings()
     {
         settings.setValue("ScriptingWindow/WindowSize", size());
         settings.setValue("ScriptingWindow/WindowPos", pos());
+        settings.setValue("ScriptingWindow/SplitterMain", ui->splitterMain->saveState());
+        settings.setValue("ScriptingWindow/SplitterLeft", ui->splitterLeft->saveState());
+        settings.setValue("ScriptingWindow/SplitterRight", ui->splitterRight->saveState());
     }
 }
 

--- a/ui/scriptingwindow.ui
+++ b/ui/scriptingwindow.ui
@@ -6,183 +6,313 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>862</width>
-    <height>651</height>
+    <width>1000</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Scripting Interface</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,4">
+  <layout class="QVBoxLayout" name="mainVLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_4">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
+    <widget class="QSplitter" name="splitterMain">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <!-- Left panel: variables + loaded scripts -->
+     <widget class="QWidget" name="leftPanel">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Public Variables</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QTableWidget" name="tableVariables"/>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Loaded Scripts</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="listLoadedScripts"/>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QPushButton" name="btnNewScript">
-         <property name="text">
-          <string>&amp;New</string>
+        <widget class="QSplitter" name="splitterLeft">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnRemoveScript">
-         <property name="text">
-          <string>&amp;Del</string>
+         <property name="childrenCollapsible">
+          <bool>false</bool>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnLoadScript">
-         <property name="text">
-          <string>&amp;Load</string>
-         </property>
+         <widget class="QWidget" name="variablesPanel">
+          <layout class="QVBoxLayout" name="verticalLayout_vars">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_4">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Public Variables</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTableWidget" name="tableVariables"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="scriptsPanel">
+          <layout class="QVBoxLayout" name="verticalLayout_scripts">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Loaded Scripts</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="listLoadedScripts"/>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QPushButton" name="btnNewScript">
+               <property name="text">
+                <string>&amp;New</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnRemoveScript">
+               <property name="text">
+                <string>&amp;Del</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnLoadScript">
+               <property name="text">
+                <string>&amp;Load</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,4,0,0">
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
+     </widget>
+     <!-- Right panel: vertical splitter between editor and log -->
+     <widget class="QWidget" name="rightPanel">
+      <layout class="QVBoxLayout" name="rightOuterLayout">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-       <property name="text">
-        <string>Script Editing Window</string>
+       <property name="topMargin">
+        <number>0</number>
        </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+       <property name="rightMargin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
        <item>
-        <widget class="QPushButton" name="btnSaveScript">
-         <property name="text">
-          <string>&amp;Save</string>
+        <widget class="QSplitter" name="splitterRight">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnSaveAsScript">
-         <property name="text">
-          <string>Sa&amp;ve As</string>
+         <property name="childrenCollapsible">
+          <bool>false</bool>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnRevertScript">
-         <property name="text">
-          <string>&amp;Revert</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnReloadScript">
-         <property name="text">
-          <string>R&amp;eload</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnRecompile">
-         <property name="text">
-          <string>Re&amp;compile</string>
-         </property>
+         <!-- Editor section (editor widget inserted here by code) -->
+         <widget class="QWidget" name="editorPanel">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Script Editing Window</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <widget class="QPushButton" name="btnSaveScript">
+               <property name="text">
+                <string>&amp;Save</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnSaveAsScript">
+               <property name="text">
+                <string>Sa&amp;ve As</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnRevertScript">
+               <property name="text">
+                <string>&amp;Revert</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnReloadScript">
+               <property name="text">
+                <string>R&amp;eload</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnRecompile">
+               <property name="text">
+                <string>Re&amp;compile</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+         <!-- Log section -->
+         <widget class="QWidget" name="logPanel">
+          <layout class="QVBoxLayout" name="verticalLayout_log">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="font">
+              <font>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Log Window</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="listLog"/>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="cbAutoScroll">
+             <property name="text">
+              <string>&amp;Auto Scroll Log Window</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_log">
+             <item>
+              <widget class="QPushButton" name="btnClearLog">
+               <property name="text">
+                <string>Clear Log &amp;Window</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnSaveLog">
+               <property name="text">
+                <string>Save L&amp;og</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_3">
-       <property name="font">
-        <font>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="text">
-        <string>Log Window</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="listLog"/>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="cbAutoScroll">
-       <property name="text">
-        <string>&amp;Auto Scroll Log Window</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_log">
-            <property name="alignment">
-                <set>Qt::AlignCenter</set>
-            </property>
-            <property name="contentsMargins">10, 0, 10, 0</property>
-            <item>
-                <widget class="QPushButton" name="btnClearLog">
-                    <property name="text">
-                        <string>Clear Log &amp;Window</string>
-                    </property>
-                </widget>
-            </item>
-            <item>
-                <widget class="QPushButton" name="btnSaveLog">
-                    <property name="text">
-                        <string>Save L&amp;og</string>
-                    </property>
-                </widget>
-            </item>
-        </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
## Summary

Three improvements to the scripting window targeting the QT6WIP branch.

## Changes

### Add resizable splitter panes ([fc6e660](https://github.com/minoseigenheer/SavvyCAN/commit/fc6e66024fa8467c199882c86bb1f52437d8e1ca))
Replaces the fixed-layout scripting window with three `QSplitter` panes (left panel / editor / log area), giving the user control over each section's width. Splitter positions are saved to `QSettings` and restored on next open.

### Fix crash and stale table entries on script delete ([0d08d51](https://github.com/minoseigenheer/SavvyCAN/commit/0d08d510be3e25e7b1d84603936c98ceb539abdd))
- A `QueuedConnection`-delivered `gotTargettedFrame` event could arrive after the `ScriptContainer` was freed, causing a segfault. Fix: call `clearFilters()` and `QCoreApplication::removePostedEvents()` on each helper before deleting it.
- Set `currentScript = nullptr` *before* calling `takeItem()`, so that the `currentRowChanged` signal fired by the list widget does not try to access the script that is being deleted.
- Clear the variables table when the last script is removed.

### Use system fixed-width font instead of hardcoded names ([a72aa50](https://github.com/minoseigenheer/SavvyCAN/commit/a72aa50298b914a92fd8d5f07b9c1274b592ceb6))
Replaces the platform-specific `Monaco` / `Monospace` font names with `QFontDatabase::systemFont(QFontDatabase::FixedFont)`, which works correctly on all platforms (macOS, Linux, Windows) without conditional compilation.

## Files changed
- `scriptingwindow.cpp`
- `ui/scriptingwindow.ui`
- `scriptcontainer.cpp`
- `jsedit.cpp`