### PR TITLE
Improve main window workflow with ID filtering, resizable splitters, and simple send panel toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ qt_standard_project_setup()
 qt_add_executable(SavvyCAN WIN32 MACOSX_BUNDLE
     bisectwindow.cpp bisectwindow.h
     blfhandler.cpp blfhandler.h
+    croplogdialog.cpp croplogdialog.h
     bus_protocols/isotp_handler.cpp bus_protocols/isotp_handler.h
     bus_protocols/handler_factory.cpp bus_protocols/handler_factory.h
     bus_protocols/isotp_message.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ qt_add_executable(SavvyCAN WIN32 MACOSX_BUNDLE
     re/isotp_interpreterwindow.cpp re/isotp_interpreterwindow.h
     re/newgraphdialog.cpp re/newgraphdialog.h
     re/rangestatewindow.cpp re/rangestatewindow.h
+    re/searchwindow.cpp re/searchwindow.h
     re/sniffer/SnifferDelegate.cpp re/sniffer/SnifferDelegate.h
     re/sniffer/snifferitem.cpp re/sniffer/snifferitem.h
     re/sniffer/sniffermodel.cpp re/sniffer/sniffermodel.h

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -276,7 +276,6 @@ uint64_t CommFrameModel::getCommFrameVal(QVector<CommFrame> *frames, int row, Co
         return static_cast<uint64_t>(frame.getBus());
     case Column::Length:
         return static_cast<uint64_t>(frame.payload().length());
-    case Column::DataDec:
     case Column::ASCII: //sort both the same for now
     case Column::Data:
         for (int i = 0; i < std::min(static_cast<int>(frame.payload().length()), 8); i++)

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -235,6 +235,16 @@ void CommFrameModel::setAllFilters(bool state)
     sendRefresh();
 }
 
+void CommFrameModel::setSearchFilter(const QString &text)
+{
+    // strip leading "0x" or "0X" to keep comparison clean
+    QString stripped = text;
+    if (stripped.startsWith("0x", Qt::CaseInsensitive))
+        stripped = stripped.mid(2);
+    m_searchFilter = stripped;
+    sendRefresh();
+}
+
 /*
  * There is probably a more correct way to have done this but below are several functions that collectively implement
  * quicksort on the columns and interpret the columns numerically. But, correct or not, this implementation is quite fast
@@ -854,6 +864,17 @@ void CommFrameModel::sendRefresh()
             {
                 tempContainer.append(frames[i]);
             }
+        }
+
+        if (!m_searchFilter.isEmpty()) {
+            QVector<CommFrame> searched;
+            searched.reserve(tempContainer.count());
+            for (int i = 0; i < tempContainer.count(); ++i) {
+                QString idStr = QString::number(tempContainer[i].frameId(), 16).toUpper();
+                if (idStr.contains(m_searchFilter, Qt::CaseInsensitive))
+                    searched.append(tempContainer[i]);
+            }
+            tempContainer = searched;
         }
 
         mutex.lock();

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -434,11 +434,6 @@ void CommFrameModel::recalcOverwrite()
         lastSeenData = newSeen;
     }
 
-    // Rebuild per-ID count cache from the overwrite frames (count already stored per frame)
-    m_idCounts.clear();
-    for (const CommFrame &f : filteredFrames)
-        m_idCounts[(int)f.frameId()] = (int)f.getFrameCount();
-
     /*for (int i = 0; i < frames.count(); i++)
     {
         if (filters[frames[i].frameId()] && busFilters[frames[i].bus])

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -76,6 +76,7 @@ CommFrameModel::CommFrameModel(QObject *parent)
     dbcHandler = DBCHandler::getReference();
     interpretFrames = false;
     overwriteDups = false;
+    changingOnly = false;
     filtersPersistDuringClear = false;
     useHexMode = true;
     useColorsByCanId = false;
@@ -396,35 +397,47 @@ void CommFrameModel::recalcOverwrite()
 
         idAugmented = frame.frameId();
         idAugmented = idAugmented + (frame.getBus() << 29ull);
-        if (filters[frame.frameId()] && busFilters[frame.getBus()])
+        if (passesFrameFilters(frame))
         {
-            bool passesSearch = m_searchFilter.isEmpty() ||
-                QString::number(frame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
-            if (passesSearch)
+            if (!overWriteFrames.contains(idAugmented))
             {
-                if (!overWriteFrames.contains(idAugmented))
-                {
-                    frame.setTimeDelta(0);
-                    frame.setFrameCount(1);
-                    overWriteFrames.insert(idAugmented, frame);
-                }
-                else
-                {
-                    frame.setTimeDelta(frame.timeStamp().microSeconds() - overWriteFrames[idAugmented].timeStamp().microSeconds());
-                    frame.setFrameCount(overWriteFrames[idAugmented].getFrameCount() + 1);
-                    overWriteFrames[idAugmented] = frame;
-                }
+                frame.setTimeDelta(0);
+                frame.setFrameCount(1);
+                overWriteFrames.insert(idAugmented, frame);
+            }
+            else
+            {
+                frame.setTimeDelta(frame.timeStamp().microSeconds() - overWriteFrames[idAugmented].timeStamp().microSeconds());
+                frame.setFrameCount(overWriteFrames[idAugmented].getFrameCount() + 1);
+                overWriteFrames[idAugmented] = frame;
             }
         }
     }
     //Then replace the old list of frames with just the unique list
-    //frames.clear();
-    //frames.append(overWriteFrames.values().toVector());
-    //frames.reserve(preallocSize);
 
     filteredFrames.clear();
     filteredFrames.append(overWriteFrames.values());
     filteredFrames.reserve(preallocSize);
+
+    if (changingOnly)
+    {
+        QVector<CommFrame> changingFiltered;
+        QHash<quint64, QByteArray> newSeen;
+        for (const CommFrame &f : filteredFrames)
+        {
+            quint64 ckey = changingKey(f);
+            if (!lastSeenData.contains(ckey) || lastSeenData[ckey] != f.payload())
+                changingFiltered.append(f);
+            newSeen[ckey] = f.payload();
+        }
+        filteredFrames = changingFiltered;
+        lastSeenData = newSeen;
+    }
+
+    // Rebuild per-ID count cache from the overwrite frames (count already stored per frame)
+    m_idCounts.clear();
+    for (const CommFrame &f : filteredFrames)
+        m_idCounts[(int)f.frameId()] = (int)f.getFrameCount();
 
     /*for (int i = 0; i < frames.count(); i++)
     {
@@ -725,6 +738,76 @@ bool CommFrameModel::any_busfilters_are_configured(void)
     return false;
 }
 
+bool CommFrameModel::any_dirfilters_are_configured(void)
+{
+    for (auto const &val : std::as_const(dirFilters))
+        if (val == false) return true;
+    return false;
+}
+
+bool CommFrameModel::any_lengthfilters_are_configured(void)
+{
+    for (auto const &val : std::as_const(lengthFilters))
+        if (val == false) return true;
+    return false;
+}
+
+// Returns true if the frame passes ALL active filters (ID, bus, type, dir, length, search).
+// Uses value(key, true) for type/dir/length so unknown entries default to visible.
+bool CommFrameModel::passesFrameFilters(const CommFrame &frame)
+{
+    if (!filters.value((int)frame.frameId(), false)) return false;
+    if (!busFilters.value((int)frame.getBus(), false)) return false;
+    int dir = frame.isReceived() ? 1 : 0;
+    if (!dirFilters.value(dir, true)) return false;
+    if (!lengthFilters.value(frame.payload().length(), true)) return false;
+    if (!m_searchFilter.isEmpty() &&
+        !QString::number(frame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive))
+        return false;
+    return true;
+}
+
+quint64 CommFrameModel::changingKey(const CommFrame &frame) const
+{
+    quint64 key  = (quint64)(frame.frameId()         & 0x1FFFFFFF);        // bits  0-28: frame ID
+    key         |= (quint64)((int)frame.frameType()  & 0x07)        << 29; // bits 29-31: frame type
+    key         |= (quint64)(frame.isReceived() ? 1 : 0)           << 32; // bit  32:    direction
+    key         |= (quint64)(frame.getBus()          & 0xFF)        << 33; // bits 33-40: bus
+    key         |= (quint64)(frame.payload().length() & 0xFF)       << 41; // bits 41-48: length
+    return key;
+}
+
+void CommFrameModel::setDirFilterState(int dir, bool state)
+{
+    if (!dirFilters.contains(dir)) return;
+    dirFilters[dir] = state;
+    sendRefresh();
+}
+
+void CommFrameModel::setLengthFilterState(int length, bool state)
+{
+    if (!lengthFilters.contains(length)) return;
+    lengthFilters[length] = state;
+    sendRefresh();
+}
+
+void CommFrameModel::setChangingOnly(bool state)
+{
+    changingOnly = state;
+    lastSeenData.clear();
+    sendRefresh();
+}
+
+const QMap<int, bool> *CommFrameModel::getDirFiltersReference() const
+{
+    return &dirFilters;
+}
+
+const QMap<int, bool> *CommFrameModel::getLengthFiltersReference() const
+{
+    return &lengthFilters;
+}
+
 
 void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
 {
@@ -759,17 +842,44 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
         needFilterRefresh = true;
     }
 
+    // Register direction in dirFilters
+    {
+        int dir = tempFrame.isReceived() ? 1 : 0;
+        if (!dirFilters.contains(dir))
+        {
+            dirFilters.insert(dir, any_dirfilters_are_configured() ? false : true);
+            needFilterRefresh = true;
+        }
+    }
+
+    // Register payload length in lengthFilters
+    {
+        int len = tempFrame.payload().length();
+        if (!lengthFilters.contains(len))
+        {
+            lengthFilters.insert(len, any_lengthfilters_are_configured() ? false : true);
+            needFilterRefresh = true;
+        }
+    }
+
     if (!overwriteDups)
     {
         try
         {
             frames.append(tempFrame);
 
-            if (filters[tempFrame.frameId()] && busFilters[tempFrame.getBus()])
+            if (passesFrameFilters(tempFrame))
             {
-                bool passesSearch = m_searchFilter.isEmpty() ||
-                    QString::number(tempFrame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
-                if (passesSearch)
+                bool show = true;
+                if (changingOnly)
+                {
+                    quint64 ckey = changingKey(tempFrame);
+                    if (lastSeenData.contains(ckey) && lastSeenData[ckey] == tempFrame.payload())
+                        show = false;
+                    else
+                        lastSeenData[ckey] = tempFrame.payload();
+                }
+                if (show)
                 {
                     if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
                     tempFrame.setFrameCount(1);
@@ -786,6 +896,7 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
     else //yes, overwrite dups
     {
         bool found = false;
+        bool dataChanged = true;
 //        for (int i = 0; i < frames.count(); i++)
 //        {
 //            if ( (frames[i].frameId() == tempFrame.frameId()) && (frames[i].bus == tempFrame.bus) )
@@ -803,7 +914,16 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
             {
                 tempFrame.setFrameCount(filteredFrames[i].getFrameCount() + 1);
                 tempFrame.setTimeDelta(tempFrame.timeStamp().microSeconds() - filteredFrames[i].timeStamp().microSeconds());
-                filteredFrames.replace(i, tempFrame);
+                if (changingOnly)
+                {
+                    quint64 ckey = changingKey(tempFrame);
+                    if (lastSeenData.contains(ckey) && lastSeenData[ckey] == tempFrame.payload())
+                        dataChanged = false;
+                    else
+                        lastSeenData[ckey] = tempFrame.payload();
+                }
+                if (dataChanged)
+                    filteredFrames.replace(i, tempFrame);
                 found = true;
                 break;
             }
@@ -812,21 +932,18 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
         if (!found)
         {
             //frames.append(tempFrame);
-            if (filters[tempFrame.frameId()] && busFilters[tempFrame.getBus()])
+            if (passesFrameFilters(tempFrame))
             {
-                bool passesSearch = m_searchFilter.isEmpty() ||
-                    QString::number(tempFrame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
-                if (passesSearch)
-                {
-                    if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
-                    tempFrame.setFrameCount(1);
-                    tempFrame.setTimeDelta(0);
-                    filteredFrames.append(tempFrame);
-                    if (autoRefresh) endInsertRows();
-                }
+                if (changingOnly)
+                    lastSeenData[changingKey(tempFrame)] = tempFrame.payload();
+                if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
+                tempFrame.setFrameCount(1);
+                tempFrame.setTimeDelta(0);
+                filteredFrames.append(tempFrame);
+                if (autoRefresh) endInsertRows();
             }
         }
-        else
+        else if (dataChanged)
         {
             for (int j = 0; j < filteredFrames.count(); j++)
             {
@@ -889,21 +1006,27 @@ void CommFrameModel::sendRefresh()
         int count = frames.count();
         for (int i = 0; i < count; i++)
         {
-            if (filters[frames[i].frameId()] && busFilters[frames[i].getBus()])
+            if (passesFrameFilters(frames[i]))
             {
                 tempContainer.append(frames[i]);
             }
         }
 
-        if (!m_searchFilter.isEmpty()) {
-            QVector<CommFrame> searched;
-            searched.reserve(tempContainer.count());
-            for (int i = 0; i < tempContainer.count(); ++i) {
-                QString idStr = QString::number(tempContainer[i].frameId(), 16).toUpper();
-                if (idStr.contains(m_searchFilter, Qt::CaseInsensitive))
-                    searched.append(tempContainer[i]);
+        if (changingOnly)
+        {
+            QVector<CommFrame> changingFiltered;
+            QHash<quint64, QByteArray> newSeen;
+            for (const CommFrame &f : tempContainer)
+            {
+                quint64 ckey = changingKey(f);
+                if (!newSeen.contains(ckey) || newSeen[ckey] != f.payload())
+                {
+                    newSeen[ckey] = f.payload();
+                    changingFiltered.append(f);
+                }
             }
-            tempContainer = searched;
+            tempContainer = changingFiltered;
+            lastSeenData = newSeen;
         }
 
         mutex.lock();
@@ -955,7 +1078,10 @@ void CommFrameModel::clearFrames()
     {
         filters.clear();
         busFilters.clear();
+        dirFilters.clear();
+        lengthFilters.clear();
     }
+    lastSeenData.clear();
     frames.reserve(preallocSize);
     filteredFrames.reserve(preallocSize);
     this->endResetModel();
@@ -991,7 +1117,13 @@ void CommFrameModel::insertFrames(const QVector<CommFrame> &newFrames)
             busFilters.insert(newFrames[i].getBus(), true);
             needFilterRefresh = true;
         }
-        if (filters[newFrames[i].frameId()] && busFilters[newFrames[i].getBus()])
+        {
+            int dir = newFrames[i].isReceived() ? 1 : 0;
+            if (!dirFilters.contains(dir)) { dirFilters.insert(dir, true); needFilterRefresh = true; }
+            int len = newFrames[i].payload().length();
+            if (!lengthFilters.contains(len)) { lengthFilters.insert(len, true); needFilterRefresh = true; }
+        }
+        if (passesFrameFilters(newFrames[i]))
         {
             // insertedFiltered++;
             filteredFrames.append(newFrames[i]);
@@ -1031,15 +1163,28 @@ void CommFrameModel::loadFilterFile(QString filename)
 
     filters.clear();
     busFilters.clear();
+    dirFilters.clear();
+    lengthFilters.clear();
 
     while (!inFile->atEnd()) {
         line = inFile->readLine().simplified();
         if (line.length() > 2)
         {
             QList<QByteArray> tokens = line.split(',');
-            ID = tokens[0].toInt(nullptr, 16);
-            if (tokens[1].toUpper() == "T") filters.insert(ID, true);
-                else filters.insert(ID, false);
+            QByteArray prefix = tokens[0].toUpper();
+            if (prefix == "BUS" && tokens.size() >= 3) {
+                busFilters.insert(tokens[1].toInt(), tokens[2].toUpper() == "T");
+            } else if (prefix == "DIR" && tokens.size() >= 3) {
+                dirFilters.insert(tokens[1].toInt(), tokens[2].toUpper() == "T");
+            } else if (prefix == "LEN" && tokens.size() >= 3) {
+                lengthFilters.insert(tokens[1].toInt(), tokens[2].toUpper() == "T");
+            } else if (prefix == "CHANGINGONLY") {
+                // handled via QSettings now; skip
+            } else {
+                ID = tokens[0].toInt(nullptr, 16);
+                if (tokens[1].toUpper() == "T") filters.insert(ID, true);
+                    else filters.insert(ID, false);
+            }
         }
     }
     inFile->close();
@@ -1065,7 +1210,18 @@ void CommFrameModel::saveFilterFile(QString filename)
             else outFile->putChar('F');
         outFile->write("\n");
     }
+    for (it = busFilters.cbegin(); it != busFilters.cend(); ++it)
+        outFile->write(QString("BUS,%1,%2\n").arg(it.key()).arg(it.value() ? "T" : "F").toUtf8());
+    for (it = dirFilters.cbegin(); it != dirFilters.cend(); ++it)
+        outFile->write(QString("DIR,%1,%2\n").arg(it.key()).arg(it.value() ? "T" : "F").toUtf8());
+    for (it = lengthFilters.cbegin(); it != lengthFilters.cend(); ++it)
+        outFile->write(QString("LEN,%1,%2\n").arg(it.key()).arg(it.value() ? "T" : "F").toUtf8());
     outFile->close();
+}
+
+bool CommFrameModel::getChangingOnly() const
+{
+    return changingOnly;
 }
 
 bool CommFrameModel::needsFilterRefresh()

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -218,6 +218,20 @@ void CommFrameModel::setFilterState(unsigned int ID, bool state)
     sendRefresh();
 }
 
+void CommFrameModel::setFilterStatesBatch(const QList<QPair<int,bool>> &updates)
+{
+    bool anyChanged = false;
+    for (const auto &pair : updates)
+    {
+        if (filters.contains(pair.first))
+        {
+            filters[pair.first] = pair.second;
+            anyChanged = true;
+        }
+    }
+    if (anyChanged) sendRefresh();
+}
+
 void CommFrameModel::setBusFilterState(unsigned int BusID, bool state)
 {
     if (!busFilters.contains(BusID)) return;

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -276,6 +276,7 @@ uint64_t CommFrameModel::getCommFrameVal(QVector<CommFrame> *frames, int row, Co
         return static_cast<uint64_t>(frame.getBus());
     case Column::Length:
         return static_cast<uint64_t>(frame.payload().length());
+    case Column::DataDec:
     case Column::ASCII: //sort both the same for now
     case Column::Data:
         for (int i = 0; i < std::min(static_cast<int>(frame.payload().length()), 8); i++)

--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -384,17 +384,22 @@ void CommFrameModel::recalcOverwrite()
         idAugmented = idAugmented + (frame.getBus() << 29ull);
         if (filters[frame.frameId()] && busFilters[frame.getBus()])
         {
-            if (!overWriteFrames.contains(idAugmented))
+            bool passesSearch = m_searchFilter.isEmpty() ||
+                QString::number(frame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
+            if (passesSearch)
             {
-                frame.setTimeDelta(0);
-                frame.setFrameCount(1);
-                overWriteFrames.insert(idAugmented, frame);
-            }
-            else
-            {
-                frame.setTimeDelta(frame.timeStamp().microSeconds() - overWriteFrames[idAugmented].timeStamp().microSeconds());
-                frame.setFrameCount(overWriteFrames[idAugmented].getFrameCount() + 1);
-                overWriteFrames[idAugmented] = frame;
+                if (!overWriteFrames.contains(idAugmented))
+                {
+                    frame.setTimeDelta(0);
+                    frame.setFrameCount(1);
+                    overWriteFrames.insert(idAugmented, frame);
+                }
+                else
+                {
+                    frame.setTimeDelta(frame.timeStamp().microSeconds() - overWriteFrames[idAugmented].timeStamp().microSeconds());
+                    frame.setFrameCount(overWriteFrames[idAugmented].getFrameCount() + 1);
+                    overWriteFrames[idAugmented] = frame;
+                }
             }
         }
     }
@@ -748,10 +753,15 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
 
             if (filters[tempFrame.frameId()] && busFilters[tempFrame.getBus()])
             {
-                if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
-                tempFrame.setFrameCount(1);
-                filteredFrames.append(tempFrame);
-                if (autoRefresh) endInsertRows();
+                bool passesSearch = m_searchFilter.isEmpty() ||
+                    QString::number(tempFrame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
+                if (passesSearch)
+                {
+                    if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
+                    tempFrame.setFrameCount(1);
+                    filteredFrames.append(tempFrame);
+                    if (autoRefresh) endInsertRows();
+                }
             }
         }
         catch (const std::exception& ex)
@@ -790,11 +800,16 @@ void CommFrameModel::addFrame(const CommFrame& frame, bool autoRefresh = false)
             //frames.append(tempFrame);
             if (filters[tempFrame.frameId()] && busFilters[tempFrame.getBus()])
             {
-                if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
-                tempFrame.setFrameCount(1);
-                tempFrame.setTimeDelta(0);
-                filteredFrames.append(tempFrame);
-                if (autoRefresh) endInsertRows();
+                bool passesSearch = m_searchFilter.isEmpty() ||
+                    QString::number(tempFrame.frameId(), 16).contains(m_searchFilter, Qt::CaseInsensitive);
+                if (passesSearch)
+                {
+                    if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
+                    tempFrame.setFrameCount(1);
+                    tempFrame.setTimeDelta(0);
+                    filteredFrames.append(tempFrame);
+                    if (autoRefresh) endInsertRows();
+                }
             }
         }
         else

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -54,7 +54,11 @@ public:
     void setFilterState(unsigned int ID, bool state);
     void setFilterStatesBatch(const QList<QPair<int,bool>> &updates);
     void setBusFilterState(unsigned int BusID, bool state);
+    void setDirFilterState(int dir, bool state);
+    void setLengthFilterState(int length, bool state);
     void setAllFilters(bool state);
+    void setChangingOnly(bool state);
+    bool getChangingOnly() const;
     void setTimeFormat(QString);
     void setBytesPerLine(int bpl);
     void loadFilterFile(QString filename);
@@ -70,6 +74,8 @@ public:
     const QVector<CommFrame> *getFilteredListReference() const; //Thus saith the Lord, NO.
     const QMap<int, bool> *getFiltersReference() const; //this neither
     const QMap<int, bool> *getBusFiltersReference() const; //this neither
+    const QMap<int, bool> *getDirFiltersReference() const;
+    const QMap<int, bool> *getLengthFiltersReference() const;
 
 public slots:
     void addFrame(const CommFrame&, bool);
@@ -82,13 +88,19 @@ private:
     void qSortCommFrameAsc(QVector<CommFrame>* frames, Column column, int lowerBound, int upperBound);
     void qSortCommFrameDesc(QVector<CommFrame>* frames, Column column, int lowerBound, int upperBound);
     uint64_t getCommFrameVal(QVector<CommFrame> *frames, int row, Column col);
+    bool passesFrameFilters(const CommFrame &frame);
+    quint64 changingKey(const CommFrame &frame) const;
     bool any_filters_are_configured(void);
     bool any_busfilters_are_configured(void);
+    bool any_dirfilters_are_configured(void);
+    bool any_lengthfilters_are_configured(void);
 
     QVector<CommFrame> frames;
     QVector<CommFrame> filteredFrames;
     QMap<int, bool> filters;
     QMap<int, bool> busFilters;
+    QMap<int, bool> dirFilters;
+    QMap<int, bool> lengthFilters;
     DBCHandler *dbcHandler;
     QMutex mutex;
     bool interpretFrames; //should we use the dbcHandler?
@@ -98,6 +110,9 @@ private:
     TimeStyle timeStyle;
     bool useHexMode;
     bool useColorsByCanId;
+    bool useHexAndDecMode;
+    bool changingOnly;
+    QHash<quint64, QByteArray> lastSeenData;
     bool needFilterRefresh;
     bool ignoreDBCColors;
     int64_t timeOffset;

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -52,6 +52,7 @@ public:
     void setTimeStyle(TimeStyle newStyle);
     void setIgnoreDBCColors(bool mode);
     void setFilterState(unsigned int ID, bool state);
+    void setFilterStatesBatch(const QList<QPair<int,bool>> &updates);
     void setBusFilterState(unsigned int BusID, bool state);
     void setAllFilters(bool state);
     void setTimeFormat(QString);

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -58,6 +58,7 @@ public:
     void setBytesPerLine(int bpl);
     void loadFilterFile(QString filename);
     void saveFilterFile(QString filename);
+    void setSearchFilter(const QString &text);
     void normalizeTiming();
     void recalcOverwrite();
     bool needsFilterRefresh();
@@ -103,6 +104,7 @@ private:
     uint32_t preallocSize;
     bool sortDirAsc;
     int bytesPerLine;
+    QString m_searchFilter;
 };
 
 

--- a/croplogdialog.cpp
+++ b/croplogdialog.cpp
@@ -1,0 +1,411 @@
+#include "croplogdialog.h"
+
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QPainter>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QStyle>
+#include <algorithm>
+#include <cmath>
+
+// =============================================================================
+// RangeSlider
+// =============================================================================
+
+RangeSlider::RangeSlider(QWidget *parent)
+    : QWidget(parent)
+{
+    setMouseTracking(true);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+}
+
+void RangeSlider::setRange(int min, int max)
+{
+    m_min = min;
+    m_max = (max > min) ? max : min + 1;
+    m_low  = std::clamp(m_low,  m_min, m_max);
+    m_high = std::clamp(m_high, m_min, m_max);
+    update();
+}
+
+void RangeSlider::setLow(int val)
+{
+    val = std::clamp(val, m_min, m_high);
+    if (val == m_low) return;
+    m_low = val;
+    update();
+}
+
+void RangeSlider::setHigh(int val)
+{
+    val = std::clamp(val, m_low, m_max);
+    if (val == m_high) return;
+    m_high = val;
+    update();
+}
+
+int RangeSlider::posFromValue(int val) const
+{
+    if (m_max == m_min) return kPad;
+    return kPad + (val - m_min) * (width() - 2 * kPad) / (m_max - m_min);
+}
+
+int RangeSlider::valueFromPos(int pos) const
+{
+    if (m_max == m_min) return m_min;
+    int raw = m_min + (pos - kPad) * (m_max - m_min) / (width() - 2 * kPad);
+    return std::clamp(raw, m_min, m_max);
+}
+
+QRect RangeSlider::handleRect(int val) const
+{
+    int cx = posFromValue(val);
+    int cy = height() / 2;
+    return QRect(cx - kHandle, cy - kHandle, kHandle * 2, kHandle * 2);
+}
+
+void RangeSlider::paintEvent(QPaintEvent *)
+{
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    int cy   = height() / 2;
+    int xLow = posFromValue(m_low);
+    int xHigh= posFromValue(m_high);
+
+    // Track background
+    QRect track(kPad, cy - 3, width() - 2 * kPad, 6);
+    p.setPen(Qt::NoPen);
+    p.setBrush(palette().mid());
+    p.drawRoundedRect(track, 3, 3);
+
+    // Active range
+    QRect active(xLow, cy - 3, xHigh - xLow, 6);
+    p.setBrush(palette().highlight());
+    p.drawRoundedRect(active, 3, 3);
+
+    // Low handle
+    p.setBrush(palette().button());
+    p.setPen(QPen(palette().highlight().color(), 2));
+    p.drawEllipse(QPoint(xLow, cy), kHandle - 2, kHandle - 2);
+
+    // High handle
+    p.drawEllipse(QPoint(xHigh, cy), kHandle - 2, kHandle - 2);
+}
+
+void RangeSlider::mousePressEvent(QMouseEvent *e)
+{
+    if (e->button() != Qt::LeftButton) return;
+    int pos = e->pos().x();
+
+    // Pick nearest handle
+    int dLow  = std::abs(pos - posFromValue(m_low));
+    int dHigh = std::abs(pos - posFromValue(m_high));
+    m_drag = (dLow <= dHigh) ? Low : High;
+}
+
+void RangeSlider::mouseMoveEvent(QMouseEvent *e)
+{
+    if (m_drag == None) return;
+    int val = valueFromPos(e->pos().x());
+
+    if (m_drag == Low)
+    {
+        val = std::min(val, m_high);
+        if (val != m_low)
+        {
+            m_low = val;
+            update();
+            emit lowChanged(m_low);
+        }
+    }
+    else
+    {
+        val = std::max(val, m_low);
+        if (val != m_high)
+        {
+            m_high = val;
+            update();
+            emit highChanged(m_high);
+        }
+    }
+}
+
+void RangeSlider::mouseReleaseEvent(QMouseEvent *)
+{
+    m_drag = None;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+static QString formatDuration(double secs)
+{
+    if (secs < 1.0)
+        return QString::number(secs * 1000.0, 'f', 1) + " ms";
+    if (secs < 60.0)
+        return QString::number(secs, 'f', 3) + " s";
+    int m = static_cast<int>(secs) / 60;
+    double s = secs - m * 60.0;
+    return QString("%1 m %2 s").arg(m).arg(s, 0, 'f', 1);
+}
+
+// =============================================================================
+// CropLogDialog
+// =============================================================================
+
+CropLogDialog::CropLogDialog(const QVector<CommFrame> *frames, QWidget *parent)
+    : QDialog(parent), m_frames(frames)
+{
+    setWindowTitle(tr("Crop Log"));
+    setMinimumWidth(480);
+
+    m_totalFrames = frames->count();
+    m_endIdx      = m_totalFrames - 1;
+
+    // Compute time span (seconds from first frame)
+    auto totalMicros = [&]() -> qint64 {
+        if (m_totalFrames < 2) return 0;
+        const auto &first = frames->first().timeStamp();
+        const auto &last  = frames->last().timeStamp();
+        qint64 t0 = first.seconds() * 1000000LL + first.microSeconds();
+        qint64 t1 = last.seconds()  * 1000000LL + last.microSeconds();
+        return t1 - t0;
+    };
+
+    qint64 spanUs   = totalMicros();
+    m_totalSecs     = spanUs / 1e6;
+    m_startTimeSec  = (m_totalFrames > 0)
+        ? (frames->first().timeStamp().seconds() + frames->first().timeStamp().microSeconds() / 1e6)
+        : 0.0;
+
+    // ---- Build UI -------------------------------------------------------
+    auto *vbox = new QVBoxLayout(this);
+
+    // Stats row – original
+    m_lblOrigStats = new QLabel(this);
+    m_lblOrigStats->setText(
+        tr("<b>Original:</b> %1 frames &nbsp;|&nbsp; %2")
+            .arg(m_totalFrames)
+            .arg(formatDuration(m_totalSecs)));
+    vbox->addWidget(m_lblOrigStats);
+
+    // Range slider
+    m_slider = new RangeSlider(this);
+    m_slider->setRange(0, std::max(0, m_totalFrames - 1));
+    m_slider->setLow(0);
+    m_slider->setHigh(std::max(0, m_totalFrames - 1));
+    vbox->addWidget(m_slider);
+
+    // Grid: columns = Start | End
+    //       rows    = Frame | Time
+    auto *grid = new QGridLayout;
+    grid->setColumnStretch(1, 1);
+    grid->setColumnStretch(3, 1);
+    grid->setHorizontalSpacing(16);
+
+    // Header labels
+    grid->addWidget(new QLabel(tr("<b>Start</b>"), this), 0, 1, Qt::AlignHCenter);
+    grid->addWidget(new QLabel(tr("<b>End</b>"),   this), 0, 3, Qt::AlignHCenter);
+
+    // Frame row
+    grid->addWidget(new QLabel(tr("Frame:"), this), 1, 0);
+    m_spinStartFrame = new QSpinBox(this);
+    m_spinStartFrame->setMinimum(1);
+    m_spinStartFrame->setMaximum(m_totalFrames);
+    m_spinStartFrame->setValue(1);
+    grid->addWidget(m_spinStartFrame, 1, 1);
+
+    grid->addWidget(new QLabel(tr("Frame:"), this), 1, 2);
+    m_spinEndFrame = new QSpinBox(this);
+    m_spinEndFrame->setMinimum(1);
+    m_spinEndFrame->setMaximum(m_totalFrames);
+    m_spinEndFrame->setValue(m_totalFrames);
+    grid->addWidget(m_spinEndFrame, 1, 3);
+
+    // Time row
+    grid->addWidget(new QLabel(tr("Time (s):"), this), 2, 0);
+    m_spinStartTime = new QDoubleSpinBox(this);
+    m_spinStartTime->setDecimals(4);
+    m_spinStartTime->setMinimum(0.0);
+    m_spinStartTime->setMaximum(m_totalSecs);
+    m_spinStartTime->setSingleStep(0.001);
+    m_spinStartTime->setValue(0.0);
+    grid->addWidget(m_spinStartTime, 2, 1);
+
+    grid->addWidget(new QLabel(tr("Time (s):"), this), 2, 2);
+    m_spinEndTime = new QDoubleSpinBox(this);
+    m_spinEndTime->setDecimals(4);
+    m_spinEndTime->setMinimum(0.0);
+    m_spinEndTime->setMaximum(m_totalSecs);
+    m_spinEndTime->setSingleStep(0.001);
+    m_spinEndTime->setValue(m_totalSecs);
+    grid->addWidget(m_spinEndTime, 2, 3);
+
+    vbox->addLayout(grid);
+
+    // Preview stats
+    m_lblPreviewStats = new QLabel(this);
+    vbox->addWidget(m_lblPreviewStats);
+    updatePreview();
+
+    // Buttons
+    auto *buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    buttons->button(QDialogButtonBox::Ok)->setText(tr("Crop"));
+    vbox->addWidget(buttons);
+
+    // ---- Connections ----------------------------------------------------
+    connect(m_slider,        &RangeSlider::lowChanged,            this, &CropLogDialog::onSliderLowChanged);
+    connect(m_slider,        &RangeSlider::highChanged,           this, &CropLogDialog::onSliderHighChanged);
+    connect(m_spinStartFrame, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &CropLogDialog::onStartFrameChanged);
+    connect(m_spinEndFrame,   QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &CropLogDialog::onEndFrameChanged);
+    connect(m_spinStartTime,  QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, &CropLogDialog::onStartTimeChanged);
+    connect(m_spinEndTime,    QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, &CropLogDialog::onEndTimeChanged);
+
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+double CropLogDialog::timeFromFrameIndex(int idx) const
+{
+    if (idx < 0 || idx >= m_totalFrames) return 0.0;
+    const auto &ts = m_frames->at(idx).timeStamp();
+    double abs = ts.seconds() + ts.microSeconds() / 1e6;
+    return abs - m_startTimeSec;
+}
+
+int CropLogDialog::frameIndexFromTime(double secs) const
+{
+    // Binary search for the frame whose relative time is closest to secs
+    if (m_totalFrames == 0) return 0;
+    double target = m_startTimeSec + secs;
+
+    int lo = 0, hi = m_totalFrames - 1;
+    while (lo < hi)
+    {
+        int mid = (lo + hi) / 2;
+        const auto &ts = m_frames->at(mid).timeStamp();
+        double t = ts.seconds() + ts.microSeconds() / 1e6;
+        if (t < target)
+            lo = mid + 1;
+        else
+            hi = mid;
+    }
+    return lo;
+}
+
+void CropLogDialog::blockAll(bool block)
+{
+    m_slider->blockSignals(block);
+    m_spinStartFrame->blockSignals(block);
+    m_spinEndFrame->blockSignals(block);
+    m_spinStartTime->blockSignals(block);
+    m_spinEndTime->blockSignals(block);
+}
+
+void CropLogDialog::updatePreview()
+{
+    int count    = m_endIdx - m_startIdx + 1;
+    double dur   = timeFromFrameIndex(m_endIdx) - timeFromFrameIndex(m_startIdx);
+
+    m_lblPreviewStats->setText(
+        tr("<b>Cropped result:</b> %1 frames &nbsp;|&nbsp; %2")
+            .arg(count)
+            .arg(formatDuration(std::max(0.0, dur))));
+}
+
+// ---------------------------------------------------------------------------
+// Slots
+// ---------------------------------------------------------------------------
+
+void CropLogDialog::onSliderLowChanged(int val)
+{
+    m_startIdx = val;
+    blockAll(true);
+    m_spinStartFrame->setValue(val + 1);
+    m_spinStartTime->setValue(timeFromFrameIndex(val));
+    blockAll(false);
+    updatePreview();
+}
+
+void CropLogDialog::onSliderHighChanged(int val)
+{
+    m_endIdx = val;
+    blockAll(true);
+    m_spinEndFrame->setValue(val + 1);
+    m_spinEndTime->setValue(timeFromFrameIndex(val));
+    blockAll(false);
+    updatePreview();
+}
+
+void CropLogDialog::onStartFrameChanged(int val)
+{
+    int idx = val - 1; // 0-based
+    if (idx > m_endIdx)
+    {
+        m_spinStartFrame->setValue(m_endIdx + 1);
+        return;
+    }
+    m_startIdx = idx;
+    blockAll(true);
+    m_slider->setLow(idx);
+    m_spinStartTime->setValue(timeFromFrameIndex(idx));
+    blockAll(false);
+    updatePreview();
+}
+
+void CropLogDialog::onEndFrameChanged(int val)
+{
+    int idx = val - 1;
+    if (idx < m_startIdx)
+    {
+        m_spinEndFrame->setValue(m_startIdx + 1);
+        return;
+    }
+    m_endIdx = idx;
+    blockAll(true);
+    m_slider->setHigh(idx);
+    m_spinEndTime->setValue(timeFromFrameIndex(idx));
+    blockAll(false);
+    updatePreview();
+}
+
+void CropLogDialog::onStartTimeChanged(double secs)
+{
+    int idx = frameIndexFromTime(secs);
+    if (idx > m_endIdx) idx = m_endIdx;
+    m_startIdx = idx;
+    blockAll(true);
+    m_slider->setLow(idx);
+    m_spinStartFrame->setValue(idx + 1);
+    // Snap displayed time to actual frame time
+    m_spinStartTime->setValue(timeFromFrameIndex(idx));
+    blockAll(false);
+    updatePreview();
+}
+
+void CropLogDialog::onEndTimeChanged(double secs)
+{
+    int idx = frameIndexFromTime(secs);
+    if (idx < m_startIdx) idx = m_startIdx;
+    m_endIdx = idx;
+    blockAll(true);
+    m_slider->setHigh(idx);
+    m_spinEndFrame->setValue(idx + 1);
+    m_spinEndTime->setValue(timeFromFrameIndex(idx));
+    blockAll(false);
+    updatePreview();
+}

--- a/croplogdialog.h
+++ b/croplogdialog.h
@@ -1,0 +1,101 @@
+#ifndef CROPLOGDIALOG_H
+#define CROPLOGDIALOG_H
+
+#include <QDialog>
+#include <QWidget>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QLabel>
+#include <QDialogButtonBox>
+#include <QPainter>
+#include <QMouseEvent>
+#include "can_structs.h"
+
+// ---------------------------------------------------------------------------
+// RangeSlider – a simple two-handle horizontal range slider
+// ---------------------------------------------------------------------------
+class RangeSlider : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit RangeSlider(QWidget *parent = nullptr);
+
+    void setRange(int min, int max);
+    void setLow(int val);
+    void setHigh(int val);
+    int  low()  const { return m_low;  }
+    int  high() const { return m_high; }
+
+    QSize sizeHint() const override { return QSize(300, 30); }
+    QSize minimumSizeHint() const override { return QSize(100, 30); }
+
+signals:
+    void lowChanged(int val);
+    void highChanged(int val);
+
+protected:
+    void paintEvent(QPaintEvent *) override;
+    void mousePressEvent(QMouseEvent *) override;
+    void mouseMoveEvent(QMouseEvent *) override;
+    void mouseReleaseEvent(QMouseEvent *) override;
+
+private:
+    int  m_min = 0, m_max = 100;
+    int  m_low = 0, m_high = 100;
+
+    enum DragHandle { None, Low, High } m_drag = None;
+
+    static const int kHandle = 12; // handle radius
+    static const int kPad    = 14; // horizontal padding for handles
+
+    int    posFromValue(int val) const;
+    int    valueFromPos(int pos) const;
+    QRect  handleRect(int val) const;
+};
+
+// ---------------------------------------------------------------------------
+// CropLogDialog
+// ---------------------------------------------------------------------------
+class CropLogDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CropLogDialog(const QVector<CommFrame> *frames, QWidget *parent = nullptr);
+
+    int startIndex() const { return m_startIdx; }
+    int endIndex()   const { return m_endIdx;   }
+
+private slots:
+    void onSliderLowChanged(int val);
+    void onSliderHighChanged(int val);
+    void onStartFrameChanged(int val);
+    void onEndFrameChanged(int val);
+    void onStartTimeChanged(double secs);
+    void onEndTimeChanged(double secs);
+    void updatePreview();
+
+private:
+    void blockAll(bool block);
+    int    frameIndexFromTime(double secs) const; // returns 0-based index of nearest frame
+    double timeFromFrameIndex(int idx) const;     // seconds from log start
+
+    const QVector<CommFrame> *m_frames;
+    int    m_totalFrames  = 0;
+    double m_totalSecs    = 0.0;
+    double m_startTimeSec = 0.0; // absolute time of first frame
+
+    int    m_startIdx = 0;
+    int    m_endIdx   = 0;
+
+    RangeSlider    *m_slider         = nullptr;
+    QSpinBox       *m_spinStartFrame = nullptr;
+    QSpinBox       *m_spinEndFrame   = nullptr;
+    QDoubleSpinBox *m_spinStartTime  = nullptr;
+    QDoubleSpinBox *m_spinEndTime    = nullptr;
+    QLabel         *m_lblOrigStats   = nullptr;
+    QLabel         *m_lblPreviewStats = nullptr;
+};
+
+#endif // CROPLOGDIALOG_H

--- a/mainsettingsdialog.cpp
+++ b/mainsettingsdialog.cpp
@@ -93,6 +93,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     ui->cbFilterLabeling->setChecked(settings.value("Main/FilterLabeling", true).toBool());
     ui->cbIgnoreDBCColors->setChecked(settings.value("Main/IgnoreDBCColors", false).toBool());
     ui->cbColorsByCanId->setChecked(settings.value("Main/ColorsByCanId", false).toBool());
+    ui->cbShowSendPanel->setChecked(settings.value("Main/ShowSendPanel", true).toBool());
 
     ui->cbEqualSniffer->setChecked(settings.value("Main/EqualDataSniff", false).toBool());
 
@@ -143,6 +144,7 @@ MainSettingsDialog::MainSettingsDialog(QWidget *parent) :
     connect(ui->spinMaximumFrames, SIGNAL(valueChanged(int)), this, SLOT(updateSettings()));
     connect(ui->cbFontFixedWidth, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
     connect(ui->spinBytesPerLine, SIGNAL(valueChanged(int)), this, SLOT(updateSettings()));
+    connect(ui->cbShowSendPanel, SIGNAL(toggled(bool)), this, SLOT(updateSettings()));
 
     installEventFilter(this);
 }
@@ -215,6 +217,7 @@ void MainSettingsDialog::updateSettings()
     settings.setValue("Main/BytesPerLine", ui->spinBytesPerLine->value());
     settings.setValue("Main/FontFixedWidth", ui->cbFontFixedWidth->isChecked());
     settings.setValue("Main/ColorsByCanId", ui->cbColorsByCanId->isChecked());
+    settings.setValue("Main/ShowSendPanel", ui->cbShowSendPanel->isChecked());
 
     settings.sync();
     emit updatedSettings();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -101,6 +101,7 @@ MainWindow::MainWindow(QWidget *parent) :
     temporalGraphWindow = nullptr;
     dbcComparatorWindow = nullptr;
     canBridgeWindow = nullptr;
+    searchWindow = nullptr;
     dbcHandler = DBCHandler::getReference();
     bDirty = false;
     inhibitFilterUpdate = false;
@@ -144,6 +145,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionSave_Continuous_Logfile, &QAction::triggered, this, &MainWindow::handleContinousLogging);
     connect(ui->actionTemporal_Graph, &QAction::triggered, this, &MainWindow::showTemporalGraphWindow);
     connect(ui->actionCAN_Bridge, &QAction::triggered, this, &MainWindow::showCANBridgeWindow);
+    connect(ui->actionFrame_Search, &QAction::triggered, this, &MainWindow::showSearchWindow);
 
     //handlers fror interactions with the main can frame view table
     connect(ui->canFramesView, &QAbstractItemView::clicked, this, &MainWindow::gridClicked);
@@ -1928,6 +1930,36 @@ void MainWindow::showCANBridgeWindow()
     canBridgeWindow->show();
 }
 
+void MainWindow::showSearchWindow()
+{
+    if (!searchWindow)
+    {
+        searchWindow = new SearchWindow(model->getListReference(), dbcHandler);
+        connect(searchWindow, &SearchWindow::jumpToFrameIndex, this, &MainWindow::jumpToSearchFrame);
+        connect(this, &MainWindow::framesUpdated, searchWindow, &SearchWindow::updatedFrames);
+    }
+    searchWindow->show();
+    searchWindow->raise();
+}
+
+void MainWindow::jumpToSearchFrame(int frameIndex)
+{
+    if (!model || frameIndex < 0 || frameIndex >= model->getListReference()->size())
+        return;
+
+    // The main table uses a proxy model; find the corresponding proxy row
+    QAbstractProxyModel *proxy = qobject_cast<QAbstractProxyModel *>(ui->canFramesView->model());
+    if (proxy)
+    {
+        QModelIndex srcIndex = model->index(frameIndex, 0);
+        QModelIndex proxyIndex = proxy->mapFromSource(srcIndex);
+        if (proxyIndex.isValid())
+        {
+            ui->canFramesView->scrollTo(proxyIndex, QAbstractItemView::PositionAtCenter);
+            ui->canFramesView->setCurrentIndex(proxyIndex);
+        }
+    }
+}
 
 void MainWindow::showFrameSenderWindow()
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -200,6 +200,9 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // Prevent annoying accidental horizontal scrolling when filter list is populated with long interpreted message names
     ui->listFilters->horizontalScrollBar()->setEnabled(false);
+    // Allow drag-select and Shift/Ctrl+click multi-selection in the ID filter list
+    ui->listFilters->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    ui->listFilters->installEventFilter(this);
 
     // Restore or default splitterLeft after the window has real geometry.
     // QTimer::singleShot(0) defers to first event loop tick.
@@ -380,6 +383,41 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
 bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
+    // Space key on the ID filter list: toggle checkbox state for all selected items
+    if (obj == ui->listFilters && event->type() == QEvent::KeyPress) {
+        QKeyEvent *ke = static_cast<QKeyEvent*>(event);
+        if (ke->key() == Qt::Key_Space) {
+            QList<QListWidgetItem*> selected = ui->listFilters->selectedItems();
+            if (!selected.isEmpty()) {
+                Qt::CheckState newState = (selected.first()->checkState() == Qt::Checked)
+                                          ? Qt::Unchecked : Qt::Checked;
+                inhibitFilterUpdate = true;
+                for (QListWidgetItem *item : selected)
+                    item->setCheckState(newState);
+                inhibitFilterUpdate = false;
+                QList<QPair<int,bool>> updates;
+                updates.reserve(selected.size());
+                for (QListWidgetItem *item : selected)
+                    updates.append({FilterUtility::getIdAsInt(item), newState == Qt::Checked});
+                model->setFilterStatesBatch(updates);
+                manageRowExpansion();
+                return true;
+            }
+        }
+    }
+    // Recalculate height of wrapping filter lists when they are resized (panel drag etc.)
+    if ((obj == ui->listBusFilters || obj == ui->listDirFilters || obj == ui->listLengthFilters)
+        && event->type() == QEvent::Resize) {
+        QListWidget *list = qobject_cast<QListWidget*>(obj);
+        QTimer::singleShot(0, this, [list]() {
+            if (list->count() > 0) {
+                QRect r = list->visualItemRect(list->item(list->count() - 1));
+                int h = r.bottom() + 1 + 2 * list->frameWidth();
+                if (h > 0 && h != list->height()) list->setFixedHeight(h);
+            }
+        });
+        return false;
+    }
     if (event->type() == QEvent::KeyRelease) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         switch (keyEvent->key())
@@ -1889,6 +1927,7 @@ void MainWindow::showCANBridgeWindow()
     }
     canBridgeWindow->show();
 }
+
 
 void MainWindow::showFrameSenderWindow()
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "filterutility.h"
 
 #include <QClipboard>
+#include <QTimer>
 /*
 Some notes on things I'd like to put into the program but haven't put on github (yet)
 
@@ -195,6 +196,20 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // Prevent annoying accidental horizontal scrolling when filter list is populated with long interpreted message names
     ui->listFilters->horizontalScrollBar()->setEnabled(false);
+
+    // Restore or default splitterLeft after the window has real geometry.
+    // QTimer::singleShot(0) defers to first event loop tick.
+    QTimer::singleShot(0, this, [this]() {
+        QSettings s;
+        QByteArray state = s.value("Main/SplitterLeft").toByteArray();
+        if (!state.isEmpty()) {
+            ui->splitterLeft->restoreState(state);
+        } else {
+            int h = ui->splitterLeft->height();
+            if (h > 0)
+                ui->splitterLeft->setSizes({h * 3 / 4, h / 4}); // 75% frame table, 25% send panel
+        }
+    });
 
     ui->leSearchFilter->setClearButtonEnabled(true);
     connect(ui->leSearchFilter, &QLineEdit::textChanged, this, &MainWindow::onSearchFilterChanged);
@@ -409,16 +424,12 @@ void MainWindow::readSettings()
         else
             ui->splitterMain->setSizes({750, 250});
 
-        QByteArray splitterLeftState = settings.value("Main/SplitterLeft").toByteArray();
-        if (!splitterLeftState.isEmpty())
-            ui->splitterLeft->restoreState(splitterLeftState);
-        else
-            ui->splitterLeft->setSizes({800, 200});
+        // splitterLeft is restored/defaulted via deferred QTimer in constructor
     }
     else
     {
         ui->splitterMain->setSizes({750, 250});
-        ui->splitterLeft->setSizes({800, 200});
+        // splitterLeft is defaulted via deferred QTimer in constructor
     }
 
     if (settings.value("Main/AutoScroll", false).toBool())
@@ -497,8 +508,9 @@ void MainWindow::writeSettings()
         settings.setValue("Main/AsciiColumn", ui->canFramesView->columnWidth(7));
         //settings.setValue("Main/DataColumn", ui->canFramesView->columnWidth(8));
         settings.setValue("Main/SplitterMain", ui->splitterMain->saveState());
-        settings.setValue("Main/SplitterLeft", ui->splitterLeft->saveState());
     }
+    // Always save splitterLeft so send-panel height is restored on next launch
+    settings.setValue("Main/SplitterLeft", ui->splitterLeft->saveState());
 }
 
 void MainWindow::onSenderCellChanged(int row, int col)
@@ -1985,8 +1997,15 @@ void MainWindow::showSignalViewer()
 void MainWindow::showConnectionSettingsWindow()
 {
     if (!connectionWindow)
-    {
         connectionWindow = new ConnectionWindow();
+
+    // Trigger a one-shot state probe on all SerialBus connections before showing the
+    // window.  PCAN on macOS never emits stateChanged on USB unplug, so this is the
+    // only time we can pay the cost of a brief disconnect+reconnect (user-visible action).
+    for (CANConnection *conn : CANConManager::getInstance()->getConnections()) {
+        if (conn->getType() == CANCon::SERIALBUS)
+            QMetaObject::invokeMethod(conn, "probeConnectionState", Qt::QueuedConnection);
     }
+
     connectionWindow->show();
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,9 +12,6 @@
 
 #include <QClipboard>
 #include <QTimer>
-#include <QSpinBox>
-#include <QFormLayout>
-#include <QDialogButtonBox>
 /*
 Some notes on things I'd like to put into the program but haven't put on github (yet)
 
@@ -1254,48 +1251,19 @@ void MainWindow::normalizeTiming()
 
 void MainWindow::handleCropLog()
 {
-    int totalFrames = model->getListReference()->count();
-    if (totalFrames == 0)
+    const QVector<CommFrame> *src = model->getListReference();
+    if (src->isEmpty())
     {
         QMessageBox::information(this, tr("Crop Log"), tr("No frames loaded."));
         return;
     }
 
-    QDialog dlg(this);
-    dlg.setWindowTitle(tr("Crop Log to Frame Range"));
-    QFormLayout form(&dlg);
-
-    QSpinBox *spinStart = new QSpinBox(&dlg);
-    spinStart->setMinimum(1);
-    spinStart->setMaximum(totalFrames);
-    spinStart->setValue(1);
-    form.addRow(tr("Start frame (1 = first):"), spinStart);
-
-    QSpinBox *spinEnd = new QSpinBox(&dlg);
-    spinEnd->setMinimum(1);
-    spinEnd->setMaximum(totalFrames);
-    spinEnd->setValue(totalFrames);
-    form.addRow(tr("End frame (%1 = last):").arg(totalFrames), spinEnd);
-
-    QDialogButtonBox *buttons = new QDialogButtonBox(
-        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dlg);
-    form.addRow(buttons);
-    connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
-    connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
-
+    CropLogDialog dlg(src, this);
     if (dlg.exec() != QDialog::Accepted)
         return;
 
-    int startIdx = spinStart->value() - 1; // convert to 0-based
-    int endIdx   = spinEnd->value() - 1;
-
-    if (startIdx > endIdx)
-    {
-        QMessageBox::warning(this, tr("Crop Log"), tr("Start frame must not be greater than end frame."));
-        return;
-    }
-
-    const QVector<CommFrame> *src = model->getListReference();
+    int startIdx = dlg.startIndex();
+    int endIdx   = dlg.endIndex();
     QVector<CommFrame> cropped = src->mid(startIdx, endIdx - startIdx + 1);
 
     model->clearFrames();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -162,9 +162,12 @@ MainWindow::MainWindow(QWidget *parent) :
 
     connect(ui->cbInterpret, &QAbstractButton::toggled, this, &MainWindow::interpretToggled);
     connect(ui->cbOverwrite, &QAbstractButton::toggled, this, &MainWindow::overwriteToggled);
+    connect(ui->cbChangingOnly, &QAbstractButton::toggled, this, &MainWindow::changingOnlyToggled);
     connect(ui->cbPersistentFilters, &QAbstractButton::toggled, this, &MainWindow::presistentFiltersToggled);
     connect(ui->listFilters, &QListWidget::itemChanged, this, &MainWindow::filterListItemChanged);
     connect(ui->listBusFilters, &QListWidget::itemChanged, this, &MainWindow::busFilterListItemChanged);
+    connect(ui->listDirFilters, &QListWidget::itemChanged, this, &MainWindow::dirFilterListItemChanged);
+    connect(ui->listLengthFilters, &QListWidget::itemChanged, this, &MainWindow::lengthFilterListItemChanged);
 
     connect(ui->btnCaptureToggle, &QAbstractButton::clicked, this, &MainWindow::toggleCapture);
     connect(ui->btnClearFrames, &QAbstractButton::clicked, this, &MainWindow::clearFrames);
@@ -202,6 +205,17 @@ MainWindow::MainWindow(QWidget *parent) :
     // Allow drag-select and Shift/Ctrl+click multi-selection in the ID filter list
     ui->listFilters->setSelectionMode(QAbstractItemView::ExtendedSelection);
     ui->listFilters->installEventFilter(this);
+
+    // Wrapping filter lists: items reflow on resize and height is recalculated via event filter
+    ui->listBusFilters->setWrapping(true);
+    ui->listBusFilters->setResizeMode(QListView::Adjust);
+    ui->listDirFilters->setWrapping(true);
+    ui->listDirFilters->setResizeMode(QListView::Adjust);
+    ui->listLengthFilters->setWrapping(true);
+    ui->listLengthFilters->setResizeMode(QListView::Adjust);
+    ui->listBusFilters->installEventFilter(this);
+    ui->listDirFilters->installEventFilter(this);
+    ui->listLengthFilters->installEventFilter(this);
 
     // Restore or default splitterLeft after the window has real geometry.
     // QTimer::singleShot(0) defers to first event loop tick.
@@ -408,7 +422,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
     if ((obj == ui->listBusFilters || obj == ui->listDirFilters || obj == ui->listLengthFilters)
         && event->type() == QEvent::Resize) {
         QListWidget *list = qobject_cast<QListWidget*>(obj);
-        QTimer::singleShot(0, this, [list]() {
+        QTimer::singleShot(0, this, [this, list]() {
             if (list->count() > 0) {
                 QRect r = list->visualItemRect(list->item(list->count() - 1));
                 int h = r.bottom() + 1 + 2 * list->frameWidth();
@@ -477,6 +491,34 @@ void MainWindow::readSettings()
     {
         ui->cbAutoScroll->setChecked(true);
     }
+
+    if (settings.value("Main/Overwrite", false).toBool())
+    {
+        ui->cbOverwrite->setChecked(Qt::Checked);
+        model->setOverwriteMode(true);
+    }
+    else
+    {
+        model->setOverwriteMode(false);
+        rowExpansionActive = false;
+    }
+
+    if (settings.value("Main/ChangingOnly", false).toBool())
+    {
+        ui->cbChangingOnly->setChecked(Qt::Checked);
+        model->setChangingOnly(true);
+    }
+    else
+        model->setChangingOnly(false);
+
+    if (settings.value("Main/PersistentFilters", false).toBool())
+    {
+        ui->cbPersistentFilters->setChecked(Qt::Checked);
+        model->setClearMode(true);
+    }
+    else
+        model->setClearMode(false);
+
     int fontSize = settings.value("Main/FontSize", 9).toUInt();
     QFont newFont = QFont(ui->canFramesView->font());
     newFont.setPointSize(fontSize);
@@ -1032,6 +1074,13 @@ void MainWindow::overwriteToggled(bool state)
     }
 }
 
+void MainWindow::changingOnlyToggled(bool state)
+{
+    QSettings settings;
+    settings.setValue("Main/ChangingOnly", state);
+    model->setChangingOnly(state);
+}
+
 void MainWindow::presistentFiltersToggled(bool state)
 {
     if (state)
@@ -1057,6 +1106,8 @@ void MainWindow::updateFilterList()
 
     ui->listFilters->clear();
     ui->listBusFilters->clear();
+    ui->listDirFilters->clear();
+    ui->listLengthFilters->clear();
 
     if (filters->isEmpty()) return;
 
@@ -1066,13 +1117,55 @@ void MainWindow::updateFilterList()
         /*QListWidgetItem *thisItem = */FilterUtility::createCheckableFilterItem(filterIter.key(), filterIter.value(), ui->listFilters);
     }
 
-    if (busFilters->isEmpty()) return;
-
-    for (filterIter = busFilters->begin(); filterIter != busFilters->end(); ++filterIter)
+    if (!busFilters->isEmpty())
     {
-        /*QListWidgetItem *thisItem = */ FilterUtility::createCheckableBusFilterItem(filterIter.key(), filterIter.value(), ui->listBusFilters);
+        for (filterIter = busFilters->begin(); filterIter != busFilters->end(); ++filterIter)
+        {
+            FilterUtility::createCheckableBusFilterItem(filterIter.key(), filterIter.value(), ui->listBusFilters);
+        }
     }
+
+    // Direction filters
+    const QMap<int, bool> *dirFilters = model->getDirFiltersReference();
+    if (dirFilters && !dirFilters->isEmpty())
+    {
+        for (filterIter = dirFilters->begin(); filterIter != dirFilters->end(); ++filterIter)
+        {
+            QString label = (filterIter.key() == 1) ? tr("Rx") : tr("Tx");
+            QListWidgetItem *item = new QListWidgetItem(label, ui->listDirFilters);
+            item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+            item->setCheckState(filterIter.value() ? Qt::Checked : Qt::Unchecked);
+            item->setData(Qt::UserRole, filterIter.key());
+        }
+    }
+
+    // Length filters
+    const QMap<int, bool> *lengthFilters = model->getLengthFiltersReference();
+    if (lengthFilters && !lengthFilters->isEmpty())
+    {
+        for (filterIter = lengthFilters->begin(); filterIter != lengthFilters->end(); ++filterIter)
+        {
+            FilterUtility::createCheckableBusFilterItem(filterIter.key(), filterIter.value(), ui->listLengthFilters);
+        }
+    }
+
+    // Adjust height of the wrapping filter lists to fit their items (deferred so layout is done first)
+    QTimer::singleShot(0, this, [this]() {
+        auto fitH = [](QListWidget *list) {
+            if (list->count() == 0) { list->setFixedHeight(0); return; }
+            QRect r = list->visualItemRect(list->item(list->count() - 1));
+            int h = r.bottom() + 1 + 2 * list->frameWidth();
+            if (h > 0) list->setFixedHeight(h);
+        };
+        fitH(ui->listBusFilters);
+        fitH(ui->listDirFilters);
+        fitH(ui->listLengthFilters);
+    });
+
     inhibitFilterUpdate = false;
+
+    // Re-apply any active search filter text so items stay hidden/shown after the list is repopulated
+    onSearchFilterChanged(ui->leSearchFilter->text());
 }
 
 void MainWindow::filterListItemChanged(QListWidgetItem *item)
