### PR TITLE
Add standard and extended frame-filter group selectors

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -220,6 +220,35 @@ void CANFrameModel::setFilterState(unsigned int ID, bool state)
     sendRefresh();
 }
 
+void CANFrameModel::setFilterRangeState(
+        unsigned int minimumID,
+        unsigned int maximumID,
+        bool state)
+{
+    if (minimumID > maximumID) return;
+
+    bool changed = false;
+
+    QMap<int, bool>::iterator it =
+            filters.lowerBound(static_cast<int>(minimumID));
+
+    const QMap<int, bool>::iterator end =
+            filters.upperBound(static_cast<int>(maximumID));
+
+    while (it != end)
+    {
+        if (it.value() != state)
+        {
+            it.value() = state;
+            changed = true;
+        }
+
+        ++it;
+    }
+
+    if (changed) sendRefresh();
+}
+
 void CANFrameModel::setBusFilterState(unsigned int BusID, bool state)
 {
     if (!busFilters.contains(BusID)) return;

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -52,6 +52,7 @@ public:
     void setTimeStyle(TimeStyle newStyle);
     void setIgnoreDBCColors(bool mode);
     void setFilterState(unsigned int ID, bool state);
+    void setFilterRangeState(unsigned int minimumID, unsigned int maximumID, bool state);
     void setBusFilterState(unsigned int BusID, bool state);
     void setAllFilters(bool state);
     void setTimeFormat(QString);

--- a/help/mainscreen.md
+++ b/help/mainscreen.md
@@ -66,6 +66,8 @@ will see only the newest one. This is generally used alongside "Interpret Frames
 *"Bus Filtering" allows for messages to be shown or hidden based on which bus they came in on.
 
 *"Frame Filtering" provides a list of all the frame IDs seen so far. Any ID which is checked will be shown in the main list. Any ID which is unchecked will not.
+
+The **Standard (11-bit)** and **Extended (29-bit)** checkboxes select or deselect all currently known IDs in their respective numeric ranges. A partially checked group indicates a mixture of selected and deselected IDs. A group is disabled when no current IDs belong to it.
 This can be used to hone in on frames of importance while hiding frames that are currently of no interest. The filtered list can be saved as well.
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2,6 +2,7 @@
 #include "ui_mainwindow.h"
 #include "can_structs.h"
 #include <QDateTime>
+#include <QCheckBox>
 #include <QFileDialog>
 #include <QtSerialPort/QSerialPortInfo>
 #include "connections/canconmanager.h"
@@ -160,6 +161,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->cbOverwrite, &QAbstractButton::toggled, this, &MainWindow::overwriteToggled);
     connect(ui->cbPersistentFilters, &QAbstractButton::toggled, this, &MainWindow::presistentFiltersToggled);
     connect(ui->listFilters, &QListWidget::itemChanged, this, &MainWindow::filterListItemChanged);
+    connect(ui->cbFilterStandardIds, &QAbstractButton::clicked, this, &MainWindow::filterStandardIdsClicked);
+    connect(ui->cbFilterExtendedIds, &QAbstractButton::clicked, this, &MainWindow::filterExtendedIdsClicked);
     connect(ui->listBusFilters, &QListWidget::itemChanged, this, &MainWindow::busFilterListItemChanged);
 
     connect(ui->btnCaptureToggle, &QAbstractButton::clicked, this, &MainWindow::toggleCapture);
@@ -937,8 +940,13 @@ void MainWindow::presistentFiltersToggled(bool state)
 void MainWindow::updateFilterList()
 {
     if (model == nullptr) return;
-    const QMap<int, bool> *filters = model->getFiltersReference();
-    const QMap<int, bool> *busFilters = model->getBusFiltersReference();
+
+    const QMap<int, bool> *filters =
+            model->getFiltersReference();
+
+    const QMap<int, bool> *busFilters =
+            model->getBusFiltersReference();
+
     if (filters == nullptr || busFilters == nullptr) return;
 
     qDebug() << "updateFilterList called on MainWindow";
@@ -948,36 +956,171 @@ void MainWindow::updateFilterList()
     ui->listFilters->clear();
     ui->listBusFilters->clear();
 
-    if (filters->isEmpty()) return;
-
     QMap<int, bool>::const_iterator filterIter;
-    for (filterIter = filters->begin(); filterIter != filters->end(); ++filterIter)
+
+    for (filterIter = filters->begin();
+         filterIter != filters->end();
+         ++filterIter)
     {
-        /*QListWidgetItem *thisItem = */FilterUtility::createCheckableFilterItem(filterIter.key(), filterIter.value(), ui->listFilters);
+        FilterUtility::createCheckableFilterItem(
+                    filterIter.key(),
+                    filterIter.value(),
+                    ui->listFilters);
     }
 
-    if (busFilters->isEmpty()) return;
-
-    for (filterIter = busFilters->begin(); filterIter != busFilters->end(); ++filterIter)
+    for (filterIter = busFilters->begin();
+         filterIter != busFilters->end();
+         ++filterIter)
     {
-        /*QListWidgetItem *thisItem = */ FilterUtility::createCheckableBusFilterItem(filterIter.key(), filterIter.value(), ui->listBusFilters);
+        FilterUtility::createCheckableBusFilterItem(
+                    filterIter.key(),
+                    filterIter.value(),
+                    ui->listBusFilters);
     }
+
     inhibitFilterUpdate = false;
+
+    updateFilterGroupCheckStates();
 }
 
