### PR TITLE
serialbus: create connection timer in worker thread

### DIFF
--- a/connections/serialbusconnection.cpp
+++ b/connections/serialbusconnection.cpp
@@ -13,7 +13,7 @@
 
 SerialBusConnection::SerialBusConnection(QString portName, QString driverName, int pBusSpeed, int pDataRate, bool pCanFd) :
     CANConnection(portName, driverName, CANCon::SERIALBUS,0 ,pBusSpeed, pCanFd, pDataRate ,1, 4000, true),
-    mTimer(this) /*NB: set connection as parent of timer to manage it from working thread */
+    mTimer(nullptr) /*NB: set connection as parent of timer to manage it from working thread */
 {
 }
 
@@ -42,10 +42,14 @@ void SerialBusConnection::piStarted()
     connect(mDev_p, &QCanBusDevice::framesWritten, this, &SerialBusConnection::framesWritten);
     connect(mDev_p, &QCanBusDevice::framesReceived, this, &SerialBusConnection::framesReceived);
 
-    connect(&mTimer, SIGNAL(timeout()), this, SLOT(testConnection()));
-    mTimer.setInterval(1000);
-    mTimer.setSingleShot(false); //keep ticking
-    mTimer.start();
+    if (!mTimer) {
+        mTimer = new QTimer(this);
+        connect(mTimer, SIGNAL(timeout()), this, SLOT(testConnection()));
+    }
+
+    mTimer->setInterval(1000);
+    mTimer->setSingleShot(false); //keep ticking
+    mTimer->start();
     mBusData[0].mBus.setActive(true);
     mBusData[0].mBus.setCanFD(false);
     mBusData[0].mConfigured = true;
@@ -63,9 +67,13 @@ void SerialBusConnection::piSuspend(bool pSuspend)
 }
 
 
-void SerialBusConnection::piStop() {
+void SerialBusConnection::piStop()
+{
     qDebug() << "piStop()";
-    mTimer.stop();
+
+    if (mTimer)
+        mTimer->stop();
+
     disconnectDevice();
 }
 

--- a/connections/serialbusconnection.h
+++ b/connections/serialbusconnection.h
@@ -50,7 +50,7 @@ private slots:
 
 protected:
     QCanBusDevice     *mDev_p = nullptr;
-    QTimer             mTimer;
+    QTimer            *mTimer;
 };
 
 


### PR DESCRIPTION
Please review 

This fixes for me the following:

QObject: Cannot create children for a parent that is in a different thread.
(Parent is SerialBusConnection(0xf5738b0), parent's thread is QThread(0xf5c6cd0), current thread is QThread(0xee624e0)
QObject::startTimer: Timers cannot be started from another thread


Otherwise, no serial connection establishes / works - e.g. my case, passthrucan .  If warnings as critical enabled, qt will abort and app dumps core. 

With the change, i can use passthrucan and it loads my j2534.so.