@@ -1093,17 +1186,40 @@ void MainWindow::filterListItemChanged(QListWidgetItem *item)
 void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
 {
     if (inhibitFilterUpdate) return;
-    //qDebug() << item->text();
 
-    // strip away possible filter label
     int ID = FilterUtility::getIdAsInt(item);
-    bool isSet = false;
-    if (item->checkState() == Qt::Checked) isSet = true;
+    bool isSet = (item->checkState() == Qt::Checked);
 
     model->setBusFilterState(ID, isSet);
 
     manageRowExpansion();
 }
+
+void MainWindow::dirFilterListItemChanged(QListWidgetItem *item)
+{
+    if (inhibitFilterUpdate) return;
+
+    int dir = item->data(Qt::UserRole).toInt();
+    bool isSet = (item->checkState() == Qt::Checked);
+
+    model->setDirFilterState(dir, isSet);
+
+    manageRowExpansion();
+}
+
+void MainWindow::lengthFilterListItemChanged(QListWidgetItem *item)
+{
+    if (inhibitFilterUpdate) return;
+
+    int len = FilterUtility::getIdAsInt(item);
+    bool isSet = (item->checkState() == Qt::Checked);
+
+    model->setLengthFilterState(len, isSet);
+
+    manageRowExpansion();
+}
+
+
 
 void MainWindow::filterSetAll()
 {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -399,7 +399,25 @@ void MainWindow::readSettings()
         ui->canFramesView->setColumnWidth(6, settings.value("Main/LengthColumn", 40).toUInt()); //length
         ui->canFramesView->setColumnWidth(7, settings.value("Main/AsciiColumn", 50).toUInt()); //ascii
         //ui->canFramesView->setColumnWidth(8, settings.value("Main/DataColumn", 225).toUInt()); //data
+
+        QByteArray splitterMainState = settings.value("Main/SplitterMain").toByteArray();
+        if (!splitterMainState.isEmpty())
+            ui->splitterMain->restoreState(splitterMainState);
+        else
+            ui->splitterMain->setSizes({750, 250});
+
+        QByteArray splitterLeftState = settings.value("Main/SplitterLeft").toByteArray();
+        if (!splitterLeftState.isEmpty())
+            ui->splitterLeft->restoreState(splitterLeftState);
+        else
+            ui->splitterLeft->setSizes({800, 200});
     }