-void MainWindow::filterListItemChanged(QListWidgetItem *item)
+void MainWindow::filterListItemChanged(
+        QListWidgetItem *item)
 {
     if (inhibitFilterUpdate) return;
-    //qDebug() << item->text();
 
-    // strip away possible filter label
     int ID = FilterUtility::getIdAsInt(item);
+
     bool isSet = false;
-    if (item->checkState() == Qt::Checked) isSet = true;
+
+    if (item->checkState() == Qt::Checked)
+        isSet = true;
 
     model->setFilterState(ID, isSet);
 
+    updateFilterGroupCheckStates();
     manageRowExpansion();
+}
+
+void MainWindow::filterStandardIdsClicked(bool checked)
+{
+    setFilterRange(0x000U, 0x7FFU, checked);
+}
+
+void MainWindow::filterExtendedIdsClicked(bool checked)
+{
+    setFilterRange(0x800U, 0x1FFFFFFFU, checked);
+}
+
+void MainWindow::setFilterRange(
+        unsigned int minimumID,
+        unsigned int maximumID,
+        bool state)
+{
+    if (model == nullptr) return;
+
+    inhibitFilterUpdate = true;
+
+    const Qt::CheckState checkState =
+            state ? Qt::Checked : Qt::Unchecked;
+
+    for (int i = 0;
+         i < ui->listFilters->count();
+         ++i)
+    {
+        QListWidgetItem *item =
+                ui->listFilters->item(i);
+
+        const unsigned int ID =
+                static_cast<unsigned int>(
+                    FilterUtility::getIdAsInt(item));
+
+        if (ID >= minimumID && ID <= maximumID)
+            item->setCheckState(checkState);
+    }
+
+    inhibitFilterUpdate = false;
+
+    model->setFilterRangeState(
+                minimumID,
+                maximumID,
+                state);
+
+    updateFilterGroupCheckStates();
+    manageRowExpansion();
+}
+
+void MainWindow::updateFilterGroupCheckStates()
+{
+    if (model == nullptr) return;
+
+    const QMap<int, bool> *filters =
+            model->getFiltersReference();
+
+    if (filters == nullptr) return;
+
+    int standardCount = 0;
+    int standardSelected = 0;
+
+    int extendedCount = 0;
+    int extendedSelected = 0;
+
+    for (QMap<int, bool>::const_iterator it =
+             filters->begin();
+         it != filters->end();
+         ++it)
+    {
+        if (it.key() >= 0 &&
+            it.key() <= 0x7FF)
+        {
+            ++standardCount;
+
+            if (it.value())
+                ++standardSelected;
+        }
+        else if (it.key() >= 0x800 &&
+                 it.key() <= 0x1FFFFFFF)
+        {
+            ++extendedCount;
+
+            if (it.value())
+                ++extendedSelected;
+        }
+    }
+
+    const auto setGroupState =
+            [](QCheckBox *checkBox,
+               int selectedCount,
+               int totalCount)
+    {
+        checkBox->setEnabled(totalCount > 0);
+
+        if (totalCount == 0 ||
+            selectedCount == 0)
+        {
+            checkBox->setCheckState(
+                        Qt::Unchecked);
+        }
+        else if (selectedCount == totalCount)
+        {
+            checkBox->setCheckState(
+                        Qt::Checked);
+        }
+        else
+        {
+            checkBox->setCheckState(
+                        Qt::PartiallyChecked);
+        }
+    };
+
+    setGroupState(
+                ui->cbFilterStandardIds,
+                standardSelected,
+                standardCount);
+
+    setGroupState(
+                ui->cbFilterExtendedIds,
+                extendedSelected,
+                extendedCount);
 }
 
 void MainWindow::busFilterListItemChanged(QListWidgetItem *item)
@@ -1004,6 +1147,7 @@ void MainWindow::filterSetAll()
     }
     inhibitFilterUpdate = false;
     model->setAllFilters(true);
+    updateFilterGroupCheckStates();
 
     manageRowExpansion();
 }
@@ -1017,6 +1161,7 @@ void MainWindow::filterClearAll()
     }
     inhibitFilterUpdate = false;
     model->setAllFilters(false);
+    updateFilterGroupCheckStates();
 }
 
 void MainWindow::logReceivedFrame(CANConnection* conn, QVector<CANFrame> frames)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -122,6 +122,8 @@ private slots:
     void normalizeTiming();
     void updateFilterList();
     void filterListItemChanged(QListWidgetItem *item);
+    void filterStandardIdsClicked(bool checked);
+    void filterExtendedIdsClicked(bool checked);
     void busFilterListItemChanged(QListWidgetItem *item);
     void filterSetAll();
     void filterClearAll();
@@ -222,6 +224,8 @@ private:
     void saveDecodedTextFileAsColumns(QString);
     void addFrameToDisplay(CANFrame &, bool);
     void updateFileStatus();
