### PR TITLE
Fix SavvyCAN crash when deleting a signal

### DIFF
--- a/dbc/dbchandler.cpp
+++ b/dbc/dbchandler.cpp
@@ -75,6 +75,7 @@ bool DBCSignalHandler::removeSignal(DBC_SIGNAL *sig)
         {
             sigs.removeAt(i);
             qDebug() << "Removed signal at idx " << i;
+            break;
         }
     }
     return true;

--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -299,9 +299,7 @@ void DBCMainEditor::onTreeDoubleClicked(const QModelIndex &index)
         }
         nameString = nameString.split(" ")[0]; //get rid of [32m 8] type stuff after the name
 
-        qDebug() << "try to find signal with name: " << nameString;
         sig = msg->sigHandler->findSignalByName(nameString);
-        qDebug() << "signal: " << (sig ? "yes" : "no");
         if (sig)
         {
             sigEditor->setSignalRef(sig);

--- a/dbc/dbcmaineditor.cpp
+++ b/dbc/dbcmaineditor.cpp
@@ -293,13 +293,15 @@ void DBCMainEditor::onTreeDoubleClicked(const QModelIndex &index)
         msgID = getParentMessageID(firstCol);
         msg = dbcFile->messageHandler->findMsgByID(msgID);
         QString nameString = firstCol->text(0);
-        if (nameString.contains("("))
+        if (nameString.startsWith("("))
         {
             nameString = nameString.split(")")[1].trimmed(); //remove (1-2) type stuff from beginning of string
         }
         nameString = nameString.split(" ")[0]; //get rid of [32m 8] type stuff after the name
 
+        qDebug() << "try to find signal with name: " << nameString;
         sig = msg->sigHandler->findSignalByName(nameString);
+        qDebug() << "signal: " << (sig ? "yes" : "no");
         if (sig)
         {
             sigEditor->setSignalRef(sig);


### PR DESCRIPTION
When trying to delete a signal in the DBC File Manager, SavvyCAN crashed with the following stack trace :
```Signal about to vanish.
Total # of signals:  5
Removed signal at idx  2

Thread 1 "SavvyCAN" received signal SIGSEGV, Segmentation fault.
0x00007ffff4d45d19 in operator== (s1=..., s2=...) at text/qstring.cpp:3437
⚠️ warning: 3437	text/qstring.cpp: Aucun fichier ou dossier de ce nom
(gdb) bt
#0  0x00007ffff4d45d19 in operator== (s1=..., s2=...) at text/qstring.cpp:3437
#1  0x000055555579016c in DBCSignalHandler::removeSignal (this=0x555555c86fe0, sig=0x555555eb1b40) at dbc/dbchandler.cpp:74
#2  0x00005555557c0d72 in DBCMainEditor::deleteSignal (this=0x55555685a330, sig=0x555555eb1b40) at dbc/dbcmaineditor.cpp:961
#3  0x00005555557c03f8 in DBCMainEditor::deleteCurrentTreeItem (this=0x55555685a330) at dbc/dbcmaineditor.cpp:879
#4  0x00005555557c8fc1 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (DBCMainEditor::*)()>::call(void (DBCMainEditor::*)(), DBCMainEditor*, void**) (
    f=(void (DBCMainEditor::*)(DBCMainEditor * const)) 0x5555557bfbd4 <DBCMainEditor::deleteCurrentTreeItem()>, o=0x55555685a330, arg=0x7fffffffcdc0)
    at /home/remi/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:152
#5  0x00005555557c83a5 in QtPrivate::FunctionPointer<void (DBCMainEditor::*)()>::call<QtPrivate::List<>, void>(void (DBCMainEditor::*)(), DBCMainEditor*, void**) (
    f=(void (DBCMainEditor::*)(DBCMainEditor * const)) 0x5555557bfbd4 <DBCMainEditor::deleteCurrentTreeItem()>, o=0x55555685a330, arg=0x7fffffffcdc0)
    at /home/remi/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:185
#6  0x00005555557c7173 in QtPrivate::QSlotObject<void (DBCMainEditor::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) (which=1, this_=0x5555564fbac0, 
    r=0x55555685a330, a=0x7fffffffcdc0, ret=0x0) at /home/remi/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:418
#7  0x00007ffff4ed5f30 in QtPrivate::QSlotObjectBase::call (a=0x7fffffffcdc0, r=0x55555685a330, this=<optimized out>) at ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:398
#8  doActivate<false> (sender=0x55555606dae0, signal_index=9, argv=argv@entry=0x7fffffffcdc0) at kernel/qobject.cpp:3886
#9  0x00007ffff4ecf479 in QMetaObject::activate (sender=sender@entry=0x55555606dae0, m=m@entry=0x7ffff7a375a0 <QAbstractButton::staticMetaObject>, local_signal_index=local_signal_index@entry=2, 
    argv=argv@entry=0x7fffffffcdc0) at kernel/qobject.cpp:3946
#10 0x00007ffff744eba2 in QAbstractButton::clicked (this=this@entry=0x55555606dae0, _t1=false) at .moc/moc_qabstractbutton.cpp:308
#11 0x00007ffff744edaa in QAbstractButtonPrivate::emitClicked (this=0x5555568ae3c0) at widgets/qabstractbutton.cpp:415
#12 0x00007ffff7450a2f in QAbstractButtonPrivate::click (this=0x5555568ae3c0) at widgets/qabstractbutton.cpp:408
#13 0x00007ffff7450b95 in QAbstractButton::mouseReleaseEvent (this=0x55555606dae0, e=0x7fffffffd290) at widgets/qabstractbutton.cpp:1044
#14 0x00007ffff7533a8a in QToolButton::mouseReleaseEvent (this=<optimized out>, e=<optimized out>) at widgets/qtoolbutton.cpp:622
#15 0x00007ffff73a1740 in QWidget::event (this=0x55555606dae0, event=event@entry=0x7fffffffd290) at kernel/qwidget.cpp:9019
#16 0x00007ffff74514d3 in QAbstractButton::event (this=this@entry=0x55555606dae0, e=e@entry=0x7fffffffd290) at widgets/qabstractbutton.cpp:1001
#17 0x00007ffff7533b59 in QToolButton::event (this=0x55555606dae0, event=0x7fffffffd290) at widgets/qtoolbutton.cpp:1012
#18 0x00007ffff736343c in QApplicationPrivate::notify_helper (this=<optimized out>, receiver=0x55555606dae0, e=0x7fffffffd290) at kernel/qapplication.cpp:3632
#19 0x00007ffff736a1f8 in QApplication::notify (this=<optimized out>, receiver=0x55555606dae0, e=0x7fffffffd290) at kernel/qapplication.cpp:3076
#20 0x00007ffff4e9d808 in QCoreApplication::notifyInternal2 (receiver=0x55555606dae0, event=0x7fffffffd290) at kernel/qcoreapplication.cpp:1063
#21 0x00007ffff4e9d9ce in QCoreApplication::sendSpontaneousEvent (receiver=receiver@entry=0x55555606dae0, event=event@entry=0x7fffffffd290) at kernel/qcoreapplication.cpp:1470
#22 0x00007ffff736953a in QApplicationPrivate::sendMouseEvent (receiver=receiver@entry=0x55555606dae0, event=event@entry=0x7fffffffd290, alienWidget=alienWidget@entry=0x55555606dae0, 
    nativeWidget=0x55555685a330, buttonDown=buttonDown@entry=0x7ffff7a61a90 <qt_button_down>, lastMouseReceiver=..., spontaneous=true, onlyDispatchEnterLeave=false) at kernel/qapplication.cpp:2614
#23 0x00007ffff73bafe8 in QWidgetWindow::handleMouseEvent (this=this@entry=0x555556772860, event=event@entry=0x7fffffffd670) at kernel/qwidgetwindow.cpp:684
#24 0x00007ffff73bdcf3 in QWidgetWindow::event (this=0x555556772860, event=0x7fffffffd670) at kernel/qwidgetwindow.cpp:300
#25 0x00007ffff736343c in QApplicationPrivate::notify_helper (this=<optimized out>, receiver=0x555556772860, e=0x7fffffffd670) at kernel/qapplication.cpp:3632
#26 0x00007ffff7369f20 in QApplication::notify (this=<optimized out>, receiver=0x555556772860, e=0x7fffffffd670) at kernel/qapplication.cpp:3378
#27 0x00007ffff4e9d808 in QCoreApplication::notifyInternal2 (receiver=0x555556772860, event=0x7fffffffd670) at kernel/qcoreapplication.cpp:1063
#28 0x00007ffff4e9d9ce in QCoreApplication::sendSpontaneousEvent (receiver=receiver@entry=0x555556772860, event=event@entry=0x7fffffffd670) at kernel/qcoreapplication.cpp:1470
#29 0x00007ffff696f56d in QGuiApplicationPrivate::processMouseEvent (e=0x55555689cad0) at kernel/qguiapplication.cpp:2282
#30 0x00007ffff6970955 in QGuiApplicationPrivate::processWindowSystemEvent (e=e@entry=0x55555689cad0) at kernel/qguiapplication.cpp:2002
#31 0x00007ffff694c8ab in QWindowSystemInterface::sendWindowSystemEvents (flags=..., flags@entry=...) at kernel/qwindowsysteminterface.cpp:1169
#32 0x00007ffff126569a in xcbSourceDispatch (source=<optimized out>) at qxcbeventdispatcher.cpp:105
#33 0x00007ffff6708b9b in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#34 0x00007ffff670a1d7 in ?? () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#35 0x00007ffff670a3c3 in g_main_context_iteration () from /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#36 0x00007ffff4ef91cc in QEventDispatcherGlib::processEvents (this=0x555555e35db0, flags=...) at kernel/qeventdispatcher_glib.cpp:423
#37 0x00007ffff4e9c21a in QEventLoop::exec (this=this@entry=0x7fffffffda50, flags=..., flags@entry=...) at kernel/qeventloop.cpp:232
#38 0x00007ffff4ea51d3 in QCoreApplication::exec () at kernel/qcoreapplication.cpp:1371
#39 0x00005555555a3faf in main (argc=1, argv=0x7fffffffdcc8) at main.cpp:77
```

Adding a `break` in the loop searching for the signal to delete fixed the issue.