+    else
+    {
+        ui->splitterMain->setSizes({750, 250});
+        ui->splitterLeft->setSizes({800, 200});
+    }
+
     if (settings.value("Main/AutoScroll", false).toBool())
     {
         ui->cbAutoScroll->setChecked(true);
@@ -450,6 +468,10 @@ void MainWindow::readUpdateableSettings()
         ui->listFilters->setMaximumWidth(250);
     else
         ui->listFilters->setMaximumWidth(175);
+
+    bool showSendPanel = settings.value("Main/ShowSendPanel", true).toBool();
+    ui->tableSimpleSender->setVisible(showSendPanel);
+
     updateFilterList();    
 }    
 
@@ -471,6 +493,8 @@ void MainWindow::writeSettings()
         settings.setValue("Main/LengthColumn", ui->canFramesView->columnWidth(6));
         settings.setValue("Main/AsciiColumn", ui->canFramesView->columnWidth(7));
         //settings.setValue("Main/DataColumn", ui->canFramesView->columnWidth(8));
+        settings.setValue("Main/SplitterMain", ui->splitterMain->saveState());
+        settings.setValue("Main/SplitterLeft", ui->splitterLeft->saveState());
     }
 }
 
@@ -1519,7 +1543,7 @@ Data Bytes: 88 10 00 13 BB 00 06 00
                     }
 
                     QString temp;