+    void setFilterRange(unsigned int minimumID, unsigned int maximumID, bool state);
+    void updateFilterGroupCheckStates();
     void closeEvent(QCloseEvent *event);
     void killEmAll();
     void killWindow(QDialog *win);

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -328,6 +328,45 @@
          </widget>
         </item>
         <item>
+         <layout class="QVBoxLayout" name="verticalLayout_filterIdGroups">
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="cbFilterStandardIds">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Select or deselect all IDs from 0x000 through 0x7FF</string>
+            </property>
+            <property name="text">
+             <string>Standard (11-bit)</string>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbFilterExtendedIds">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>Select or deselect all IDs from 0x800 through 0x1FFFFFFF</string>
+            </property>
+            <property name="text">
+             <string>Extended (29-bit)</string>
+            </property>
+            <property name="tristate">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QListWidget" name="listFilters">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">


### PR DESCRIPTION
## Summary

Add vertically stacked, tri-state bulk-selection controls for standard-range and extended-range CAN frame IDs on the main capture screen.

The controls appear directly below **Frame Filtering:** and above the existing per-ID filter list:

- **Standard (11-bit)**
- **Extended (29-bit)**

This allows users to quickly select or deselect potentially large groups of frame IDs without changing every individual checkbox.

## Behavior

### Standard (11-bit)

Controls all currently known numeric IDs from:

0x000 through 0x7FF

### Extended (29-bit)

Controls all currently known numeric IDs from:

0x800 through 0x1FFFFFFF

Each group checkbox displays:

- **Checked** when every current ID in that group is selected.
- **Unchecked** when no IDs in that group are selected.
- **Partially checked** when the group contains mixed selections.
- **Disabled** when no current IDs belong to the group.

Changing an individual frame-ID checkbox immediately recalculates the applicable group state.

The existing **All** and **None** buttons also synchronize both group checkboxes.

## Layout

The two group selectors are stacked vertically rather than placed side by side. This avoids unnecessarily increasing the width of the frame-filtering sidebar.

## Implementation

This change:

- Adds two tri-state checkboxes to the main-window UI.
- Adds a model operation that updates one numeric ID range and refreshes the filtered frame model once.
- Synchronizes the group states after:
  - the filter list is refreshed;
  - an individual ID is changed;
  - a group selector is changed;
  - **All** is selected;
  - **None** is selected.
- Removes early returns from `MainWindow::updateFilterList()` that could leave `inhibitFilterUpdate` enabled when a filter collection is empty.
- Updates the main-screen help documentation.

## Scope

This PR does not change:

- **Clear Frames**
- **Keep Filters When Clearing**
- `CANFrameModel::clearFrames()`
- `setClearMode()`
- Existing filter-persistence behavior
- PeakCAN or any other CAN-interface backend

## Current model limitation

The existing frame-filter map is keyed only by numeric CAN ID and does not include the extended-frame-format flag in the key.

Accordingly, this focused change groups IDs by numeric range. It does not attempt to distinguish a numerically low extended-format ID from a standard ID with the same numeric identifier. Supporting that distinction would require a broader redesign of the filter model and saved-filter format.

## Validation

Tested successfully on Windows x64 with Qt 5.15.2 and MSVC.

**Commit tested:**

4f8c107c91bf896f8fe18d324e3be2f95e7c50d1

### Build validation

- [x] qmake completed successfully.
- [x] nmake completed successfully.
- [x] A release executable was produced.
- [x] No compiler, linker, or fatal build errors were detected.

### Functional validation

- [x] Standard group selects and deselects IDs from `0x000` through `0x7FF`.
- [x] Extended group selects and deselects IDs from `0x800` through `0x1FFFFFFF`.
- [x] The two groups operate independently.
- [x] Individual ID changes produce the correct partial state.
- [x] **All** and **None** synchronize both group controls.
- [x] Empty groups disable the applicable selector.
- [x] Existing **Keep Filters When Clearing** behavior remains unchanged.
- [x] The selectors are vertically stacked to avoid widening the sidebar.

## Screenshots

Final screenshots of the vertically stacked controls and partial-selection behavior will be attached below.

<img width="400" height="1375" alt="Screenshot 2026-07-11 105506" src="https://github.com/user-attachments/assets/a7328526-3b21-4b37-ba8e-ec97b0c79df5" />
<img width="435" height="1355" alt="Screenshot 2026-07-11 105547" src="https://github.com/user-attachments/assets/b376b972-b599-45c0-8de3-1c79eb77705a" />
<img width="437" height="1362" alt="Screenshot 2026-07-11 105712" src="https://github.com/user-attachments/assets/62ee5704-5742-4b45-9065-edd1d9ef9499" />
<img width="447" height="1290" alt="Screenshot 2026-07-11 105725" src="https://github.com/user-attachments/assets/745f4e4f-49cb-4cbb-b734-3751d8d9cee8" />
<img width="382" height="1292" alt="Screenshot 2026-07-11 105744" src="https://github.com/user-attachments/assets/e8f32490-b449-4fd8-b8f1-f79c217ef3e1" />
