### PR TITLE
fix: Cmd+W closes active window on macOS

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include <QApplication>
+#include <QKeyEvent>
 
 class SavvyCANApplication : public QApplication
 {
@@ -19,6 +20,24 @@ public:
         }
 
         return QApplication::event(event);
+    }
+
+    bool notify(QObject *receiver, QEvent *event) override
+    {
+        if (event->type() == QEvent::KeyPress)
+        {
+            QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+            if (keyEvent->matches(QKeySequence::Close))
+            {
+                QWidget *active = QApplication::activeWindow();
+                if (active)
+                {
+                    active->close();
+                    return true;
+                }
+            }
+        }
+        return QApplication::notify(receiver, event);
     }
 };
 


### PR DESCRIPTION
## Problem
On macOS, pressing `Cmd+W` did not close sub-windows (graphing, frame info, playback, etc.) because Qt does not automatically wire `QKeySequence::Close` for non-QMainWindow widgets.

## Fix
Override `notify()` in `SavvyCANApplication` (main.cpp) to intercept `QKeySequence::Close` globally. When triggered, it calls `close()` on whichever window is currently active.

- No changes needed to individual window classes
- Works for all windows (QMainWindow, QDialog, etc.)
- Only one file changed: `main.cpp`