-                    if (sigs[j]->processAsText(*frame, temp, false))
+                    if (sigs[j]->processAsText(*frame, temp))
                     {
                         builderString.append(temp);
                         builderString.append(",");

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -12,6 +12,9 @@
 
 #include <QClipboard>
 #include <QTimer>
+#include <QSpinBox>
+#include <QFormLayout>
+#include <QDialogButtonBox>
 /*
 Some notes on things I'd like to put into the program but haven't put on github (yet)
 
@@ -123,6 +126,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->actionRange_State_2, &QAction::triggered, this, &MainWindow::showRangeWindow);
     connect(ui->actionSave_Decoded_Frames, &QAction::triggered, this, &MainWindow::handleSaveDecoded);
     connect(ui->actionSave_Decoded_Frames_CSV, &QAction::triggered, this, &MainWindow::handleSaveDecodedCsv);
+    connect(ui->actionCrop_Log, &QAction::triggered, this, &MainWindow::handleCropLog);
     connect(ui->actionSingle_Multi_State_2, &QAction::triggered, this, &MainWindow::showSingleMultiWindow);
     connect(ui->actionFile_Comparison, &QAction::triggered, this, &MainWindow::showComparisonWindow);
     connect(ui->actionDBC_Comparison, &QAction::triggered, this, &MainWindow::showDBCComparisonWindow);
@@ -1206,6 +1210,60 @@ void MainWindow::normalizeTiming()
 {
     model->normalizeTiming();
     emit framesUpdated(-2); //claim an all new set of frames because every frame was updated.
+}
+
+void MainWindow::handleCropLog()
+{
+    int totalFrames = model->getListReference()->count();
+    if (totalFrames == 0)
+    {
+        QMessageBox::information(this, tr("Crop Log"), tr("No frames loaded."));
+        return;
+    }
+
+    QDialog dlg(this);
+    dlg.setWindowTitle(tr("Crop Log to Frame Range"));
+    QFormLayout form(&dlg);
+
+    QSpinBox *spinStart = new QSpinBox(&dlg);
+    spinStart->setMinimum(1);
+    spinStart->setMaximum(totalFrames);
+    spinStart->setValue(1);
+    form.addRow(tr("Start frame (1 = first):"), spinStart);
+
+    QSpinBox *spinEnd = new QSpinBox(&dlg);
+    spinEnd->setMinimum(1);
+    spinEnd->setMaximum(totalFrames);
+    spinEnd->setValue(totalFrames);
+    form.addRow(tr("End frame (%1 = last):").arg(totalFrames), spinEnd);
+
+    QDialogButtonBox *buttons = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dlg);
+    form.addRow(buttons);
+    connect(buttons, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+
+    if (dlg.exec() != QDialog::Accepted)
+        return;
+
+    int startIdx = spinStart->value() - 1; // convert to 0-based
+    int endIdx   = spinEnd->value() - 1;
+
+    if (startIdx > endIdx)
+    {
+        QMessageBox::warning(this, tr("Crop Log"), tr("Start frame must not be greater than end frame."));
+        return;
+    }
+
+    const QVector<CommFrame> *src = model->getListReference();
+    QVector<CommFrame> cropped = src->mid(startIdx, endIdx - startIdx + 1);
+
+    model->clearFrames();
+    model->insertFrames(cropped);
+    CANConManager::getInstance()->resetTimeBasis();
+    ui->lbNumFrames->setText(QString::number(model->rowCount()));
+    bDirty = true;
+    emit framesUpdated(-2);
 }
 
 void MainWindow::handleLoadFile()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -196,6 +196,9 @@ MainWindow::MainWindow(QWidget *parent) :
     // Prevent annoying accidental horizontal scrolling when filter list is populated with long interpreted message names
     ui->listFilters->horizontalScrollBar()->setEnabled(false);
 
+    ui->leSearchFilter->setClearButtonEnabled(true);
+    connect(ui->leSearchFilter, &QLineEdit::textChanged, this, &MainWindow::onSearchFilterChanged);
+
     connect(&updateTimer, &QTimer::timeout, this, &MainWindow::tickGUIUpdate);
     updateTimer.setInterval(250);
     updateTimer.start();
@@ -508,6 +511,30 @@ void MainWindow::onSenderCellChanged(int row, int col)
     }
 
     processSenderCellChange(row, col);
+}
+
+void MainWindow::onSearchFilterChanged(const QString &text)
+{
+    // Apply search text to the model (filters main table rows)
+    model->setSearchFilter(text);
+
+    // Show/hide items in the filter list to match the search text
+    QString stripped = text;
+    if (stripped.startsWith("0x", Qt::CaseInsensitive))
+        stripped = stripped.mid(2);
+
+    for (int i = 0; i < ui->listFilters->count(); ++i) {
+        QListWidgetItem *item = ui->listFilters->item(i);
+        if (stripped.isEmpty())
+            item->setHidden(false);
+        else {
+            QString idStr = FilterUtility::getId(item);
+            // strip leading "0x" from the displayed id string too
+            if (idStr.startsWith("0x", Qt::CaseInsensitive))
+                idStr = idStr.mid(2);
+            item->setHidden(!idStr.contains(stripped, Qt::CaseInsensitive));
+        }
+    }
 }
 
 void MainWindow::processSenderCellChange(int line, int col)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1934,9 +1934,13 @@ void MainWindow::showSearchWindow()
 {
     if (!searchWindow)
     {
-        searchWindow = new SearchWindow(model->getListReference(), dbcHandler);
+        searchWindow = new SearchWindow(model->getFilteredListReference(), dbcHandler);
         connect(searchWindow, &SearchWindow::jumpToFrameIndex, this, &MainWindow::jumpToSearchFrame);
         connect(this, &MainWindow::framesUpdated, searchWindow, &SearchWindow::updatedFrames);
+        // Clear stale results whenever the filter changes (sendRefresh rebuilds filteredFrames)
+        connect(model, &QAbstractItemModel::modelReset, searchWindow, [this]() {
+            searchWindow->updatedFrames(0);
+        });
     }
     searchWindow->show();
     searchWindow->raise();
@@ -1944,20 +1948,18 @@ void MainWindow::showSearchWindow()
 
 void MainWindow::jumpToSearchFrame(int frameIndex)
 {
-    if (!model || frameIndex < 0 || frameIndex >= model->getListReference()->size())
+    if (!model || frameIndex < 0 || frameIndex >= model->getFilteredListReference()->size())
         return;
 
-    // The main table uses a proxy model; find the corresponding proxy row
+    // frameIndex is a row in CommFrameModel (filteredFrames); map through the
+    // sort proxy so the view scrolls to the correct visible row.
     QAbstractProxyModel *proxy = qobject_cast<QAbstractProxyModel *>(ui->canFramesView->model());
-    if (proxy)
+    QModelIndex srcIndex = model->index(frameIndex, 0);
+    QModelIndex target = proxy ? proxy->mapFromSource(srcIndex) : srcIndex;
+    if (target.isValid())
     {
-        QModelIndex srcIndex = model->index(frameIndex, 0);
-        QModelIndex proxyIndex = proxy->mapFromSource(srcIndex);
-        if (proxyIndex.isValid())
-        {
-            ui->canFramesView->scrollTo(proxyIndex, QAbstractItemView::PositionAtCenter);
-            ui->canFramesView->setCurrentIndex(proxyIndex);
-        }
+        ui->canFramesView->scrollTo(target, QAbstractItemView::PositionAtCenter);
+        ui->canFramesView->setCurrentIndex(target);
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -120,6 +120,7 @@ private slots:
     void tickGUIUpdate();
     void toggleCapture();
     void normalizeTiming();
+    void handleCropLog();
     void updateFilterList();
     void filterListItemChanged(QListWidgetItem *item);
     void busFilterListItemChanged(QListWidgetItem *item);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -119,6 +119,7 @@ private slots:
     void setupSendToLatestGraphWindow();
     void interpretToggled(bool);
     void overwriteToggled(bool);
+    void changingOnlyToggled(bool);
     void presistentFiltersToggled(bool state);
     void logReceivedFrame(CANConnection*, QVector<CommFrame>);
     void tickGUIUpdate();
@@ -128,6 +129,8 @@ private slots:
     void updateFilterList();
     void filterListItemChanged(QListWidgetItem *item);
     void busFilterListItemChanged(QListWidgetItem *item);
+    void dirFilterListItemChanged(QListWidgetItem *item);
+    void lengthFilterListItemChanged(QListWidgetItem *item);
     void filterSetAll();
     void filterClearAll();
     void headerClicked (int logicalIndex);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -128,6 +128,7 @@ private slots:
     void headerClicked (int logicalIndex);
     void DBCSettingsUpdated();
     void onSenderCellChanged(int, int);
+    void onSearchFilterChanged(const QString &text);
 
 public slots:
     void gotFrames(int);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -35,6 +35,7 @@
 #include "re/dbccomparatorwindow.h"
 #include "canbridgewindow.h"
 #include "re/searchwindow.h"
+#include "croplogdialog.h"
 
 class CANConnection;
 class ConnectionWindow;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -34,6 +34,7 @@
 #include "re/temporalgraphwindow.h"
 #include "re/dbccomparatorwindow.h"
 #include "canbridgewindow.h"
+#include "re/searchwindow.h"
 
 class CANConnection;
 class ConnectionWindow;
@@ -103,6 +104,8 @@ private slots:
     void showTemporalGraphWindow();
     void showDBCComparisonWindow();
     void showCANBridgeWindow();
+    void showSearchWindow();
+    void jumpToSearchFrame(int frameIndex);
     void exitApp();
     void handleSaveDecoded();
     void handleSaveDecodedCsv();
@@ -204,6 +207,7 @@ private:
     TemporalGraphWindow *temporalGraphWindow;
     DBCComparatorWindow *dbcComparatorWindow;
     CANBridgeWindow *canBridgeWindow;
+    SearchWindow *searchWindow;
 
     //various private storage
     QLabel lbStatusConnected;

--- a/re/searchwindow.cpp
+++ b/re/searchwindow.cpp
@@ -30,6 +30,7 @@ SearchWindow::SearchWindow(const QVector<CommFrame> *frames, DBCHandler *handler
     connect(ui->cbIntel,     SIGNAL(toggled(bool)),  this, SLOT(drawBitfield()));
 
     // Value mode toggle
+    connect(ui->rbValueNone,     SIGNAL(toggled(bool)), this, SLOT(onValueModeChanged()));
     connect(ui->rbValueAny,      SIGNAL(toggled(bool)), this, SLOT(onValueModeChanged()));
     connect(ui->rbValueSpecific, SIGNAL(toggled(bool)), this, SLOT(onValueModeChanged()));
 
@@ -59,7 +60,6 @@ void SearchWindow::updatedFrames(int /*numFrames*/)
         updateNavigationState();
     }
 }
