### PR TITLE
SavvyCAN.pro: fix linking errors.

### DIFF
--- a/SavvyCAN.pro
+++ b/SavvyCAN.pro
@@ -105,7 +105,8 @@ SOURCES += main.cpp\
     connections/newconnectiondialog.cpp \
     re/temporalgraphwindow.cpp \
     filterutility.cpp \
-    pcaplite.cpp
+    pcaplite.cpp \
+    bus_protocols/handler_factory.cpp
 
 HEADERS  += mainwindow.h \
     can_structs.h \
@@ -201,7 +202,8 @@ HEADERS  += mainwindow.h \
     connections/newconnectiondialog.h \
     re/temporalgraphwindow.h \
     filterutility.h \
-    pcaplite.h
+    pcaplite.h \
+    bus_protocols/handler_factory.h
 
 FORMS    += ui/candatagrid.ui \
     triggerdialog.ui \


### PR DESCRIPTION
Could you have a look.. fixes for me this:


/usr/bin/ld: scriptcontainer.o: in function `ISOTPScriptHelper::ISOTPScriptHelper(QJSEngine*)':
scriptcontainer.cpp:(.text+0x1bb): undefined reference to `HandlerFactory::createISOTPHandler()'
/usr/bin/ld: scriptcontainer.o: in function `UDSScriptHelper::UDSScriptHelper(QJSEngine*)':
scriptcontainer.cpp:(.text+0x356): undefined reference to `HandlerFactory::createUDSHandler()'
/usr/bin/ld: isotp_interpreterwindow.o: in function `ISOTP_InterpreterWindow::ISOTP_InterpreterWindow(QList<CommFrame> const*, QWidget*)':
isotp_interpreterwindow.cpp:(.text+0x1464): undefined reference to `HandlerFactory::createISOTPHandler()'
/usr/bin/ld: isotp_interpreterwindow.cpp:(.text+0x146d): undefined reference to `HandlerFactory::createUDSHandler()'
/usr/bin/ld: udsscanwindow.o: in function `UDSScanWindow::UDSScanWindow(QList<CommFrame> const*, QWidget*)':
udsscanwindow.cpp:(.text+0x19bf): undefined reference to `HandlerFactory::createUDSHandler()'
collect2: error: ld returned 1 exit status