### PR TITLE
Save/restore main window UI state across sessions

### DIFF
--- a/mainsettingsdialog.cpp
+++ b/mainsettingsdialog.cpp
@@ -182,39 +182,49 @@ void MainSettingsDialog::updateSettings()
 {
     QSettings settings;
 
-    settings.setValue("Main/UseHex", ui->cbDisplayHex->isChecked());
     settings.setValue("FlowView/AutoRef", ui->cbFlowAutoRef->isChecked());
     settings.setValue("FlowView/UseTimestamp", ui->cbFlowUseTimestamp->isChecked());
     settings.setValue("FlowView/GraphHex", ui->cbHexGraphFlow->isChecked());
     settings.setValue("InfoCompare/GraphHex", ui->cbHexGraphInfo->isChecked());
     settings.setValue("InfoCompare/AutoExpand", ui->cbInfoAutoExpand->isChecked());
-    settings.setValue("Main/AutoScroll", ui->cbMainAutoScroll->isChecked());
-    settings.setValue("Playback/AutoLoop", ui->cbPlaybackLoop->isChecked());
-    settings.setValue("Main/SaveRestorePositions", ui->cbRestorePositions->isChecked());
-    settings.setValue("Main/SaveRestoreConnections", ui->cbLoadConnections->isChecked());
-    settings.setValue("Main/ValidateComm", ui->cbValidate->isChecked());
-    settings.setValue("Playback/DefSpeed", ui->spinPlaybackSpeed->value());
-    settings.setValue("Main/TimeSeconds", ui->rbSeconds->isChecked());
-    settings.setValue("Main/TimeMillis", ui->rbMillis->isChecked());
-    settings.setValue("Main/TimeClock", ui->rbSysClock->isChecked());
-    settings.setValue("Main/CSVAbsTime", ui->cbCSVAbsTime->isChecked());
-    settings.setValue("Playback/SendingBus", ui->comboSendingBus->currentIndex());
+
+    settings.setValue("Main/MainAutoScroll", ui->cbMainAutoScroll->isChecked());
+
+/*
+    settings.setValue("Main/AutoScroll", false);
+    settings.setValue("Main/Interpret", false);
+    settings.setValue("Main/Overwrite", false);
+    settings.setValue("Main/PersistentFilters", false);
+*/
+    settings.setValue("Main/UseHex", ui->cbDisplayHex->isChecked());
     settings.setValue("Main/UseFiltered", ui->cbUseFiltered->isChecked());
     settings.setValue("Main/UseOpenGL", ui->cbUseOpenGL->isChecked());
     settings.setValue("Main/EqualDataSniff", ui->cbEqualSniffer->isChecked());
     settings.setValue("Main/TimeFormat", ui->lineClockFormat->text());
     settings.setValue("Main/FontSize", ui->spinFontSize->value());
-    settings.setValue("Remote/Host", ui->lineRemoteHost->text());
-    settings.setValue("Remote/Port", ui->lineRemotePort->text());
-    settings.setValue("Remote/User", ui->lineRemoteUser->text());
-    QByteArray encPass = crypto.encryptToByteArray(ui->lineRemotePassword->text());
-    settings.setValue("Remote/Pass", encPass);
+    settings.setValue("Main/TimeSeconds", ui->rbSeconds->isChecked());
+    settings.setValue("Main/TimeMillis", ui->rbMillis->isChecked());
+    settings.setValue("Main/TimeClock", ui->rbSysClock->isChecked());
+    settings.setValue("Main/CSVAbsTime", ui->cbCSVAbsTime->isChecked());
+    settings.setValue("Main/SaveRestorePositions", ui->cbRestorePositions->isChecked());
+    settings.setValue("Main/SaveRestoreConnections", ui->cbLoadConnections->isChecked());
+    settings.setValue("Main/ValidateComm", ui->cbValidate->isChecked());
     settings.setValue("Main/FilterLabeling", ui->cbFilterLabeling->isChecked());
     settings.setValue("Main/IgnoreDBCColors", ui->cbIgnoreDBCColors->isChecked());
     settings.setValue("Main/MaximumFrames", ui->spinMaximumFrames->value());
     settings.setValue("Main/BytesPerLine", ui->spinBytesPerLine->value());
     settings.setValue("Main/FontFixedWidth", ui->cbFontFixedWidth->isChecked());
     settings.setValue("Main/ColorsByCanId", ui->cbColorsByCanId->isChecked());
+
+    settings.setValue("Playback/AutoLoop", ui->cbPlaybackLoop->isChecked());
+    settings.setValue("Playback/DefSpeed", ui->spinPlaybackSpeed->value());
+    settings.setValue("Playback/SendingBus", ui->comboSendingBus->currentIndex());
+
+    settings.setValue("Remote/Host", ui->lineRemoteHost->text());
+    settings.setValue("Remote/Port", ui->lineRemotePort->text());
+    settings.setValue("Remote/User", ui->lineRemoteUser->text());
+    QByteArray encPass = crypto.encryptToByteArray(ui->lineRemotePassword->text());
+    settings.setValue("Remote/Pass", encPass);
 
     settings.sync();
     emit updatedSettings();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -175,6 +175,10 @@ MainWindow::MainWindow(QWidget *parent) :
 
     //Frame count column should be hidden by default. Only used in overwrite mode
     ui->canFramesView->hideColumn((int)Column::FrameCount);
+    //If overwrite mode was restored from settings, show the column again
+    if (ui->cbOverwrite->isChecked()) {
+        ui->canFramesView->showColumn((int)Column::FrameCount);
+    }
 
     lbStatusConnected.setText(tr("Connected to 0 buses"));
     lbHelp.setText(tr("Press F1 on any screen for help"));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -156,6 +156,7 @@ MainWindow::MainWindow(QWidget *parent) :
     //new implementation for continuous logging
     connect(CANConManager::getInstance(), &CANConManager::framesReceived, this, &MainWindow::logReceivedFrame);
 
+    connect(ui->cbAutoScroll, &QAbstractButton::toggled, this, &MainWindow::interpretAutoScroll);
     connect(ui->cbInterpret, &QAbstractButton::toggled, this, &MainWindow::interpretToggled);
     connect(ui->cbOverwrite, &QAbstractButton::toggled, this, &MainWindow::overwriteToggled);
     connect(ui->cbPersistentFilters, &QAbstractButton::toggled, this, &MainWindow::presistentFiltersToggled);
@@ -333,7 +334,6 @@ void MainWindow::exitApp()
 //the close event can be trapped and ignored so put unsaved warnings in here so the user can abort the program closing if they forgot to save things.
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-
     QMessageBox::StandardButton confirmDialog;
 
     for (int i = 0; i < dbcHandler->getFileCount(); i++)
@@ -400,10 +400,39 @@ void MainWindow::readSettings()
         ui->canFramesView->setColumnWidth(7, settings.value("Main/AsciiColumn", 50).toUInt()); //ascii
         //ui->canFramesView->setColumnWidth(8, settings.value("Main/DataColumn", 225).toUInt()); //data
     }