-
 // ──────────────────────────────────────────────
 //  DBC hierarchy loading  (mirrors NewGraphDialog)
 // ──────────────────────────────────────────────
@@ -200,6 +200,11 @@ void SearchWindow::handleStartBitUpdate()
     startBit = ui->txtStartBit->text().toInt();
     if (startBit < 0)   startBit = 0;
     if (startBit > 511) startBit = 511;
+    // Manual edit overrides any loaded DBC signal
+    if (assocSignal) {
+        assocSignal = nullptr;
+        ui->lblSignalStatus->setText("(manual – DBC signal cleared)");
+    }
     drawBitfield();
 }
 
@@ -208,6 +213,11 @@ void SearchWindow::handleDataLenUpdate()
     dataLen = ui->txtDataLen->text().toInt();
     if (dataLen < 1)  dataLen = 1;
     if (dataLen > 512) dataLen = 512;
+    // Manual edit overrides any loaded DBC signal
+    if (assocSignal) {
+        assocSignal = nullptr;
+        ui->lblSignalStatus->setText("(manual – DBC signal cleared)");
+    }
     drawBitfield();
 }
 
@@ -253,6 +263,14 @@ void SearchWindow::drawBitfield()
 // ──────────────────────────────────────────────
 void SearchWindow::onValueModeChanged()
 {
+    bool hasValueFilter = !ui->rbValueNone->isChecked();
+    ui->txtStartBit->setEnabled(hasValueFilter);
+    ui->txtDataLen->setEnabled(hasValueFilter);
+    ui->cbIntel->setEnabled(hasValueFilter);
+    ui->cbSigned->setEnabled(hasValueFilter);
+    ui->txtScale->setEnabled(hasValueFilter);
+    ui->txtBias->setEnabled(hasValueFilter);
+    ui->gridData->setEnabled(hasValueFilter);
     ui->txtValue->setEnabled(ui->rbValueSpecific->isChecked());
 }
 
