### PR TITLE
Improve frame info window: timestamps, x-axis range, and per-byte-graph controls

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -9,6 +9,11 @@
 #include <QSettings>
 #include "utility.h"
 
+static inline qint64 frameTimestampMicros(const CANFrame &frame)
+{
+    return (frame.timeStamp().seconds() * 1000000ll) + frame.timeStamp().microSeconds();
+}
+
 CANFrameModel::~CANFrameModel()
 {
     frames.clear();
@@ -171,29 +176,31 @@ void CANFrameModel::normalizeTiming()
         mutex.unlock();
         return;
     }
-    timeOffset = frames[0].timeStamp().microSeconds();
+    timeOffset = frameTimestampMicros(frames[0]);
     qint64 prevStamp = 0;
 
     //find the absolute lowest timestamp in the whole time. Needed because maybe timestamp was reset in the middle.
     for (int j = 0; j < frames.count(); j++)
     {
-        if (frames[j].timeStamp().microSeconds() < timeOffset) timeOffset = frames[j].timeStamp().microSeconds();
+        const qint64 thisStamp = frameTimestampMicros(frames[j]);
+        if (thisStamp < timeOffset) timeOffset = thisStamp;
     }
 
     for (int i = 0; i < frames.count(); i++)
     {
-        qint64 thisStamp = frames[i].timeStamp().microSeconds() - timeOffset;
+        qint64 thisStamp = frameTimestampMicros(frames[i]) - timeOffset;
         if (thisStamp <= prevStamp)
         {
             timeOffset -= prevStamp;
         }
         frames[i].setTimeStamp(QCanBusFrame::TimeStamp(0, thisStamp));
+        prevStamp = thisStamp;
     }
 
     this->beginResetModel();
     for (int i = 0; i < filteredFrames.count(); i++)
     {
-        filteredFrames[i].setTimeStamp(QCanBusFrame::TimeStamp(0, filteredFrames[i].timeStamp().microSeconds() - timeOffset));
+        filteredFrames[i].setTimeStamp(QCanBusFrame::TimeStamp(0, frameTimestampMicros(filteredFrames[i]) - timeOffset));
     }
     this->endResetModel();
 
@@ -251,7 +258,7 @@ uint64_t CANFrameModel::getCANFrameVal(QVector<CANFrame> *frames, int row, Colum
     {
     case Column::TimeStamp:
         if (overwriteDups) return frame.timedelta;
-        return frame.timeStamp().microSeconds();
+        return frameTimestampMicros(frame);
     case Column::FrameId:
         return frame.frameId();
     case Column::Extended:
@@ -383,7 +390,7 @@ void CANFrameModel::recalcOverwrite()
             }
             else
             {
-                frame.timedelta = frame.timeStamp().microSeconds() - overWriteFrames[idAugmented].timeStamp().microSeconds();
+                frame.timedelta = frameTimestampMicros(frame) - frameTimestampMicros(overWriteFrames[idAugmented]);
                 frame.frameCount = overWriteFrames[idAugmented].frameCount + 1;
                 overWriteFrames[idAugmented] = frame;
             }
@@ -492,11 +499,11 @@ QVariant CANFrameModel::data(const QModelIndex &index, int role) const
                 if (timeStyle == TS_SECONDS) return QString::number(thisFrame.timedelta / 1000000.0, 'f', 5);
                 return QString::number(thisFrame.timedelta);
             }
-            else ts = Utility::formatTimestamp(thisFrame.timeStamp().microSeconds());
+            else ts = Utility::formatTimestamp(frameTimestampMicros(thisFrame));
             if (ts.type() == QVariant::Double) return QString::number(ts.toDouble(), 'f', 5); //never scientific notation, 5 decimal places
             if (ts.type() == QVariant::LongLong) return QString::number(ts.toLongLong()); //never scientific notion, all digits shown
             if (ts.type() == QVariant::DateTime) return ts.toDateTime().toString(timeFormat); //custom set format for dates and times
-            return Utility::formatTimestamp(thisFrame.timeStamp().microSeconds());
+            return Utility::formatTimestamp(frameTimestampMicros(thisFrame));
         case Column::FrameId:
             return Utility::formatCANID(thisFrame.frameId(), thisFrame.hasExtendedFrameFormat());
         case Column::Extended:
@@ -679,7 +686,7 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
     CANFrame tempFrame;
     tempFrame = frame;
 
