### PR TITLE
Add real-time search trace bar for filtering by CAN ID and Data

### DIFF
--- a/canframemodel.cpp
+++ b/canframemodel.cpp
@@ -711,7 +711,7 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
         {
             frames.append(tempFrame);
 
-            if (filters[tempFrame.frameId()] && busFilters[tempFrame.bus])
+            if (filters[tempFrame.frameId()] && busFilters[tempFrame.bus] && passesSearchFilter(tempFrame))
             {
                 if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
                 tempFrame.frameCount = 1;
@@ -753,7 +753,7 @@ void CANFrameModel::addFrame(const CANFrame& frame, bool autoRefresh = false)
         if (!found)
         {
             //frames.append(tempFrame);
-            if (filters[tempFrame.frameId()] && busFilters[tempFrame.bus])
+            if (filters[tempFrame.frameId()] && busFilters[tempFrame.bus] && passesSearchFilter(tempFrame))
             {
                 if (autoRefresh) beginInsertRows(QModelIndex(), filteredFrames.count(), filteredFrames.count());
                 tempFrame.frameCount = 1;
@@ -825,7 +825,7 @@ void CANFrameModel::sendRefresh()
         int count = frames.count();
         for (int i = 0; i < count; i++)
         {
-            if (filters[frames[i].frameId()] && busFilters[frames[i].bus])
+            if (filters[frames[i].frameId()] && busFilters[frames[i].bus] && passesSearchFilter(frames[i]))
             {
                 tempContainer.append(frames[i]);
             }
@@ -998,6 +998,24 @@ bool CANFrameModel::needsFilterRefresh()
     bool temp = needFilterRefresh;
     needFilterRefresh = false;
     return temp;
+}
+
+bool CANFrameModel::passesSearchFilter(const CANFrame& frame) const
+{
+    if (searchText.isEmpty()) return true;
+    QString idStr = QString::number(frame.frameId(), 16);
+    if (idStr.contains(searchText, Qt::CaseInsensitive)) return true;
+    QString dataStr = QString(frame.payload().toHex(' '));
+    if (dataStr.contains(searchText, Qt::CaseInsensitive)) return true;
+    return false;
+}
+
+void CANFrameModel::setSearchText(const QString &text)
+{
+    mutex.lock();
+    searchText = text.trimmed();
+    mutex.unlock();
+    sendRefresh();
 }
 
 /*

--- a/canframemodel.h
+++ b/canframemodel.h
@@ -68,6 +68,8 @@ public:
     const QVector<CANFrame> *getFilteredListReference() const; //Thus saith the Lord, NO.
     const QMap<int, bool> *getFiltersReference() const; //this neither
     const QMap<int, bool> *getBusFiltersReference() const; //this neither
+    void setSearchText(const QString &text);
+    bool passesSearchFilter(const CANFrame& frame) const;
 
 public slots:
     void addFrame(const CANFrame&, bool);
@@ -103,6 +105,7 @@ private:
     uint32_t preallocSize;
     bool sortDirAsc;
     int bytesPerLine;
+    QString searchText;
 };
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -257,6 +257,12 @@ MainWindow::MainWindow(QWidget *parent) :
     frameSender->startSending(); //start the timer in the object so enabled things can send
 
     installEventFilter(this);
+
+    QLineEdit *txtSearchTrace = new QLineEdit(this);
+    txtSearchTrace->setPlaceholderText("Search Trace by ID or Data");
+    txtSearchTrace->setClearButtonEnabled(true);
+    ui->verticalLayout_3->insertWidget(0, txtSearchTrace);
+    connect(txtSearchTrace, &QLineEdit::textChanged, model, &CANFrameModel::setSearchText);
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
## description
This PR introduces a real-time search input bar located right above the main CAN trace table. It allows users to quickly filter frames by matching text against the **CAN ID** (in Hex) or the **Payload/Data** bytes
### changes Made
- UI (`MainWindow`)**: Added a `QLineEdit` search bar above the CAN frame table with placeholder text
- Data Model (`CANFrameModel`)**:
 - Implemented `passesSearchFilter()` helper method to validate frames against the input text
 - Added `setSearchText()` slot to update search state and refresh view in real-time
 - Updated `addFrame()` and `sendRefresh()` to enforce search filtering alongside existing bus/ID filters

closes #1106 