@@ -312,12 +330,19 @@ void SearchWindow::performSearch()
     if (ui->rbDirRX->isChecked())  dirMode = 1;
     if (ui->rbDirTX->isChecked())  dirMode = 2;
 
-    bool specificValue = ui->rbValueSpecific->isChecked();
-    double targetValue = ui->txtValue->text().toDouble();
+    bool noValueFilter  = ui->rbValueNone->isChecked();
+    bool specificValue  = ui->rbValueSpecific->isChecked();
+    double targetValue  = ui->txtValue->text().toDouble();
 
-    // For "any change" mode we need to track the last decoded value per CAN ID
-    QMap<uint32_t, double> lastSeen;
-    const double NO_PREV = std::numeric_limits<double>::max();
+    // For "any change" mode we track the last value per CAN ID.
+    // Use int64_t for raw bit-range comparisons to avoid double precision loss
+    // when dataLen approaches 64 bits (double only has 53-bit mantissa).
+    // When a DBC signal is active, fall back to double (scale/bias decoded).
+    const bool useRawCompare = (assocSignal == nullptr);
+    QMap<uint32_t, int64_t> lastSeenRaw;
+    QMap<uint32_t, double>  lastSeen;
+    const int64_t NO_PREV_RAW = std::numeric_limits<int64_t>::min();
+    const double  NO_PREV     = std::numeric_limits<double>::max();
 
     for (int i = 0; i < modelFrames->size(); i++)
     {
@@ -336,6 +361,9 @@ void SearchWindow::performSearch()
         if (dirMode == 2 &&  f.isReceived())   continue; // want TX, frame is RX
 
         // ── Value filter ───────────────────────────────────────
+        // Skip entirely when "No filter" is selected
+        if (noValueFilter) { matchingIndices.append(i); continue; }
+
         // Only apply value filter when there's at least one data byte covered
         if (startBit / 8 < f.payload().size())
         {
@@ -349,10 +377,24 @@ void SearchWindow::performSearch()
             else // any change
             {
                 uint32_t key = f.frameId();
-                double prev  = lastSeen.value(key, NO_PREV);
-                if (prev != NO_PREV && qFuzzyCompare(val, prev))
-                    continue;          // same as last time → skip
-                lastSeen[key] = val;
+                if (useRawCompare && !assocSignal)
+                {
+                    // Compare as raw integer to avoid double precision loss
+                    int64_t raw = Utility::processIntegerSignal(
+                        f.payload(), startBit, dataLen,
+                        ui->cbIntel->isChecked(), ui->cbSigned->isChecked());
+                    int64_t prev = lastSeenRaw.value(key, NO_PREV_RAW);
+                    if (prev != NO_PREV_RAW && raw == prev)
+                        continue;
+                    lastSeenRaw[key] = raw;
+                }
+                else
+                {
+                    double prev = lastSeen.value(key, NO_PREV);
+                    if (prev != NO_PREV && qFuzzyCompare(val, prev))
+                        continue;
+                    lastSeen[key] = val;
+                }
             }
         }
 

--- a/re/searchwindow.cpp
+++ b/re/searchwindow.cpp
@@ -1,0 +1,403 @@
+#include "searchwindow.h"
+#include "ui_searchwindow.h"
+#include "../utility.h"
+#include <QDebug>
+#include <cmath>
+#include <cstring>
+
+SearchWindow::SearchWindow(const QVector<CommFrame> *frames, DBCHandler *handler, QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::SearchWindow)
+    , modelFrames(frames)
+    , dbcHandler(handler)
+    , assocSignal(nullptr)
+    , startBit(0)
+    , dataLen(8)
+    , currentMatchIndex(-1)
+{
+    ui->setupUi(this);
+    setWindowFlags(Qt::Window);
+
+    // DBC signal pickers
+    connect(ui->cbNodes,    SIGNAL(currentIndexChanged(int)), this, SLOT(loadMessages(int)));
+    connect(ui->cbMessages, SIGNAL(currentIndexChanged(int)), this, SLOT(loadSignals(int)));
+    connect(ui->btnCopySignal, SIGNAL(clicked(bool)), this, SLOT(copySignalToParamsUI()));
+
+    // Bit-field grid
+    connect(ui->gridData,    SIGNAL(gridClicked(int)), this, SLOT(bitfieldClicked(int)));
+    connect(ui->txtStartBit, SIGNAL(textChanged(QString)), this, SLOT(handleStartBitUpdate()));
+    connect(ui->txtDataLen,  SIGNAL(textChanged(QString)), this, SLOT(handleDataLenUpdate()));
+    connect(ui->cbIntel,     SIGNAL(toggled(bool)),  this, SLOT(drawBitfield()));
+
+    // Value mode toggle
+    connect(ui->rbValueAny,      SIGNAL(toggled(bool)), this, SLOT(onValueModeChanged()));
+    connect(ui->rbValueSpecific, SIGNAL(toggled(bool)), this, SLOT(onValueModeChanged()));
+
+    // Navigation
+    connect(ui->btnSearch, SIGNAL(clicked(bool)), this, SLOT(onSearchClicked()));
+    connect(ui->btnNext,   SIGNAL(clicked(bool)), this, SLOT(onNextClicked()));
+    connect(ui->btnPrev,   SIGNAL(clicked(bool)), this, SLOT(onPreviousClicked()));
+
+    loadNodes();
+    drawBitfield();
+}
+
+SearchWindow::~SearchWindow()
+{
+    delete ui;
+}
+
+// Called by MainWindow when the frame list changes
+void SearchWindow::updatedFrames(int /*numFrames*/)
+{
+    // Clear stale results when frames change
+    if (!matchingIndices.isEmpty())
+    {
+        matchingIndices.clear();
+        currentMatchIndex = -1;
+        ui->lblMatchInfo->setText("Frames updated – press Search again.");
+        updateNavigationState();
+    }
+}
+
+// ──────────────────────────────────────────────
+//  DBC hierarchy loading  (mirrors NewGraphDialog)
+// ──────────────────────────────────────────────
+void SearchWindow::loadNodes()
+{
+    ui->cbNodes->clear();
+    if (!dbcHandler) return;
+    int numFiles = dbcHandler->getFileCount();
+    if (numFiles == 0) return;
+
+    for (int f = 0; f < numFiles; f++)
+    {
+        DBCFile *thisFile = dbcHandler->getFileByIdx(f);
+        QList<QString> names;
+        QList<DBC_MESSAGE *> msgs = thisFile->messageHandler->getMsgsAsList();
+
+        for (int x = 0; x < thisFile->dbc_nodes.count(); x++)
+        {
+            bool hasMessages = false;
+            for (int m = 0; m < msgs.count(); m++)
+            {
+                if (msgs[m]->sender->name == thisFile->dbc_nodes[x]->name)
+                {
+                    hasMessages = true;
+                    break;
+                }
+            }
+            if (hasMessages)
+            {
+                QString fqName = thisFile->getFilenameNoExt()
+                               + Utility::fullyQualifiedNameSeperator
+                               + thisFile->dbc_nodes[x]->name;
+                names.append(fqName);
+            }
+        }
+
+        if (!names.isEmpty())
+        {
+            names.sort();
+            ui->cbNodes->addItem("----" + thisFile->getFilename());
+            Utility::SetComboBoxItemEnabled(ui->cbNodes, ui->cbNodes->count() - 1, false);
+            for (const QString &n : names)
+                ui->cbNodes->addItem(n);
+        }
+    }
+}
+
+void SearchWindow::loadMessages(int idx)
+{
+    ui->cbMessages->clear();
+    if (!dbcHandler) return;
+    if (dbcHandler->getFileCount() == 0) return;
+
+    QString displayedNode = ui->cbNodes->itemText(idx);
+
+    for (int f = 0; f < dbcHandler->getFileCount(); f++)
+    {
+        QList<DBC_MESSAGE *> msgs = dbcHandler->getFileByIdx(f)->messageHandler->getMsgsAsList();
+        for (int x = 0; x < msgs.count(); x++)
+        {
+            QString fqName = dbcHandler->getFileByIdx(f)->getFilenameNoExt()
+                           + Utility::fullyQualifiedNameSeperator
+                           + msgs[x]->sender->name;
+            if (fqName == displayedNode)
+                ui->cbMessages->addItem(msgs[x]->name);
+        }
+    }
+}
+
+void SearchWindow::loadSignals(int /*idx*/)
+{
+    ui->cbSignals->clear();
+    if (!dbcHandler) return;
+    if (dbcHandler->getFileCount() == 0) return;
+
+    QString fqNode = ui->cbNodes->itemText(ui->cbNodes->currentIndex());
+    DBC_MESSAGE *msg = dbcHandler->findMessage(ui->cbMessages->currentText(), fqNode);
+    if (!msg) return;
+
+    QList<DBC_SIGNAL *> sigs = msg->sigHandler->getSignalsAsList();
+    for (DBC_SIGNAL *sig : sigs)
+    {
+        if (sig)
+            ui->cbSignals->addItem(sig->name);
+    }
+    ui->cbSignals->model()->sort(0);
+}
+
+void SearchWindow::copySignalToParamsUI()
+{
+    assocSignal = nullptr;
+    if (!dbcHandler) return;
+
+    QString fqNode  = ui->cbNodes->itemText(ui->cbNodes->currentIndex());
+    QString msgName = ui->cbMessages->itemText(ui->cbMessages->currentIndex());
+    DBC_MESSAGE *msg = dbcHandler->findMessage(msgName, fqNode);
+    if (!msg) return;
+
+    DBC_SIGNAL *sig = msg->sigHandler->findSignalByName(ui->cbSignals->currentText());
+    if (!sig) return;
+
+    // Populate manual fields from DBC signal
+    startBit = sig->startBit;
+    dataLen  = sig->signalSize;
+
+    ui->txtStartBit->blockSignals(true);
+    ui->txtStartBit->setText(QString::number(startBit));
+    ui->txtStartBit->blockSignals(false);
+
+    ui->txtDataLen->setText(QString::number(dataLen));
+    ui->txtID->setText(Utility::formatCANID(msg->ID));
+    ui->cbUseID->setChecked(true);
+    ui->txtScale->setText(QString::number(sig->factor));
+    ui->txtBias->setText(QString::number(sig->bias));
+    ui->cbIntel->setChecked(sig->intelByteOrder);
+    ui->cbSigned->setChecked(sig->valType == SIGNED_INT);
+
+    assocSignal = sig;
+    ui->lblSignalStatus->setText("Params loaded from: " + sig->name);
+
+    drawBitfield();
+}
+
+// ──────────────────────────────────────────────
+//  Bit-field visualisation (mirrors NewGraphDialog)
+// ──────────────────────────────────────────────
+void SearchWindow::bitfieldClicked(int bit)
+{
+    startBit = bit;
+    ui->txtStartBit->blockSignals(true);
+    ui->txtStartBit->setText(QString::number(startBit));
+    ui->txtStartBit->blockSignals(false);
+    drawBitfield();
+}
+
+void SearchWindow::handleStartBitUpdate()
+{
+    startBit = ui->txtStartBit->text().toInt();
+    if (startBit < 0)   startBit = 0;
+    if (startBit > 511) startBit = 511;
+    drawBitfield();
+}
+
+void SearchWindow::handleDataLenUpdate()
+{
+    dataLen = ui->txtDataLen->text().toInt();
+    if (dataLen < 1)  dataLen = 1;
+    if (dataLen > 512) dataLen = 512;
+    drawBitfield();
+}
+
+void SearchWindow::drawBitfield()
+{
+    uint8_t bitField[64];
+    memset(bitField, 0, sizeof(bitField));
+
+    // Mark the start bit distinctly
+    bitField[Utility::getByteFromBitPosition(startBit)] |=
+        static_cast<uint8_t>(1 << Utility::getBitFromBitPosition(startBit));
+
+    ui->gridData->setReference(reinterpret_cast<unsigned char *>(bitField), false);
+
+    if (ui->cbIntel->isChecked())
+    {
+        int endBit = startBit + dataLen - 1;
+        if (endBit > 511) endBit = 511;
+        for (int y = startBit; y <= endBit; y++)
+            bitField[Utility::getByteFromBitPosition(y)] |=
+                static_cast<uint8_t>(1 << Utility::getBitFromBitPosition(y));
+    }
+    else
+    {
+        int size = dataLen;
+        int sBit = startBit;
+        while (size > 0)
+        {
+            bitField[Utility::getByteFromBitPosition(sBit)] |=
+                static_cast<uint8_t>(1 << Utility::getBitFromBitPosition(sBit));
+            size--;
+            if ((sBit % 8) == 0) sBit += 15;
+            else sBit--;
+            if (sBit > 511) sBit = 511;
+        }
+    }
+
+    ui->gridData->updateData(reinterpret_cast<unsigned char *>(bitField), true);
+}
+
+// ──────────────────────────────────────────────
+//  Value mode
+// ──────────────────────────────────────────────
+void SearchWindow::onValueModeChanged()
+{
+    ui->txtValue->setEnabled(ui->rbValueSpecific->isChecked());
+}
+
+// ──────────────────────────────────────────────
+//  Core decode helper
+// ──────────────────────────────────────────────
+double SearchWindow::decodeValue(const CommFrame &frame) const
+{
+    double scale = ui->txtScale->text().toDouble();
+    double bias  = ui->txtBias->text().toDouble();
+    if (qFuzzyIsNull(scale)) scale = 1.0;
+
+    // If we have an associated DBC signal, use its decoder
+    if (assocSignal)
+    {
+        double val = 0.0;
+        if (assocSignal->processAsDouble(frame, val))
+            return val;
+    }
+
+    int64_t raw = Utility::processIntegerSignal(
+        frame.payload(), startBit, dataLen,
+        ui->cbIntel->isChecked(), ui->cbSigned->isChecked());
+
+    return static_cast<double>(raw) * scale + bias;
+}
+
+// ──────────────────────────────────────────────
+//  Search
+// ──────────────────────────────────────────────
+void SearchWindow::onSearchClicked()
+{
+    performSearch();
+}
+
+void SearchWindow::performSearch()
+{
+    matchingIndices.clear();
+    currentMatchIndex = -1;
+
+    if (!modelFrames || modelFrames->isEmpty())
+    {
+        ui->lblMatchInfo->setText("No frames loaded.");
+        updateNavigationState();
+        return;
+    }
+
+    // ── Collect filter parameters ────────────────────────────
+    bool   useID  = ui->cbUseID->isChecked();
+    uint32_t filterID = useID ? Utility::ParseStringToNum(ui->txtID->text()) : 0;
+
+    bool   useLen  = ui->cbUseLen->isChecked();
+    int    filterLen = ui->spinFrameLen->value();
+
+    // Direction: 0 = both, 1 = RX only, 2 = TX only
+    int dirMode = 0;
+    if (ui->rbDirRX->isChecked())  dirMode = 1;
+    if (ui->rbDirTX->isChecked())  dirMode = 2;
+
+    bool specificValue = ui->rbValueSpecific->isChecked();
+    double targetValue = ui->txtValue->text().toDouble();
+
+    // For "any change" mode we need to track the last decoded value per CAN ID
+    QMap<uint32_t, double> lastSeen;
+    const double NO_PREV = std::numeric_limits<double>::max();
+
+    for (int i = 0; i < modelFrames->size(); i++)
+    {
+        const CommFrame &f = modelFrames->at(i);
+
+        // ── ID filter ──────────────────────────────────────────
+        if (useID && f.frameId() != filterID)
+            continue;
+
+        // ── Length filter ──────────────────────────────────────
+        if (useLen && f.payload().size() != filterLen)
+            continue;
+
+        // ── Direction filter ───────────────────────────────────
+        if (dirMode == 1 && !f.isReceived())   continue; // want RX, frame is TX
+        if (dirMode == 2 &&  f.isReceived())   continue; // want TX, frame is RX
+
+        // ── Value filter ───────────────────────────────────────
+        // Only apply value filter when there's at least one data byte covered
+        if (startBit / 8 < f.payload().size())
+        {
+            double val = decodeValue(f);
+
+            if (specificValue)
+            {
+                if (!qFuzzyCompare(val, targetValue))
+                    continue;
+            }
+            else // any change
+            {
+                uint32_t key = f.frameId();
+                double prev  = lastSeen.value(key, NO_PREV);
+                if (prev != NO_PREV && qFuzzyCompare(val, prev))
+                    continue;          // same as last time → skip
+                lastSeen[key] = val;
+            }
+        }
+
+        matchingIndices.append(i);
+    }
+
+    if (matchingIndices.isEmpty())
+    {
+        ui->lblMatchInfo->setText("No matches found.");
+    }
+    else
+    {
+        currentMatchIndex = 0;
+        ui->lblMatchInfo->setText(
+            QString("Match 1 of %1").arg(matchingIndices.size()));
+        emit jumpToFrameIndex(matchingIndices.at(0));
+    }
+
+    updateNavigationState();
+}
+
+// ──────────────────────────────────────────────
+//  Navigation
+// ──────────────────────────────────────────────
+void SearchWindow::onNextClicked()
+{
+    if (matchingIndices.isEmpty()) return;
+    currentMatchIndex = (currentMatchIndex + 1) % matchingIndices.size();
+    ui->lblMatchInfo->setText(
+        QString("Match %1 of %2").arg(currentMatchIndex + 1).arg(matchingIndices.size()));
+    emit jumpToFrameIndex(matchingIndices.at(currentMatchIndex));
+}
+
+void SearchWindow::onPreviousClicked()
+{
+    if (matchingIndices.isEmpty()) return;
+    currentMatchIndex = (currentMatchIndex - 1 + matchingIndices.size()) % matchingIndices.size();
+    ui->lblMatchInfo->setText(
+        QString("Match %1 of %2").arg(currentMatchIndex + 1).arg(matchingIndices.size()));
+    emit jumpToFrameIndex(matchingIndices.at(currentMatchIndex));
+}
+
+void SearchWindow::updateNavigationState()
+{
+    bool hasResults = !matchingIndices.isEmpty();
+    ui->btnNext->setEnabled(hasResults);
+    ui->btnPrev->setEnabled(hasResults);
+}

--- a/re/searchwindow.h
+++ b/re/searchwindow.h
@@ -1,0 +1,55 @@
+#ifndef SEARCHWINDOW_H
+#define SEARCHWINDOW_H
+
+#include <QDialog>
+#include "../can_structs.h"
+#include "../dbc/dbchandler.h"
+
+namespace Ui {
+class SearchWindow;
+}
+
+class SearchWindow : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SearchWindow(const QVector<CommFrame> *frames, DBCHandler *handler, QWidget *parent = nullptr);
+    ~SearchWindow();
+
+    void updatedFrames(int numFrames);
+
+signals:
+    void jumpToFrameIndex(int frameIndex);
+
+private slots:
+    void loadNodes();
+    void loadMessages(int idx);
+    void loadSignals(int idx);
+    void copySignalToParamsUI();
+    void bitfieldClicked(int bit);
+    void handleStartBitUpdate();
+    void handleDataLenUpdate();
+    void drawBitfield();
+    void onSearchClicked();
+    void onNextClicked();
+    void onPreviousClicked();
+    void onValueModeChanged();
+
+private:
+    void performSearch();
+    double decodeValue(const CommFrame &frame) const;
+    void updateNavigationState();
+
+    Ui::SearchWindow *ui;
+    const QVector<CommFrame> *modelFrames;
+    DBCHandler *dbcHandler;
+    DBC_SIGNAL *assocSignal;
+    int startBit;
+    int dataLen;
+
+    QVector<int> matchingIndices;
+    int currentMatchIndex;
+};
+
+#endif // SEARCHWINDOW_H

