### PR TITLE
fix: correct PCAN timestamps (uptime-based backends)

### DIFF
--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -134,6 +134,11 @@ uint64_t CANConManager::getTimeBasis()
     return mTimestampBasis;
 }
 
+uint64_t CANConManager::getElapsedUs()
+{
+    return static_cast<uint64_t>(mElapsedTimer.nsecsElapsed()) / 1000ULL;
+}
+
 QList<CANConnection*>& CANConManager::getConnections()
 {
     return mConns;

--- a/connections/canconmanager.cpp
+++ b/connections/canconmanager.cpp
@@ -39,6 +39,11 @@ void CANConManager::resetTimeBasis()
 {
     mTimestampBasis = QDateTime::currentMSecsSinceEpoch() * 1000;
     mElapsedTimer.restart();
+    // Flush any frames already queued by connections — they carry timestamps
+    // computed against the old mElapsedTimer and would appear with incorrect
+    // (large) values after the reset if not discarded now.
+    foreach (CANConnection* conn_p, mConns)
+        conn_p->getQueue().flush();
 }
 
 CANConManager::~CANConManager()

--- a/connections/canconmanager.h
+++ b/connections/canconmanager.h
@@ -25,6 +25,7 @@ public:
     CANConnection* getByName(const QString& pName) const;
 
     uint64_t getTimeBasis();
+    uint64_t getElapsedUs(); // µs elapsed since last resetTimeBasis() — same reference as Tx timestamps
     void resetTimeBasis();
 
     int getNumBuses();

--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -151,6 +151,22 @@ void SerialBusConnection::disconnectDevice() {
     }
 }
 
+/* Immediately update status when the device state changes */
+void SerialBusConnection::deviceStateChanged(QCanBusDevice::CanBusDeviceState state)
+{
+    CANConStatus stats;
+    if (state == QCanBusDevice::ConnectedState) {
+        setStatus(CANCon::CONNECTED);
+        stats.conStatus = getStatus();
+        stats.numHardwareBuses = mNumBuses;
+        emit status(stats);
+    } else if (state == QCanBusDevice::UnconnectedState && getStatus() == CANCon::CONNECTED) {
+        setStatus(CANCon::NOT_CONNECTED);
+        stats.conStatus = getStatus();
+        stats.numHardwareBuses = mNumBuses;
+        emit status(stats);
+    }
+}
 
 void SerialBusConnection::errorReceived(QCanBusDevice::CanBusError error) const
 {
@@ -229,7 +245,22 @@ void SerialBusConnection::framesReceived()
                 if (useSystemTime) {
                     frame_p->setTimeStamp(CommFrame::TimeStamp::fromMicroSeconds(QDateTime::currentMSecsSinceEpoch() * 1000ul));
                 }
-                else frame_p->setTimeStamp(CommFrame::TimeStamp(0, (recFrame.timeStamp().seconds() * 1000000ul + recFrame.timeStamp().microSeconds()) - timeBasis));
+                else {
+                    uint64_t hwTimestamp = static_cast<uint64_t>(recFrame.timeStamp().seconds()) * 1000000ULL
+                                          + static_cast<uint64_t>(recFrame.timeStamp().microSeconds());
+                    uint64_t relTimestamp;
+                    if (hwTimestamp >= timeBasis) {
+                        // Epoch-based hw timestamp (e.g. SocketCAN): subtract session basis.
+                        relTimestamp = hwTimestamp - timeBasis;
+                    } else {
+                        // Uptime-based hw timestamp (e.g. PCAN): the hw clock cannot be
+                        // synchronised to the elapsed timer without a fixed anchor bias,
+                        // so use the elapsed timer directly — the same source as Tx timestamps.
+                        // This guarantees Tx and Rx share one consistent clock with no drift.
+                        relTimestamp = CANConManager::getInstance()->getElapsedUs();
+                    }
+                    frame_p->setTimeStamp(CommFrame::TimeStamp(0, relTimestamp));
+                }
 
                 checkTargettedFrame(*frame_p);
 


### PR DESCRIPTION
## Problem

PCAN/PeakCAN hardware provides timestamps relative to device power-on (uptime), not the Unix epoch. The existing code subtracted `timeBasis` (a Unix epoch value in µs) from this small uptime value, causing **unsigned integer underflow** and producing large negative-looking timestamps (e.g. -1777429996593330 µs).

A secondary problem existed even after detecting the uptime clock: using a `QDateTime` wall-clock anchor to convert the PCAN uptime to session-relative time introduced a systematic ~3 ms bias (macOS monotonic vs. wall clock drift ~14 ppm). This made every Rx timestamp appear slightly *after* its corresponding Tx timestamp in override-mode delta calculations, breaking the expected request/response order.

A third problem: clicking **Clear Frames** while frames are arriving restarts `mElapsedTimer`, but frames already queued by the hardware thread carry timestamps from the *old* timer epoch. Those frames are drained ~20 ms later by the refresh tick and appear with incorrect (large) timestamps relative to subsequent frames.

## Fix

**Commit 1 — correct PCAN timestamps for uptime-based backends**
- Detect uptime-based hw timestamps by checking `hwTimestamp < timeBasis`.
- For those backends, use `CANConManager::getElapsedUs()` directly instead of the PCAN hw clock. This is the identical `QElapsedTimer` monotonic source used for Tx timestamps, so Tx and Rx are always on the same clock with zero drift or bias.
- Add `CANConManager::getElapsedUs()` helper (exposes `mElapsedTimer.nsecsElapsed() / 1000`).
- Remove first-frame anchor members (`mFirstHwTimestamp`, `mFirstElapsedUs`) that are no longer needed.

**Commit 2 — prevent incorrect timestamps after Clear Frames**
- `resetTimeBasis()` now flushes every connection's frame queue immediately after restarting `mElapsedTimer`, so pre-reset frames are discarded before the drain timer fires.

## Files changed

- `connections/serialbusconnection.cpp` — uptime detection + `getElapsedUs()` for Rx
- `connections/serialbusconnection.h` — removed obsolete anchor members
- `connections/canconmanager.cpp` — added `getElapsedUs()`, queue flush in `resetTimeBasis()`
- `connections/canconmanager.h` — added `getElapsedUs()` declaration

## Testing

Verified with a PCAN-USB on macOS:
- Timestamps are now positive and start near 0 µs on session start.
- Rx timestamps align with Tx timestamps (same monotonic source, no fixed bias).
- Clicking Clear Frames while live traffic is flowing produces correct timestamps immediately after the clear.