-    tempFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, tempFrame.timeStamp().microSeconds() - timeOffset));
+    tempFrame.setTimeStamp(QCanBusFrame::TimeStamp(0, frameTimestampMicros(tempFrame) - timeOffset));
 
     lastUpdateNumFrames++;
 
@@ -743,7 +750,7 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
             if ( (filteredFrames[i].frameId() == tempFrame.frameId()) && (filteredFrames[i].bus == tempFrame.bus) )
             {
                 tempFrame.frameCount = filteredFrames[i].frameCount + 1;
-                tempFrame.timedelta = tempFrame.timeStamp().microSeconds() - filteredFrames[i].timeStamp().microSeconds();
+                tempFrame.timedelta = frameTimestampMicros(tempFrame) - frameTimestampMicros(filteredFrames[i]);
                 filteredFrames.replace(i, tempFrame);
                 found = true;
                 break;
@@ -938,7 +945,7 @@ int CANFrameModel::getIndexFromTimeID(unsigned int ID, double timestamp)
     {
         if ((frames[i].frameId() == ID))
         {
-            if (frames[i].timeStamp().microSeconds() <= intTimeStamp) bestIndex = i;
+            if (frameTimestampMicros(frames[i]) <= intTimeStamp) bestIndex = i;
             else break; //drop out of loop as soon as we pass the proper timestamp
         }
     }

--- a/re/frameinfowindow.cpp
+++ b/re/frameinfowindow.cpp
@@ -4,6 +4,7 @@
 #include "helpwindow.h"
 #include <QtDebug>
 #include <vector>
+#include <limits>
 #include "filterutility.h"
 #include "qcpaxistickerhex.h"
 
@@ -41,8 +42,27 @@ FrameInfoWindow::FrameInfoWindow(const QVector<CANFrame> *frames, QWidget *paren
     {
         graphByte[i] = new QCustomPlot();
         setupByteGraph(graphByte[i], i);
+
+        btnResetByteGraph[i] = new QPushButton(QString(QChar(0x2302)), graphByte[i]);
+        btnResetByteGraph[i]->setFixedSize(26, 22);
+        btnResetByteGraph[i]->setToolTip(tr("Reset axis scaling"));
+        connect(btnResetByteGraph[i], &QPushButton::clicked, [this, i]() { resetByteGraph(i); });
+
+        btnTogglePlotType[i] = new QPushButton(QString(QChar(0x2500)), graphByte[i]); // "─" = line mode
+        btnTogglePlotType[i]->setFixedSize(26, 22);
+        btnTogglePlotType[i]->setCheckable(true);
+        btnTogglePlotType[i]->setToolTip(tr("Toggle line / scatter plot"));
+        connect(btnTogglePlotType[i], &QPushButton::clicked, [this, i](bool checked) { togglePlotType(i, checked); });
+
+        graphByte[i]->installEventFilter(this);
         ui->gridLower->addWidget(graphByte[i], i / 4, i & 3);
     }
+
+    ui->btnResetAllByteGraphs->setText(QString(QChar(0x2302)));
+    connect(ui->btnResetAllByteGraphs, &QPushButton::clicked, this, &FrameInfoWindow::resetAllByteGraphs);
+
+    ui->btnToggleAllPlotType->setText(QString(QChar(0x2500)));
+    connect(ui->btnToggleAllPlotType, &QPushButton::clicked, this, &FrameInfoWindow::toggleAllPlotType);
 
     ui->gridUpper->addWidget(new QLabel("Heatmap"), 0, 0);
     heatmap = new CANDataGrid();
@@ -143,7 +163,28 @@ void FrameInfoWindow::setupByteGraph(QCustomPlot *plot, int num)
     }
     //plot->axisRect()->setupFullAxesBox();
 
-    plot->xAxis->setLabel("Time [" + QString::number(num) + "]");
+    if (timeStyle == TS_CLOCK)
+    {
+        QSharedPointer<QCPAxisTickerDateTime> dateTicker(new QCPAxisTickerDateTime);
+        dateTicker->setDateTimeFormat(Utility::timeFormat);
+        plot->xAxis->setTicker(dateTicker);
+        plot->xAxis->setLabel("Timestamp [" + QString::number(num) + "]");
+    }
+    else if (timeStyle == TS_SECONDS)
+    {
+        QSharedPointer<QCPAxisTickerTime> timeTicker(new QCPAxisTickerTime);
+        timeTicker->setTimeFormat("%h:%m:%s");
+        plot->xAxis->setTicker(timeTicker);
+        plot->xAxis->setLabel("Time [s] [" + QString::number(num) + "]");
+    }
+    else if (timeStyle == TS_MILLIS)
+    {
+        plot->xAxis->setLabel("Time [ms] [" + QString::number(num) + "]");
+    }
+    else
+    {
+        plot->xAxis->setLabel("Time [s] [" + QString::number(num) + "]");
+    }
     //if (useHexTicker) plot->yAxis->setLabel("Value (HEX)");
     //else plot->yAxis->setLabel("Value (Dec)");
     plot->yAxis->setLabel("");
@@ -242,6 +283,23 @@ void FrameInfoWindow::showEvent(QShowEvent* event)
 
 bool FrameInfoWindow::eventFilter(QObject *obj, QEvent *event)
 {
+    if (event->type() == QEvent::Resize)
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            if (obj == graphByte[i])
+            {
+                int btnW = btnResetByteGraph[i]->width();
+                int btnH = btnResetByteGraph[i]->height();
+                int y = graphByte[i]->height() - btnH;
+                btnResetByteGraph[i]->move(0, y);
+                btnResetByteGraph[i]->raise();
+                btnTogglePlotType[i]->move(btnW, y);
+                btnTogglePlotType[i]->raise();
+                return false;
+            }
+        }
+    }
     if (event->type() == QEvent::KeyRelease) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         switch (keyEvent->key())