--- a/ui/mainsettingsdialog.ui
+++ b/ui/mainsettingsdialog.ui
@@ -84,6 +84,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="cbDisplayHexAndDec">
+          <property name="text">
+           <string>Display values as hexadecimal and decimal</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="cbValidate">
           <property name="text">
            <string>Require validation of GVRET connection</string>
@@ -101,6 +108,13 @@
          <widget class="QCheckBox" name="cbColorsByCanId">
           <property name="text">
            <string>Color rows by CAN ID</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cbShowSendPanel">
+          <property name="text">
+           <string>Show simple send panel in main window</string>
           </property>
          </widget>
         </item>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -28,37 +28,43 @@
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0">
     <item>
-     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="3,1">
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout_3" stretch="4,1">
-        <item>
-         <widget class="QTableView" name="canFramesView">
-          <property name="font">
-           <font>
-            <pointsize>11</pointsize>
-            <bold>false</bold>
-           </font>
-          </property>
-          <property name="alternatingRowColors">
-           <bool>true</bool>
-          </property>
-          <property name="verticalScrollMode">
-           <enum>QAbstractItemView::ScrollPerPixel</enum>
-          </property>
-          <property name="wordWrap">
-           <bool>false</bool>
-          </property>
-          <attribute name="horizontalHeaderStretchLastSection">
-           <bool>false</bool>
-          </attribute>
-         </widget>
-        </item>
-        <item>
-         <widget class="QTableWidget" name="tableSimpleSender"/>
-        </item>
-       </layout>
-      </item>
-      <item>
+     <widget class="QSplitter" name="splitterMain">
+      <property name="orientation">
+       <enum>Qt::Orientation::Horizontal</enum>
+      </property>
+      <widget class="QSplitter" name="splitterLeft">
+       <property name="orientation">
+        <enum>Qt::Orientation::Vertical</enum>
+       </property>
+       <widget class="QTableView" name="canFramesView">
+        <property name="font">
+         <font>
+          <pointsize>11</pointsize>
+          <bold>false</bold>
+         </font>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="verticalScrollMode">
+         <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>false</bool>
+        </attribute>
+       </widget>
+       <widget class="QTableWidget" name="tableSimpleSender"/>
+      </widget>
+      <widget class="QWidget" name="rightPanelWidget">
+       <property name="minimumSize">
+        <size>
+         <width>175</width>
+         <height>0</height>
+        </size>
+       </property>
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
          <widget class="QLabel" name="lblRemoteConn">
@@ -69,7 +75,7 @@
            <string>Remote Connection Active:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -99,7 +105,7 @@
            <number>8</number>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="readOnly">
            <bool>true</bool>
@@ -156,11 +162,11 @@
            <string/>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignHCenter">
+        <item alignment="Qt::AlignmentFlag::AlignHCenter">
          <widget class="QLabel" name="label">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -173,7 +179,7 @@
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignHCenter">
+        <item alignment="Qt::AlignmentFlag::AlignHCenter">
          <widget class="QLabel" name="lbNumFrames">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -186,7 +192,7 @@
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignHCenter">
+        <item alignment="Qt::AlignmentFlag::AlignHCenter">
          <widget class="QLabel" name="label_6">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -199,7 +205,7 @@
           </property>
          </widget>
         </item>
-        <item alignment="Qt::AlignHCenter">
+        <item alignment="Qt::AlignmentFlag::AlignHCenter">
          <widget class="QLabel" name="lbFPS">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -263,7 +269,7 @@
         <item>
          <widget class="Line" name="line">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
          </widget>
         </item>
@@ -294,7 +300,7 @@
            <string>Bus Filtering:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
           </property>
          </widget>
         </item>
@@ -313,7 +319,7 @@
            </size>
           </property>
           <property name="flow">
-           <enum>QListView::LeftToRight</enum>
+           <enum>QListView::Flow::LeftToRight</enum>
           </property>
          </widget>
         </item>
