### PR TITLE
fix: app icon not showing on macOS and Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,14 @@ qt_add_executable(SavvyCAN WIN32 MACOSX_BUNDLE
 )
 
 if(APPLE)
+    set(APP_ICON_MACOS "${CMAKE_CURRENT_SOURCE_DIR}/icons/SavvyIcon.icns")
+    set_source_files_properties(${APP_ICON_MACOS} PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Resources"
+    )
+    target_sources(SavvyCAN PRIVATE ${APP_ICON_MACOS})
     set_target_properties(SavvyCAN PROPERTIES
         MACOSX_BUNDLE_ICON_FILE SavvyIcon.icns
-        RESOURCE "icons/SavvyIcon.icns"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.cmake"
     )
 endif()
 

--- a/Info.plist.cmake
+++ b/Info.plist.cmake
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>SavvyIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>me.evtv.SavvyCAN</string>
+	<key>CFBundleName</key>
+	<string>SavvyCAN</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>asc</string>
+				<string>avc</string>
+				<string>blf</string>
+				<string>can</string>
+				<string>crt</string>
+				<string>crtd</string>
+				<string>csv</string>
+				<string>evc</string>
+				<string>log</string>
+				<string>qcc</string>
+				<string>trace</string>
+				<string>trc</string>
+				<string>txt</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/icons/SavvyIcon.rc
+++ b/icons/SavvyIcon.rc
@@ -1,0 +1,1 @@
+IDI_ICON1               ICON    "SavvyIcon.ico"


### PR DESCRIPTION
macOS:
- Replace broken RESOURCE property with set_source_files_properties MACOSX_PACKAGE_LOCATION approach so the .icns is correctly copied into SavvyCAN.app/Contents/Resources/ during the build
- Add Info.plist.cmake with proper CMake variables (CFBundleIconFile set to SavvyIcon) replacing the qmake-only Info.plist.template that used incompatible ${ASSETCATALOG_COMPILER_APPICON_NAME} variable

Windows:
- Add icons/SavvyIcon.rc resource file that was referenced in CMakeLists.txt but missing, which caused the .ico to not be embedded in the executable