@@ -251,10 +309,8 @@ bool FrameInfoWindow::eventFilter(QObject *obj, QEvent *event)
             break;
         }
         return true;
-    } else {
-        // standard event processing
-        return QObject::eventFilter(obj, event);
     }
+    return QObject::eventFilter(obj, event);
 }
 
 FrameInfoWindow::~FrameInfoWindow()
@@ -289,6 +345,11 @@ void FrameInfoWindow::readSettings()
         move(Utility::constrainedWindowPos(settings.value("FrameInfo/WindowPos", QPoint(50, 50)).toPoint()));
     }
     useOpenGL = settings.value("Main/UseOpenGL", false).toBool();
+    timeStyle = TS_MICROS;
+    if (settings.value("Main/TimeSeconds", false).toBool()) timeStyle = TS_SECONDS;
+    if (settings.value("Main/TimeMillis", false).toBool()) timeStyle = TS_MILLIS;
+    if (settings.value("Main/TimeClock", false).toBool()) timeStyle = TS_CLOCK;
+    Utility::timeFormat = settings.value("Main/TimeFormat", "MMM-dd HH:mm:ss.zzz").toString();
     useHexTicker = settings.value("InfoCompare/GraphHex", false).toBool();
 }
 
@@ -300,6 +361,74 @@ void FrameInfoWindow::writeSettings()
     {
         settings.setValue("FrameInfo/WindowSize", size());
         settings.setValue("FrameInfo/WindowPos", pos());
+    }
+}
+
+void FrameInfoWindow::captureXRange(double &xmin, double &xmax)
+{
+    xmin = 0.0;
+    xmax = 1.0;
+    if (modelFrames->isEmpty()) return;
+
+    int64_t minTs = std::numeric_limits<int64_t>::max();
+    int64_t maxTs = std::numeric_limits<int64_t>::lowest();
+    for (const CANFrame &f : *modelFrames)
+    {
+        const int64_t ts = f.timeStamp().seconds() * 1000000ll + f.timeStamp().microSeconds();
+        if (ts < minTs) minTs = ts;
+        if (ts > maxTs) maxTs = ts;
+    }
+    xmin = (timeStyle == TS_MILLIS) ? minTs / 1000.0 : minTs / 1000000.0;
+    xmax = (timeStyle == TS_MILLIS) ? maxTs / 1000.0 : maxTs / 1000000.0;
+    if (xmin == xmax) xmax = xmin + 1.0;
+}
+
+void FrameInfoWindow::resetByteGraph(int idx)
+{
+    double xmin, xmax;
+    captureXRange(xmin, xmax);
+    graphByte[idx]->xAxis->setRange(xmin, xmax);
+    graphByte[idx]->yAxis->setRange(0, 265);
+    graphByte[idx]->replot();
+}
+
+void FrameInfoWindow::resetAllByteGraphs()
+{
+    double xmin, xmax;
+    captureXRange(xmin, xmax);
+    for (int i = 0; i < 8; i++)
+    {
+        graphByte[i]->xAxis->setRange(xmin, xmax);
+        graphByte[i]->yAxis->setRange(0, 265);
+        graphByte[i]->replot();
+    }
+}
+
+void FrameInfoWindow::togglePlotType(int idx, bool scatter)
+{
+    if (!graphRef[idx]) return;
+    if (scatter)
+    {
+        graphRef[idx]->setLineStyle(QCPGraph::lsNone);
+        graphRef[idx]->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssDisc, 4));
+        btnTogglePlotType[idx]->setText(QString(QChar(0x25CF))); // "●" = scatter mode
+    }
+    else
+    {
+        graphRef[idx]->setLineStyle(QCPGraph::lsLine);
+        graphRef[idx]->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssNone));
+        btnTogglePlotType[idx]->setText(QString(QChar(0x2500))); // "─" = line mode
+    }
+    graphByte[idx]->replot();
+}
+
+void FrameInfoWindow::toggleAllPlotType(bool scatter)
+{
+    ui->btnToggleAllPlotType->setText(scatter ? QString(QChar(0x25CF)) : QString(QChar(0x2500)));
+    for (int i = 0; i < 8; i++)
+    {
+        btnTogglePlotType[i]->setChecked(scatter);
+        togglePlotType(i, scatter);
     }
 }
 