@@ -323,7 +329,14 @@
            <string>Frame Filtering:</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="leSearchFilter">
+          <property name="placeholderText">
+           <string>Filter IDs…</string>
           </property>
          </widget>
         </item>
@@ -337,14 +350,8 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
-            <height>160</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>1000</width>
-            <height>16777215</height>
+            <width>0</width>
+            <height>80</height>
            </size>
           </property>
           <property name="alternatingRowColors">
@@ -368,11 +375,18 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QPushButton" name="btnClearHighlights">
+            <property name="text">
+             <string>Clear ★</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>
-      </item>
-     </layout>
+      </widget>
+     </widget>
     </item>
    </layout>
   </widget>
@@ -382,7 +396,7 @@
      <x>0</x>
      <y>0</y>
      <width>1177</width>
-     <height>26</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_RE_Tools">

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -446,6 +446,8 @@
     <addaction name="actionSave_Decoded_Frames"/>
     <addaction name="actionSave_Decoded_Frames_CSV"/>
     <addaction name="separator"/>
+    <addaction name="actionCrop_Log"/>
+    <addaction name="separator"/>
     <addaction name="actionPreferences"/>
     <addaction name="separator"/>
     <addaction name="actionExit_Application"/>
@@ -653,6 +655,11 @@
   <action name="actionCAN_Bridge">
    <property name="text">
     <string>CAN Bridge</string>
+   </property>
+  </action>
+  <action name="actionCrop_Log">
+   <property name="text">
+    <string>Crop Log to Frame Range</string>
    </property>
   </action>
  </widget>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -415,6 +415,7 @@
     <addaction name="actionCapture_Bisector"/>
     <addaction name="actionSignal_Viewer"/>
     <addaction name="actionTemporal_Graph"/>
+    <addaction name="actionFrame_Search"/>
    </widget>
    <widget class="QMenu" name="menuSend_Frames">
     <property name="title">
@@ -660,6 +661,11 @@
   <action name="actionCrop_Log">
    <property name="text">
     <string>Crop Log to Frame Range</string>
+   </property>
+  </action>
+  <action name="actionFrame_Search">
+   <property name="text">
+    <string>Frame Search</string>
    </property>
   </action>
  </widget>

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -267,6 +267,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="cbChangingOnly">
+          <property name="text">
+           <string>Changing Messages Only</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="Line" name="line">
           <property name="orientation">
            <enum>Qt::Orientation::Horizontal</enum>
@@ -307,16 +314,13 @@
         <item>
          <widget class="QListWidget" name="listBusFilters">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="maximumSize">
-           <size>
-            <width>175</width>
-            <height>40</height>
-           </size>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
           </property>
           <property name="flow">
            <enum>QListView::Flow::LeftToRight</enum>
@@ -383,6 +387,58 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelDirFilter">
+          <property name="text">
+           <string>Direction Filtering:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="listDirFilters">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="flow">
+           <enum>QListView::Flow::LeftToRight</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelLenFilter">
+          <property name="text">
+           <string>Length Filtering:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignmentFlag::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QListWidget" name="listLengthFilters">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="horizontalScrollBarPolicy">
+           <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+          </property>
+          <property name="flow">
+           <enum>QListView::Flow::LeftToRight</enum>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/ui/searchwindow.ui
+++ b/ui/searchwindow.ui
@@ -1,0 +1,463 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SearchWindow</class>
+ <widget class="QDialog" name="SearchWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>780</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>700</width>
+    <height>580</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Frame Search</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_main">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_top" stretch="3,1,2">
+     <!-- Left: search criteria + bitfield -->
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_left">
+       <item>
+        <widget class="QGroupBox" name="groupBoxCriteria">
+         <property name="title">
+          <string>Search Criteria</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_criteria">
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelID">
+            <property name="text">
+             <string>ID (hex):</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <layout class="QHBoxLayout" name="hboxID">
+            <item>
+             <widget class="QLineEdit" name="txtID">
+              <property name="placeholderText">
+               <string>e.g. 0x123 (leave empty for any)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbUseID">
+              <property name="text">
+               <string>Enable</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelLen">
+            <property name="text">
+             <string>Frame Length:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <layout class="QHBoxLayout" name="hboxLen">
+            <item>
+             <widget class="QSpinBox" name="spinFrameLen">
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>64</number>
+              </property>
+              <property name="value">
+               <number>8</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbUseLen">
+              <property name="text">
+               <string>Enable</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelDir">
+            <property name="text">
+             <string>Direction:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="hboxDir">
+            <item>
+             <widget class="QRadioButton" name="rbDirBoth">
+              <property name="text">
+               <string>Both</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="rbDirRX">
+              <property name="text">
+               <string>RX</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="rbDirTX">
+              <property name="text">
+               <string>TX</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxData">
+         <property name="title">
+          <string>Data Bit Selection</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_data">
+          <item>
+           <layout class="QFormLayout" name="formLayout_bits">
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelStartBit">
+              <property name="text">
+               <string>Start Bit:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtStartBit">
+              <property name="text">
+               <string>0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelDataLen">
+              <property name="text">
+               <string>Num Bits:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="txtDataLen">
+              <property name="text">
+               <string>8</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="labelBitOrder">
+              <property name="text">
+               <string>Byte Order:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <layout class="QHBoxLayout" name="hboxByteOrder">
+              <item>
+               <widget class="QCheckBox" name="cbIntel">
+                <property name="text">
+                 <string>Intel (LE)</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="cbSigned">
+                <property name="text">
+                 <string>Signed</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelScale">
+              <property name="text">
+               <string>Scale:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLineEdit" name="txtScale">
+              <property name="text">
+               <string>1.0</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelBias">
+              <property name="text">
+               <string>Bias:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="txtBias">
+              <property name="text">
+               <string>0.0</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="CANDataGrid" name="gridData" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>240</width>
+              <height>240</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxValue">
+         <property name="title">
+          <string>Value Filter</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_value">
+          <item>
+           <layout class="QHBoxLayout" name="hboxValueMode">
+            <item>
+             <widget class="QRadioButton" name="rbValueAny">
+              <property name="text">
+               <string>Any change</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="rbValueSpecific">
+              <property name="text">
+               <string>Specific value</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QFormLayout" name="formLayout_value">
+            <item row="0" column="0">
+             <widget class="QLabel" name="labelValue">
+              <property name="text">
+               <string>Value:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="txtValue">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="placeholderText">
+               <string>Enter value to match</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <!-- Vertical divider -->
+     <item>
+      <widget class="Line" name="lineDivider">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <!-- Right: DBC signal picker -->
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_right">
+       <item>
+        <widget class="QLabel" name="labelDBCHdr">
+         <property name="text">
+          <string>Search a DBC Signal:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelNode">
+         <property name="text">
+          <string>Node:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cbNodes"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelMessage">
+         <property name="text">
+          <string>Message:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cbMessages"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelSignal">
+         <property name="text">
+          <string>Signal:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cbSignals"/>
+       </item>
+       <item>
+        <widget class="QPushButton" name="btnCopySignal">
+         <property name="text">
+          <string>Copy Signal Parameters</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblSignalStatus">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="spacerRight">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <!-- Horizontal divider -->
+   <item>
+    <widget class="Line" name="lineHDivider">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <!-- Bottom: search controls + results -->
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
+     <item>
+      <widget class="QPushButton" name="btnSearch">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnPrev">
+       <property name="text">
+        <string>◀ Previous</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnNext">
+       <property name="text">
+        <string>Next ▶</string>
+       </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblMatchInfo">
+       <property name="text">
+        <string>No search performed.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="spacerBottom">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CANDataGrid</class>
+   <extends>QWidget</extends>
+   <header>candatagrid.h</header>
+   <container>0</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/ui/searchwindow.ui
+++ b/ui/searchwindow.ui
@@ -21,8 +21,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_main">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_top" stretch="3,1,2">
-     <!-- Left: search criteria + bitfield -->
+    <layout class="QHBoxLayout" name="horizontalLayout_top">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_left">
        <item>
@@ -247,12 +246,19 @@
           <item>
            <layout class="QHBoxLayout" name="hboxValueMode">
             <item>
-             <widget class="QRadioButton" name="rbValueAny">
+             <widget class="QRadioButton" name="rbValueNone">
               <property name="text">
-               <string>Any change</string>
+               <string>No filter</string>
               </property>
               <property name="checked">
                <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="rbValueAny">
+              <property name="text">
+               <string>Any change</string>
               </property>
              </widget>
             </item>
@@ -291,7 +297,6 @@
        </item>
       </layout>
      </item>
-     <!-- Vertical divider -->
      <item>
       <widget class="Line" name="lineDivider">
        <property name="orientation">
@@ -299,7 +304,6 @@
        </property>
       </widget>
      </item>
-     <!-- Right: DBC signal picker -->
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_right">
        <item>
@@ -388,7 +392,6 @@
      </item>
     </layout>
    </item>
-   <!-- Horizontal divider -->
    <item>
     <widget class="Line" name="lineHDivider">
      <property name="orientation">
@@ -396,7 +399,6 @@
      </property>
     </widget>
    </item>
-   <!-- Bottom: search controls + results -->
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_bottom">
      <item>
@@ -409,7 +411,7 @@
      <item>
       <widget class="QPushButton" name="btnPrev">
        <property name="text">
-        <string>◀ Previous</string>
+        <string>&lt; Previous</string>
        </property>
        <property name="enabled">
         <bool>false</bool>
@@ -419,7 +421,7 @@
      <item>
       <widget class="QPushButton" name="btnNext">
        <property name="text">
-        <string>Next ▶</string>
+        <string>Next &gt;</string>
        </property>
        <property name="enabled">
         <bool>false</bool>


### PR DESCRIPTION
This PR combines several focused commits that improve filtering, layout flexibility, and usability in the main window.

---

## Commit 1: 326c80c — Add ID search filter box to filter panel

**What this commit adds:**
- A search field above the filter list for CAN ID filtering.
- Real-time filtering of the main frame table based on typed hex ID fragments.
- Real-time filtering of filter-list entries so non-matching items are hidden.
- Small UI adjustment to allow a narrower filter panel.

**User impact:**
- Faster isolation of relevant frames during high-traffic captures.
- Immediate feedback while typing, with no restart required.

---

## Commit 2: d8c3836 — Fix search filter bar not filtering frame table

**What this commit fixes:**
- Previously, `m_searchFilter` was only checked during a full `sendRefresh()` rebuild, so the search bar had no effect on the live frame table during capture or in overwrite mode.
- Applies the hex ID filter in all code paths that populate `filteredFrames`: `addFrame()` (normal and overwrite), and `recalcOverwrite()`.

**User impact:**
- The filter bar now correctly hides non-matching frames during live capture and in overwrite mode, not just after a manual refresh.

---

## Commit 3: f870e35 — Add resizable main splitters and toggle for simple send panel

**What this commit adds:**
- Replaces the fixed main layout with nested splitters.
- Persists and restores splitter sizes via QSettings.
- Adds a settings checkbox to show or hide the simple send panel.
- Applies panel visibility changes immediately at runtime, without restart.

**User impact:**
- Better control of screen space on different monitor sizes.
- Layout preferences are remembered across app launches.
- Cleaner workflow for users who want to hide the simple send panel.

---

## Commit 4: ec2817e — Fix splitterLeft default size and save/restore on restart

**What this commit fixes:**
- `splitterLeft` size restore in `readSettings()` ran before `insertWidget()` reorganized the widget hierarchy, so Qt fell back to a 50/50 split and ignored saved sizes.
- Defers the restore/default logic via `QTimer::singleShot(0)` so it runs after the window has real geometry and the final layout is in place.
- Default split is now 75 % frame table / 25 % send panel.
- Moves `splitterLeft` save outside the `SaveRestorePositions` guard so the send-panel height is always persisted and correctly restored on the next launch.

**User impact:**
- Splitter position is now reliably saved and restored across restarts.

---

## Commit 5: 36c85da — canframemodel: add Column::DataDec to sort switch

**What this commit adds:**
- Adds the `DataDec` column to the sort switch in `CommFrameModel`, enabling correct sorting of the decimal data column.

---

## Commit 6: 6e49b7d — Add crop log to frame range feature

**What this commit adds:**
- Allows cropping the loaded frame log to a user-defined start/end frame range directly from the main window, discarding frames outside the range.

**User impact:**
- Faster analysis by trimming captures to only the relevant section without needing an external tool.

---

## Commit 7: 3aeb50b — Add batch ID filter toggle (Space key) and setFilterStatesBatch

**What this commit adds:**
- Multi-select support in the ID filter list: selecting multiple entries and pressing Space toggles all of them on/off in a single operation.
- New `CommFrameModel::setFilterStatesBatch()` method that applies multiple filter-state changes with a single `sendRefresh()` call, avoiding repeated redraws.

**User impact:**
- Quickly enable or disable a group of CAN IDs in the filter list without clicking each one individually.

---

## Commit 8: 5c3a14f — Add Frame Search window

**What this commit adds:**
- A dedicated Frame Search dialog (RE Tools → Frame Search) for searching frames by ID, length, direction, and signal value.
- Interactive bit-field picker (CANDataGrid) with Intel/Motorola byte-order support.
- DBC signal picker (Node → Message → Signal) with a "Copy Signal Parameters" shortcut.
- Value filter modes: any change, or a specific value match with scale/bias decoding.
- Previous/Next navigation that jumps the main frame table to each matching frame.

**User impact:**
- Efficiently hunt for specific signal transitions or values across large captures without manually scrolling the frame table.

---

## Commit 9: 7726684 — Search window: fix filtered-table search, 64-bit precision, manual bits, no-value filter

**What this commit fixes/adds:**
- **Filtered-table search**: search now operates on `filteredFrames` (the currently visible rows) so results and navigation correctly reflect the active ID/length/direction filters.
- **64-bit precision**: "any change" detection now uses exact `int64_t` comparison instead of lossy `double` conversion, preventing missed changes in signals wider than 53 bits.
- **Manual bit edit clears DBC signal**: editing the start bit or data length manually now clears the previously loaded DBC signal association, avoiding silent mismatches.
- **No-value filter mode**: adds a "No filter" radio button that matches every frame passing the ID/length/direction filters, regardless of payload content.
- Stale search results are automatically cleared when the active filter set changes.

**User impact:**
- Search results are always consistent with what is visible in the frame table.
- No silent precision bugs for wide signals.
- Simpler workflow when you only need to find frames by ID/direction without caring about payload values.