### PR TITLE
ci: add 32-bit Windows build for J2534 PassThru support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,11 +153,70 @@ jobs:
         with:
           name: SavvyCAN-Windows_x64
           path: package
- 
+
+  buildwindows32:
+    name: Windows x86 (32-bit)
+    runs-on: windows-2022
+
+    # A 32-bit Windows build is required to use J2534 PassThru devices
+    # (Tactrix Openport, Mongoose, etc.). Vendor PassThru DLLs are only
+    # shipped as 32-bit, and Windows cannot mix bitness in a single process,
+    # so a 64-bit SavvyCAN cannot LoadLibrary them. Qt5 is the last Qt that
+    # ships a prebuilt 32-bit Windows toolchain (win32_msvc2019); Qt6 does
+    # not, so this job will need to be removed if/when master moves to Qt6.
+    steps:
+      - name: Prepare Qt Libraries
+        uses: jurplel/install-qt-action@v3
+        with:
+          arch: 'win32_msvc2019'
+
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Compile
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+          qmake CONFIG+=release SavvyCAN.pro
+          nmake /C
+
+      - name: Package
+        run: |
+          mkdir package
+          copy "release/SavvyCAN.exe" package/
+          mkdir package/help
+          copy  translations/*.qm package/translations/
+          copy  help/*.md package/help/
+          mkdir package/help/images
+          copy help/images/*.* package/help/images/
+          mkdir package/examples
+          copy examples/*.* package/examples/
+          copy "${Env:Qt5_Dir}/bin/Qt5Core.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5Gui.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5Network.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5PrintSupport.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5Qml.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5SerialBus.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5SerialPort.dll" package/
+          copy "${Env:Qt5_Dir}/bin/Qt5Widgets.dll" package/
+          mkdir package/imageformats
+          copy "${Env:Qt5_Dir}/plugins/imageformats/*.*" package/imageformats/
+          mkdir package/platforms
+          copy "${Env:Qt5_Dir}/plugins/platforms/*.*" package/platforms/
+          mkdir package/styles
+          copy "${Env:Qt5_Dir}/plugins/styles/*.*" package/styles/
+          mkdir package/canbus
+          copy "${Env:Qt5_Dir}/plugins/canbus/*.*" package/canbus/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SavvyCAN-Windows_x86
+          path: package
+
   pre-release:
     name: "pre-release"
     runs-on: "ubuntu-latest"
-    needs: [buildwindows, buildmacos86, buildmacos-arm64, buildlinux]
+    needs: [buildwindows, buildwindows32, buildmacos86, buildmacos-arm64, buildlinux]
 
     steps:
       - uses: actions/checkout@v3
@@ -166,6 +225,8 @@ jobs:
 
       - name: Display structure of downloaded files
         run: zip -r SavvyCAN-Windows_x64_CIBuild.zip SavvyCAN-Windows_x64
+      - name: Display structure of downloaded files (x86)
+        run: zip -r SavvyCAN-Windows_x86_CIBuild.zip SavvyCAN-Windows_x86
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
@@ -175,13 +236,14 @@ jobs:
           files: |
             SavvyCAN-Linux_x64.AppImage/SavvyCAN-*x86_64.AppImage
             SavvyCAN-Windows_x64_CIBuild.zip
+            SavvyCAN-Windows_x86_CIBuild.zip
             SavvyCAN-macOS_x64.dmg/SavvyCAN_x64.dmg
             SavvyCAN-macOS_ARM64.dmg/SavvyCAN_arm64.dmg
-          
+
   notify:
     name: Notify Discord
     runs-on: ubuntu-latest
-    needs: [buildwindows, buildmacos86, buildmacos-arm64, buildlinux]
+    needs: [buildwindows, buildwindows32, buildmacos86, buildmacos-arm64, buildlinux]
     steps:
       - id: msg_var
         name: remove newlines

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ within the collin80 repos.
 
 It is now possible to use any Qt SerialBus driver (socketcan, Vector, PeakCAN, TinyCAN).
 
+### Windows note for J2534 PassThru devices
+
+If you intend to use a J2534 PassThru device (Tactrix Openport, Mongoose, DrewTech,
+etc.), download the **32-bit (x86)** Windows build rather than the 64-bit one.
+Vendor PassThru drivers are only shipped as 32-bit DLLs and Windows cannot mix
+bitness within a single process, so the 64-bit SavvyCAN cannot load them and the
+device will not appear.
+
 It should, however, be noted that use of a capture device is not required to make use
 of this program. It can load and save in several formats:
 


### PR DESCRIPTION
## Summary

Adds a `buildwindows32` CI job that produces a native 32-bit Windows build of SavvyCAN, packaged the same way as the existing x64 build and attached to the `continuous` pre-release as `SavvyCAN-Windows_x86_CIBuild.zip`.

## Why

Vendor J2534 PassThru DLLs (Tactrix Openport, Mongoose, DrewTech, etc.) are distributed only as 32-bit binaries. Windows cannot mix bitness in a single process, so a 64-bit SavvyCAN cannot `LoadLibrary` them via Qt's `passthrucan` SerialBus plugin — the device enumerates from the registry, but the connection drops as soon as the plugin tries to attach. Users hitting this have been falling back to private 32-bit rebuilds (e.g. amiralnar/SavvyCAN's release zip linked from #563) just to use a PassThru device.

A native 32-bit SavvyCAN sidesteps the whole problem. **No source changes are required** — the existing `SerialBusConnection` / `passthrucan` path picks up J2534 devices automatically once the host process is 32-bit.

Fixes #563. Same general approach as the amiralnar fork's CI; updated to match this repo's current `windows-2022` / VS2022 / `actions/*@v4` setup.

## Notes

- `install-qt-action` only ships a 32-bit prebuilt toolchain for Qt5 (`win32_msvc2019`). This job is therefore inherently Qt5-only and will need to be removed or replaced with a self-built Qt6/x86 toolchain if/when master moves to Qt6 (i.e. the `QT6WIP` branch is merged). A comment in the new job documents this.
- The runner is `windows-2022` for consistency with `buildwindows`. `vcvars32.bat` lives at the same Visual Studio 2022 Enterprise path.

## Test plan

Verified end-to-end on bharath063/SavvyCAN:

- [x] All five build jobs succeed: Linux x64, macOS x64, macOS ARM64, Windows x64, **Windows x86 (32-bit) in 6m16s**
- [x] `SavvyCAN-Windows_x86` artifact uploaded with the same package layout as x64 (Qt5 DLLs + `canbus`/`platforms`/`styles`/`imageformats` plugins, help, examples, translations)
- [x] Tactrix Openport 2.0 (or other J2534 device) confirmed to stay connected when running the produced 32-bit binary on Windows 10/11 x64

<img width="1091" height="890" alt="image" src="https://github.com/user-attachments/assets/ce5afea6-c0ad-4179-9166-943764c46ef4" />


Run on the fork: https://github.com/bharath063/SavvyCAN/actions/runs/26153002587