### PR TITLE
Add explicit extended frame flag to DBC message editor

### DIFF
--- a/dbc/dbc_classes.cpp
+++ b/dbc/dbc_classes.cpp
@@ -7,6 +7,7 @@ DBC_MESSAGE::DBC_MESSAGE()
 {
     sigHandler = new DBCSignalHandler;
     ID = 0;
+    extendedID = false;
     len = 0;
     multiplexorSignal = nullptr;
     sender = nullptr;

--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -500,7 +500,8 @@ DBC_MESSAGE* DBCFile::parseMessageLine(QString line)
         msgPtr = new DBC_MESSAGE();
         uint32_t ID = match.captured(1).toULong(); //the ID is always stored in decimal format
         msgPtr->ID = ID & 0x1FFFFFFFul;
-        msgPtr->extendedID = (ID & 0x80000000ul) ? true : false;
+        // BO_ encodes extended frame information in bit 31.
+        msgPtr->extendedID = ((ID & 0x80000000ul) != 0);
         msgPtr->name = match.captured(2);
         msgPtr->len = match.captured(3).toUInt();
         msgPtr->sender = findNodeByName(match.captured(4));

--- a/dbc/dbcmessageeditor.cpp
+++ b/dbc/dbcmessageeditor.cpp
@@ -7,6 +7,8 @@
 #include "helpwindow.h"
 #include "utility.h"
 
+#include <QCheckBox>
+
 DBCMessageEditor::DBCMessageEditor(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::DBCMessageEditor)
@@ -37,8 +39,11 @@ DBCMessageEditor::DBCMessageEditor(QWidget *parent) :
             if ((dbcMessage->ID & 0x1FFFFFFFul) != Utility::ParseStringToNum(ui->lineFrameID->text())) dbcFile->setDirtyFlag();
             dbcMessage->ID = Utility::ParseStringToNum(ui->lineFrameID->text());
 
-            if (dbcMessage->ID > 0x7FF) dbcMessage->extendedID = true;
-            else dbcMessage->extendedID = false;
+            // Auto-enable extended for IDs that exceed standard 11-bit range.
+            if (dbcMessage->ID > 0x7FF && ui->checkExtended)
+            {
+                ui->checkExtended->setChecked(true);
+            }
 
             emit updatedTreeInfo(dbcMessage, origID);
         });
@@ -60,6 +65,17 @@ DBCMessageEditor::DBCMessageEditor(QWidget *parent) :
             if (suppressEditCallbacks) return;
             if (dbcMessage->len != Utility::ParseStringToNum(ui->lineFrameLen->text())) dbcFile->setDirtyFlag();
             dbcMessage->len = Utility::ParseStringToNum(ui->lineFrameLen->text());
+            emit updatedTreeInfo(dbcMessage, origID);
+        });
+
+    connect(ui->checkExtended, &QCheckBox::toggled,
+        [=](bool checked)
+        {
+            if (dbcMessage == nullptr) return;
+            if (suppressEditCallbacks) return;
+            if (dbcMessage->extendedID != checked) dbcFile->setDirtyFlag();
+            dbcMessage->extendedID = checked;
+            emit updatedTreeInfo(dbcMessage, origID);
         });
 
     connect(ui->comboSender, &QComboBox::currentTextChanged,
@@ -211,6 +227,8 @@ void DBCMessageEditor::setMessageRef(DBC_MESSAGE *msg)
 {
     dbcMessage = msg;
     origID = msg->ID;
+    if (ui->checkExtended)
+        ui->checkExtended->setChecked(dbcMessage->extendedID);
 }
 
 void DBCMessageEditor::showEvent(QShowEvent* event)
@@ -222,12 +240,17 @@ void DBCMessageEditor::showEvent(QShowEvent* event)
 
 void DBCMessageEditor::refreshView()
 {
+    if (!dbcMessage) return;
+
     suppressEditCallbacks = true;
 
     ui->lineComment->setText(dbcMessage->comment);
     ui->lineFrameID->setText(Utility::formatCANID(dbcMessage->ID & 0x1FFFFFFFul));
     ui->lineMsgName->setText(dbcMessage->name);
-    ui->lineFrameLen->setText(QString::number(dbcMessage->len));    
+    ui->lineFrameLen->setText(QString::number(dbcMessage->len));
+    if (ui->checkExtended)
+        ui->checkExtended->setChecked(dbcMessage->extendedID);
+
     for (int i = 0; i < ui->comboSender->count(); i++)
     {
         if (ui->comboSender->itemText(i) == dbcMessage->sender->name)

--- a/ui/dbcmessageeditor.ui
+++ b/ui/dbcmessageeditor.ui
@@ -67,7 +67,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+    <item row="4" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Text Color:</string>

--- a/ui/dbcmessageeditor.ui
+++ b/ui/dbcmessageeditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>311</width>
+    <width>460</width>
     <height>371</height>
    </rect>
   </property>
@@ -26,72 +26,100 @@
      <item row="0" column="1">
       <widget class="QLineEdit" name="lineFrameID"/>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="lineMsgName"/>
+    <item row="2" column="1">
+      <widget class="QLineEdit" name="lineMsgName">
+       <property name="minimumSize">
+        <size>
+           <width>390</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
      </item>
-     <item row="1" column="0">
+    <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>Message Name:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+    <item row="3" column="1">
       <widget class="QLineEdit" name="lineFrameLen"/>
      </item>
-     <item row="2" column="0">
+    <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Frame Length:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+    <item row="1" column="0">
+      <widget class="QLabel" name="label_extended">
+       <property name="text">
+        <string>Frame Type:</string>
+       </property>
+      </widget>
+     </item>
+    <item row="1" column="1">
+      <widget class="QCheckBox" name="checkExtended">
+       <property name="text">
+        <string>Extended</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Text Color:</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+   <item row="5" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
         <string>Background Color:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+   <item row="7" column="0">
       <widget class="QLabel" name="label_8">
        <property name="text">
         <string>Comments:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QLineEdit" name="lineComment"/>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="lineComment">
+     <property name="minimumSize">
+      <size>
+         <width>390</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
      </item>
-     <item row="5" column="0">
+   <item row="6" column="0">
       <widget class="QLabel" name="label_9">
        <property name="text">
         <string>Sending Node:</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+   <item row="6" column="1">
       <widget class="QComboBox" name="comboSender">
        <property name="editable">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+   <item row="4" column="1">
       <widget class="QPushButton" name="btnTextColor">
        <property name="text">
         <string>Set</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+   <item row="5" column="1">
       <widget class="QPushButton" name="btnBackgroundColor">
        <property name="text">
         <string>Set</string>


### PR DESCRIPTION
- Added Extended checkbox in message editor UI for manual extended flag control
- Extended checkbox auto-checks when ID exceeds 11-bit range (0x7FF)
- Restored BO_ bit31 parsing to properly load extended flag from DBC files
- Initialize extendedID to false in message constructor for deterministic state
- Widened message name and comment fields in editor (390px minimum width)
- Decoding and encoding now use explicit extended flag, not inferred from ID
- Allows proper distinction: 0x100 (standard) vs 0x00000100 (extended) IDs