@@ -550,7 +679,21 @@ void FrameInfoWindow::updateDetailsWindow(QString newID)
             data = reinterpret_cast<const unsigned char *>(frameCache.at(j).payload().constData());
             dataLen = frameCache.at(j).payload().length();
 
-            byteGraphX.append(j);
+            const int64_t thisTimestamp = frameCache.at(j).timeStamp().seconds() * 1000000ll + frameCache.at(j).timeStamp().microSeconds();
+            switch (timeStyle)
+            {
+            case TS_CLOCK:
+            case TS_SECONDS:
+                byteGraphX.append(thisTimestamp / 1000000.0);
+                break;
+            case TS_MILLIS:
+                byteGraphX.append(thisTimestamp / 1000.0);
+                break;
+            case TS_MICROS:
+            default:
+                byteGraphX.append(thisTimestamp / 1000000.0);
+                break;
+            }
             for (int bytcnt = 0; bytcnt < dataLen; bytcnt++)
             {
                 byteGraphY[bytcnt].append(data[bytcnt]);
@@ -560,10 +703,11 @@ void FrameInfoWindow::updateDetailsWindow(QString newID)
             {
                 //TODO - we try the interval whichever way doesn't go negative. But, we should probably sort the frame list before
                 //starting so that the intervals are all correct.
-                if (frameCache[j].timeStamp().microSeconds() > frameCache[j-1].timeStamp().microSeconds())
-                    thisInterval = (frameCache[j].timeStamp().microSeconds() - frameCache[j-1].timeStamp().microSeconds());
+                const int64_t prevTimestamp = frameCache[j-1].timeStamp().seconds() * 1000000ll + frameCache[j-1].timeStamp().microSeconds();
+                if (thisTimestamp > prevTimestamp)
+                    thisInterval = (thisTimestamp - prevTimestamp);
                 else
-                    thisInterval = (frameCache[j-1].timeStamp().microSeconds() - frameCache[j].timeStamp().microSeconds());
+                    thisInterval = (prevTimestamp - thisTimestamp);
 
                 sortedIntervals.push_back(thisInterval);
                 intervalSum += thisInterval;
@@ -803,13 +947,21 @@ void FrameInfoWindow::updateDetailsWindow(QString newID)
         graphHistogram->axisRect()->setupFullAxesBox();
         graphHistogram->replot();
 
+        double xRangeMin, xRangeMax;
+        captureXRange(xRangeMin, xRangeMax);
+
         for (int graphs = 0; graphs < 8; graphs++)
         {
             graphByte[graphs]->clearGraphs();
             graphRef[graphs] = graphByte[graphs]->addGraph();
             graphByte[graphs]->graph()->setData(byteGraphX, byteGraphY[graphs]);
             graphByte[graphs]->graph()->setPen(bytePens[graphs]);
-            graphByte[graphs]->xAxis->setRange(0, byteGraphX.count());
+            if (btnTogglePlotType[graphs]->isChecked())
+            {
+                graphRef[graphs]->setLineStyle(QCPGraph::lsNone);
+                graphRef[graphs]->setScatterStyle(QCPScatterStyle(QCPScatterStyle::ssDisc, 4));
+            }
+            graphByte[graphs]->xAxis->setRange(xRangeMin, xRangeMax);
             graphByte[graphs]->replot();
         }
 

--- a/re/frameinfowindow.h
+++ b/re/frameinfowindow.h
@@ -5,8 +5,10 @@
 #include <QFile>
 #include <QListWidget>
 #include <QTreeWidget>
+#include <QPushButton>
 #include <candatagrid.h>
 #include "can_structs.h"
+#include "utility.h"
 #include "bus_protocols/j1939_handler.h"
 #include "dbc/dbchandler.h"
 
@@ -32,6 +34,10 @@ private slots:
     void mousePress();
     void mouseWheel();
     void mouseDoubleClick();
+    void resetByteGraph(int idx);
+    void resetAllByteGraphs();
+    void togglePlotType(int idx, bool scatter);
+    void toggleAllPlotType(bool scatter);
 
 private:
     Ui::FrameInfoWindow *ui;
@@ -44,13 +50,17 @@ private:
     const QVector<CANFrame> *modelFrames;
     bool useOpenGL;
     bool useHexTicker;
+    TimeStyle timeStyle;
     static const QColor byteGraphColors[8];
     static QPen bytePens[8];
     DBCHandler *dbcHandler;
 
     QCPGraph *graphRef[8];
+    QPushButton *btnResetByteGraph[8];
+    QPushButton *btnTogglePlotType[8];
 
     void refreshIDList();
+    void captureXRange(double &xmin, double &xmax);
     void closeEvent(QCloseEvent *event);
     bool eventFilter(QObject *obj, QEvent *event);
     void setupByteGraph(QCustomPlot *plot, int num);

--- a/ui/frameinfowindow.ui
+++ b/ui/frameinfowindow.ui
@@ -126,14 +126,53 @@
         <layout class="QGridLayout" name="gridUpper"/>
        </item>
        <item>
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Bytes Graph</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_bytesHeader">
+         <item>
+          <widget class="QPushButton" name="btnResetAllByteGraphs">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="toolTip">
+            <string>Reset all byte graphs to default scaling</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnToggleAllPlotType">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="toolTip">
+            <string>Toggle all byte graphs line/scatter</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Bytes Graph</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <layout class="QGridLayout" name="gridLower" rowstretch="0"/>


### PR DESCRIPTION
SavvyCAN has been a tremendous help in my hobby of reverse engineering the canbus of my car.  Please consider this improvement to the frame data analysis window. I'd be happy to adjust it if something is off or not up to par. My C++ is a bit rusty so Claude Code has done the heavy lifting. 

## Summary

- Fix `canframemodel.cpp` timestamp arithmetic to combine `seconds()` + `microSeconds()` fields correctly everywhere, fixing display for captures longer than one second
- Byte graphs now plot against real timestamps (respecting the app-wide time style setting) instead of frame index, and the x-axis spans the full capture window rather than only where the selected frame ID appears
- Add per-graph **⌂** reset button (lower-left overlay) restoring x-axis to full capture range and y-axis to `[0, 265]`
- Add per-graph **─/●** toggle button switching between line and scatter plots; state persists when switching frame IDs
- Add **⌂** reset-all and **─/●** toggle-all buttons in the "Bytes Graph" section header

## Changes

### `canframemodel.cpp`
- Add `frameTimestampMicros()` helper combining `seconds()` + `microSeconds()` so timestamps spanning more than one second are handled correctly throughout `normalizeTiming`, `recalcOverwrite`, `addFrame`, `getIndexFromTimeID`, and `data()`

### `re/frameinfowindow`
- Read time style and format from settings so byte graphs use the same representation (seconds, millis, clock) as the rest of the application
- Plot byte graph x-axis using real frame timestamps instead of frame index; fix interval calculation to use full seconds+microseconds timestamp
- Set byte graph x-axis range to span the entire capture window using `captureXRange()`, which scans all frames for the true min/max timestamp
- Overlay buttons track the lower-left corner of each graph via `eventFilter` on `QEvent::Resize`

## Test plan

- [ ] Load a CAN log where a given ID appears only in a subset of the capture; verify byte graph x-axis spans the full capture
- [ ] Switch between frame IDs; verify scatter/line toggle state is preserved per graph
- [ ] Click ⌂ per-graph and ⌂ all-graphs; verify axes reset to defaults
- [ ] Resize window/splitter; verify overlay buttons stay pinned to lower-left of each graph
- [ ] Toggle ─/● all-graphs; verify all individual buttons update to match
- [ ] Verify timestamp display matches the time style set in application preferences

Screenshot of dot scatter plots.
<img width="1512" height="783" alt="image" src="https://github.com/user-attachments/assets/5b5f9dd8-bfbf-4309-8bb8-4ac3b86853f9" />
