### PR TITLE
Fix frame sender: processModifierText reads wrong column

### DIFF
--- a/framesenderwindow.cpp
+++ b/framesenderwindow.cpp
@@ -729,7 +729,7 @@ void FrameSenderWindow::processModifierText(int line)
 
     //yeah, lots of operations on this one line but it's for a good cause. Removes the convenience English versions of the
     //logical operators and replaces them with the math equivs. Also uppercases and removes all superfluous whitespace
-    modString = ui->tableSender->item(line, 8)->text().toUpper().trimmed().replace("AND", "&").replace("XOR", "^").replace("OR", "|").replace(" ", "");
+    modString = ui->tableSender->item(line, ST_COLS::SENDTAB_COL_MODS)->text().toUpper().trimmed().replace("AND", "&").replace("XOR", "^").replace("OR", "|").replace(" ", "");
     if (modString != "")
     {
         QStringList mods = modString.split(',');


### PR DESCRIPTION
## Summary

One-line bug fix in the frame sender window, targeting the QT6WIP branch.

## Change ([6734f4a](https://github.com/minoseigenheer/SavvyCAN/commit/6734f4a27a276bb863f65da58976afe3890417cf))

`processModifierText()` was reading the text from column **8** (TRIGGER) instead of column **9** (MODS) due to a hardcoded magic number. This caused modifier expressions to always be empty, so data-byte modifiers in the send table had no effect.

**Fix:** Replace the literal `8` with `ST_COLS::SENDTAB_COL_MODS`, the named constant that correctly identifies the modifiers column.

## Files changed
- `framesenderwindow.cpp`