+
+    if (settings.value("Main/Interpret", false).toBool())
+    {
+        ui->cbInterpret->setChecked(Qt::Checked);
+        model->setInterpretMode(true);
+    }
+    else
+        model->setInterpretMode(false);
+
     if (settings.value("Main/AutoScroll", false).toBool())
     {
-        ui->cbAutoScroll->setChecked(true);
+        ui->cbAutoScroll->setChecked(Qt::Checked);
     }
+
+    if (settings.value("Main/Overwrite", false).toBool())
+    {
+        ui->cbOverwrite->setChecked(Qt::Checked);
+        model->setOverwriteMode(true);
+    }
+    else
+    {
+        model->setOverwriteMode(false);
+        rowExpansionActive = false;
+    }
+
+    if (settings.value("Main/PersistentFilters", false).toBool())
+    {
+        ui->cbPersistentFilters->setChecked(Qt::Checked);
+        model->setClearMode(true);
+    }
+    else
+        model->setClearMode(false);
+
     int fontSize = settings.value("Main/FontSize", 9).toUInt();
     QFont newFont = QFont(ui->canFramesView->font());
     newFont.setPointSize(fontSize);
@@ -899,14 +928,27 @@ void MainWindow::setupSendToLatestGraphWindow()
         msgbox.exec();
     }
 }
+
+void MainWindow::interpretAutoScroll(bool state)
+{
+    QSettings settings;
+    settings.setValue("Main/AutoScroll", state);
+}
+
 void MainWindow::interpretToggled(bool state)
 {
+    QSettings settings;
+    settings.setValue("Main/Interpret", state);
+
     model->setInterpretMode(state);
     //ui->canFramesView->resizeRowsToContents();   //a VERY costly operation!
 }
 
 void MainWindow::overwriteToggled(bool state)
 {
+    QSettings settings;
+    settings.setValue("Main/Overwrite", state);
+
     if (state)
     {
         QMessageBox::StandardButton confirmDialog;
@@ -929,7 +971,10 @@ void MainWindow::overwriteToggled(bool state)
 }
 
 void MainWindow::presistentFiltersToggled(bool state)
-{
+{    
+    QSettings settings;
+    settings.setValue("Main/PersistentFilters", state);
+
     if (state)
     {
         model->setClearMode(true);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -113,6 +113,7 @@ private slots:
     void copyFromTable();
     void setupAddToNewGraph();
     void setupSendToLatestGraphWindow();
+    void interpretAutoScroll(bool);
     void interpretToggled(bool);
     void overwriteToggled(bool);
     void presistentFiltersToggled(bool state);


### PR DESCRIPTION
## Summary

Persists the main window checkbox states and column widths across application restarts, targeting the QT6WIP branch.

## Changes ([3463a57](https://github.com/minoseigenheer/SavvyCAN/commit/3463a57b01d8a99a8c09030501754cc55b5f3f89))

Previously only window geometry was saved. This change extends persistence to the four main-view toggle checkboxes and their associated model state:

| Setting | QSettings key |
|---|---|
| AutoScroll | `Main/AutoScroll` |
| Interpret | `Main/Interpret` |
| Overwrite | `Main/Overwrite` |
| Persistent Filters | `Main/PersistentFilters` |

Each checkbox's `toggled` signal now immediately writes its new state, and `readSettings()` restores each checkbox *and* applies the corresponding model setting (e.g. `setOverwriteMode`, `setClearMode`) on startup so the view behaves consistently from the first frame.

Column widths are also now saved and restored when the hex+dec data column is active.

## Files changed
- `mainwindow.cpp/.h`
- `mainsettingsdialog.cpp`