### PR TITLE
Fix missing and mislabeled received CAN frames

### DIFF
--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -113,9 +113,11 @@ void SerialBusConnection::piSetBusSettings(int pBusIdx, CANBus bus)
     mDev_p->setConfigurationParameter(QCanBusDevice::UserKey, sbusconfig);
 
     /* connect device */
-    if (!mDev_p->connectDevice()) {
-        disconnectDevice();
-        qDebug() << "can't connect device";
+    if (mDev_p && mDev_p->state() == QCanBusDevice::UnconnectedState) {
+        if (!mDev_p->connectDevice()) {
+            disconnectDevice();
+            qDebug() << "SerialBusConnection::piSetBusSettings - can't connect device";
+        }
     }
 }
 

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -201,11 +201,16 @@ void SerialBusConnection::framesReceived()
             if(frame_p) {
                 frame_p->setPayload(recFrame.payload());
                 frame_p->setBus(0);
+                // All frames arriving via framesReceived() are genuinely received frames.
+                // Do not use QCanBusFrame::hasLocalEcho() to determine direction: some backends
+                // (e.g. PeakCAN/PCAN on certain platforms) report local echo unreliably,
+                // causing all received frames to appear as Tx.
+                frame_p->setReceived(true);
+
                 if (recFrame.frameType() == recFrame.ErrorFrame)
                 {
                     frame_p->setExtendedFrameFormat(recFrame.hasExtendedFrameFormat());
                     frame_p->setFrameId(recFrame.frameId() + 0x20000000ull);
-                    frame_p->setReceived(true);
                 }
                 else
                 {

--- a/help/scriptingwindow.md
+++ b/help/scriptingwindow.md
@@ -34,7 +34,7 @@ setup () - If you create a function named setup then it will be called as soon a
 
 tick () - If you registered to receive a periodic tick within your setup function then the script interface will call this function for every tick. You can do whatever you need to periodically do here. But, you get only one tick handler so if you need multiple tick rates you'll have to create a fast tick here and dispatch from this function at different rates yourself.
 
-gotCommFrame (bus, id, len, data) - A callback that will be called whenever a CAN frame comes in that you've registered for. You did register for frames in your setup function didn't you? Well, if you use one of the below callbacks you might not need this one.
+gotCommFrame (bus, id, len, data) - A callback that will be called whenever a CAN frame comes in that you've registered for. You did register for frames in your setup function didn't you? Well, if you use one of the below callbacks you might not need this one. For backward compatibility, older scripts that still define gotCANFrame(bus, id, len, data) are also accepted.
 
 gotISOTPMessage (bus, id, len, data) - If you are instead looking for ISO-TP messages (which could have been multiple CAN frames in length) then you can create this function and it will automatically be registered with the system. But, you still will need to set which ISO-TP message IDs you want to receive. That is covered later on.
 
@@ -129,5 +129,4 @@ A full example script
             } 
         }
     }
-
 

--- a/scriptcontainer.cpp
+++ b/scriptcontainer.cpp
@@ -85,7 +85,14 @@ void ScriptContainer::compileScript()
 
         //Find out which callbacks the script has created.
         setupFunction = scriptEngine->globalObject().property("setup");
-        canHelper->setRxCallback(scriptEngine->globalObject().property("gotCommFrame"));
+        QJSValue canRxCallback = scriptEngine->globalObject().property("gotCommFrame");
+        if (!canRxCallback.isCallable())
+        {
+            // Backward compatibility with older scripts.
+            canRxCallback = scriptEngine->globalObject().property("gotCANFrame");
+            if (canRxCallback.isCallable()) qDebug() << "Using legacy gotCANFrame callback";
+        }
+        canHelper->setRxCallback(canRxCallback);
         isoHelper->setRxCallback(scriptEngine->globalObject().property("gotISOTPMessage"));
         udsHelper->setRxCallback(scriptEngine->globalObject().property("gotUDSMessage"));
 
@@ -438,4 +445,3 @@ void UDSScriptHelper::newUDSMessage(UDS_MESSAGE msg)
     args.append(dataBytes);
     gotFrameFunction.call(args);
 }
-


### PR DESCRIPTION
## Summary

Three fixes that together ensure received CAN frames are correctly captured and displayed, targeting the QT6WIP branch.

## Changes

### Fix Rx/Tx mislabeling for SerialBus received frames ([0d70306](https://github.com/minoseigenheer/SavvyCAN/commit/0d703061e76c363644aaf3c402488fad8409f642))
All frames arriving through `framesReceived()` are genuinely received frames. The previous code used `QCanBusFrame::hasLocalEcho()` to determine direction, but several backends (notably PeakCAN/PCAN) report local echo unreliably, causing received frames to appear as Tx in the main view. `setReceived(true)` is now called unconditionally for every frame from this path.

### Restore `connectDevice()` in `piSetBusSettings()` to fix missing RX frames ([5b60674](https://github.com/minoseigenheer/SavvyCAN/commit/5b6067415d5358b1714082e0903a6ec5506e196e))
A previous refactor removed the `connectDevice()` call from `piSetBusSettings()`. Without it, applying bus settings (speed, FD mode, listen-only) did not reconnect the device, so no frames were received until the user manually reconnected. The call is restored, guarded with a state check so it is only attempted when the device is in `UnconnectedState`.

### Fix JS `gotCANFrame` → `gotCommFrame` rename compatibility ([276c470](https://github.com/minoseigenheer/SavvyCAN/commit/276c470cf98135bc0b592fe114bd2c4083433f90))
The JS callback was renamed from `gotCANFrame` to `gotCommFrame` in a prior commit, silently breaking all existing user scripts. `compileScript()` now first looks for `gotCommFrame`; if not found, it falls back to `gotCANFrame` for backward compatibility (with a debug log message).

## Files changed
- `connections/serialbusconnection.cpp`
- `scriptcontainer.cpp`